### PR TITLE
chore: exclude graphql generated files

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -49,6 +49,7 @@ header:
     - '**/*.d.ts'
     - '**/generated/**'
     - '**/auto-generated/**'
+    - '**/src/gen/**'
 
   comment: on-failure
 


### PR DESCRIPTION
# License Header Configuration Update
Exclude GraphQL generated files from license header requirements.

## Changes

Updated `.licenserc.yaml` to exclude `**/src/gen/**` path from license header checks
This prevents auto-generated GraphQL files in packages/indexer-public-data-provider/src/gen/ from requiring license headers

## Why

GraphQL generated files (gql.ts, graphql.ts, fragment-masking.ts, index.ts) are auto-generated and should not have license headers applied as they are not source code authored by the project.