### PR TITLE
hotfix: change the docker compose port configuration

### DIFF
--- a/packages/testing/compose.yml
+++ b/packages/testing/compose.yml
@@ -3,7 +3,7 @@ services:
     image: "ghcr.io/midnight-ntwrk/proof-server:4.0.0@sha256:bdbdfe74f4766d91c5be87a58cd64bb762445e9f87e0175059231892884d665b"
     container_name: "proof-server_$TESTCONTAINERS_UID"
     ports:
-      - "0:6300"
+      - "8000-9000:6300"
     environment:
       NETWORK: ${NETWORK_ID:-undeployed}
       EXTRA_ARGS: -v
@@ -18,7 +18,7 @@ services:
     image: "ghcr.io/midnight-ntwrk/indexer-standalone:2.1.4@sha256:ad9b2ced30e3ebd5070fb3ce40e8dfe4e41d8d491410e34feb0c8c1afa70499e"
     container_name: "indexer_$TESTCONTAINERS_UID"
     ports:
-      - "0:8088"
+      - "8000-9000:8088"
     environment:
       RUST_LOG: "indexer=debug,chain_indexer=debug,indexer_api=debug,wallet_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
       APP__INFRA__SECRET: "303132333435363738393031323334353637383930313233343536373839303132"
@@ -37,7 +37,7 @@ services:
     image: "ghcr.io/midnight-ntwrk/midnight-node:0.12.1@sha256:b01ab75dca12f670573fd89eb3a363c63dc2ac095c6844df0b49e57169bb9f10"
     container_name: "node_$TESTCONTAINERS_UID"
     ports:
-      - "0:9944"
+      - "8000-9000:9944"
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9944/health" ]
       interval: 2s

--- a/packages/testing/proof-server.yml
+++ b/packages/testing/proof-server.yml
@@ -3,7 +3,7 @@ services:
     image: "ghcr.io/midnight-ntwrk/proof-server:4.0.0"
     container_name: "proof-server_$TESTCONTAINERS_UID"
     ports:
-      - "0:6300"
+      - "8000-9000:6300"
     environment:
       NETWORK: ${NETWORK_ID:-undeployed}
       EXTRA_ARGS: -v


### PR DESCRIPTION
Fix for the rare cases of conflicting port allocation on CI

```request to http://127.0.0.1:32771/api/v1/graphql failed, reason: connect ECONNREFUSED 127.0.0.1:32771```