### PR TITLE
(chore): Change `CD` workflows to publish only when changed

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,10 +49,18 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Determine Build Targets
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            midnight-js: 'packages/**' 
+
       - name: Publish packages
+        if: steps.changes.outputs.midnight-js == 'true'
         run: |
           rm docs/image/deployment-diagram.png || true
           rm docs/image/call-tx-build-sequence-diagram.png || true
-          yarn deploy --cache-dir ./turbo
+          yarn deploy --filter="./packages/*" --cache-dir ./turbo
         env:
           GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,7 +50,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Determine Build Targets
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: changes
         with:
           filters: |

--- a/.github/workflows/cd_c_js.yml
+++ b/.github/workflows/cd_c_js.yml
@@ -78,7 +78,7 @@ jobs:
           [[ '$on_release_branch' = 'true' ]] && echo "Releasing v$target_version (tagged as $tag)." >> $GITHUB_OUTPUT || echo "Unlisted release branch, following steps will be skipped." >> $GITHUB_OUTPUT
 
       - name: Determine Build Targets
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: changes
         with:
           filters: |

--- a/.github/workflows/cd_c_js.yml
+++ b/.github/workflows/cd_c_js.yml
@@ -77,17 +77,24 @@ jobs:
           echo "### Summary" >> $GITHUB_STEP_SUMMARY
           [[ '$on_release_branch' = 'true' ]] && echo "Releasing v$target_version (tagged as $tag)." >> $GITHUB_OUTPUT || echo "Unlisted release branch, following steps will be skipped." >> $GITHUB_OUTPUT
 
+      - name: Determine Build Targets
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            compact-js: 'compact-js/**' 
+
       - name: Bump versions
-        if: steps.vars.outputs.on_release_branch
+        if: steps.vars.outputs.on_release_branch steps.changes.outputs.compact-js == 'true'
         run: yarn workspaces foreach --all version ${{ steps.vars.outputs.target_version }}
 
       - name: Publish packages
-        if: steps.vars.outputs.on_release_branch
+        if: steps.vars.outputs.on_release_branch steps.changes.outputs.compact-js == 'true'
         run: yarn deploy --filter="./compact-js/*" --cache-dir ./turbo -- --tag ${{ steps.vars.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
           NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
 
       - name: Set build instance version number
-        if: steps.vars.outputs.on_release_branch
+        if: steps.vars.outputs.on_release_branch steps.changes.outputs.compact-js == 'true'
         run: echo "id=${{ steps.vars.outputs.target_version }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cd_p_js.yml
+++ b/.github/workflows/cd_p_js.yml
@@ -77,17 +77,24 @@ jobs:
           echo "### Summary" >> $GITHUB_STEP_SUMMARY
           [[ '$on_release_branch' = 'true' ]] && echo "Releasing v$target_version (tagged as $tag)." >> $GITHUB_OUTPUT || echo "Unlisted release branch, following steps will be skipped." >> $GITHUB_OUTPUT
 
+      - name: Determine Build Targets
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            platform-js: 'platform-js/**' 
+
       - name: Bump versions
-        if: steps.vars.outputs.on_release_branch
+        if: steps.vars.outputs.on_release_branch steps.changes.outputs.platform-js == 'true'
         run: yarn workspaces foreach --all version ${{ steps.vars.outputs.target_version }}
 
       - name: Publish packages
-        if: steps.vars.outputs.on_release_branch
+        if: steps.vars.outputs.on_release_branch steps.changes.outputs.platform-js == 'true'
         run: yarn deploy --filter="./platform-js/*" --cache-dir ./turbo -- --tag ${{ steps.vars.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
           NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
 
       - name: Set build instance version number
-        if: steps.vars.outputs.on_release_branch
+        if: steps.vars.outputs.on_release_branch steps.changes.outputs.platform-js == 'true'
         run: echo "id=${{ steps.vars.outputs.target_version }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cd_p_js.yml
+++ b/.github/workflows/cd_p_js.yml
@@ -78,7 +78,7 @@ jobs:
           [[ '$on_release_branch' = 'true' ]] && echo "Releasing v$target_version (tagged as $tag)." >> $GITHUB_OUTPUT || echo "Unlisted release branch, following steps will be skipped." >> $GITHUB_OUTPUT
 
       - name: Determine Build Targets
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: changes
         with:
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     outputs:
+      build_workflows: ${{ steps.build-targets.outputs.workflows }}
       build_mn_js: ${{ steps.build-targets.outputs.midnight-js }}
       build_c_js: ${{ steps.build-targets.outputs.compact-js }}
       build_p_js: ${{ steps.build-targets.outputs.platform-js }}
@@ -61,7 +62,7 @@ jobs:
     name: Build Midnight.js
     uses: ./.github/workflows/ci_mn_js.yml
     with:
-      should_run: ${{ needs.ci.outputs.build_mn_js }} || ${{ needs.ci.outputs.workflows }}
+      should_run: ${{ needs.ci.outputs.build_mn_js }} || ${{ needs.ci.outputs.build_workflows }}
       should_prerelease: ${{ 
           github.event_name != 'schedule' &&
           (github.ref_name == 'main' || contains(github.event.head_commit.message, '[do_publish]') || github.event_name == 'workflow_dispatch')
@@ -72,7 +73,7 @@ jobs:
     needs: ci
     name: Build Compact.js
     with:
-      should_run: ${{ needs.ci.outputs.build_c_js }} || ${{ needs.ci.outputs.workflows }}
+      should_run: ${{ needs.ci.outputs.build_c_js }} || ${{ needs.ci.outputs.build_workflows }}
       should_prerelease: ${{ 
           github.event_name != 'schedule' &&
           (github.ref_name == 'main' || contains(github.event.head_commit.message, '[do_publish]') || github.event_name == 'workflow_dispatch')
@@ -84,7 +85,7 @@ jobs:
     needs: ci
     name: Build Platform.js
     with:
-      should_run: ${{ needs.ci.outputs.build_p_js }} || ${{ needs.ci.outputs.workflows }}
+      should_run: ${{ needs.ci.outputs.build_p_js }} || ${{ needs.ci.outputs.build_workflows }}
       should_prerelease: ${{ 
           github.event_name != 'schedule' &&
           (github.ref_name == 'main' || contains(github.event.head_commit.message, '[do_publish]') || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
         id: build-targets
         with:
           filters: |
+            workflows: '.github/workflows'
             compact-js: 'compact-js/**'
             platform-js: 'platform-js/**'
             midnight-js: 'packages/**' 
@@ -60,7 +61,7 @@ jobs:
     name: Build Midnight.js
     uses: ./.github/workflows/ci_mn_js.yml
     with:
-      should_run: ${{ needs.ci.outputs.build_mn_js }}
+      should_run: ${{ needs.ci.outputs.build_mn_js }} || ${{ needs.ci.outputs.workflows }}
       should_prerelease: ${{ 
           github.event_name != 'schedule' &&
           (github.ref_name == 'main' || contains(github.event.head_commit.message, '[do_publish]') || github.event_name == 'workflow_dispatch')
@@ -71,7 +72,7 @@ jobs:
     needs: ci
     name: Build Compact.js
     with:
-      should_run: ${{ needs.ci.outputs.build_c_js }}
+      should_run: ${{ needs.ci.outputs.build_c_js }} || ${{ needs.ci.outputs.workflows }}
       should_prerelease: ${{ 
           github.event_name != 'schedule' &&
           (github.ref_name == 'main' || contains(github.event.head_commit.message, '[do_publish]') || github.event_name == 'workflow_dispatch')
@@ -83,7 +84,7 @@ jobs:
     needs: ci
     name: Build Platform.js
     with:
-      should_run: ${{ needs.ci.outputs.build_p_js }}
+      should_run: ${{ needs.ci.outputs.build_p_js }} || ${{ needs.ci.outputs.workflows }}
       should_prerelease: ${{ 
           github.event_name != 'schedule' &&
           (github.ref_name == 'main' || contains(github.event.head_commit.message, '[do_publish]') || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     name: Build Midnight.js
     uses: ./.github/workflows/ci_mn_js.yml
     with:
-      should_run: ${{ needs.ci.outputs.build_mn_js }} || ${{ needs.ci.outputs.build_workflows }}
+      should_run: ${{ needs.ci.outputs.build_mn_js || needs.ci.outputs.build_workflows }}
       should_prerelease: ${{ 
           github.event_name != 'schedule' &&
           (github.ref_name == 'main' || contains(github.event.head_commit.message, '[do_publish]') || github.event_name == 'workflow_dispatch')
@@ -73,7 +73,7 @@ jobs:
     needs: ci
     name: Build Compact.js
     with:
-      should_run: ${{ needs.ci.outputs.build_c_js }} || ${{ needs.ci.outputs.build_workflows }}
+      should_run: ${{ needs.ci.outputs.build_c_js || needs.ci.outputs.build_workflows }}
       should_prerelease: ${{ 
           github.event_name != 'schedule' &&
           (github.ref_name == 'main' || contains(github.event.head_commit.message, '[do_publish]') || github.event_name == 'workflow_dispatch')
@@ -85,7 +85,7 @@ jobs:
     needs: ci
     name: Build Platform.js
     with:
-      should_run: ${{ needs.ci.outputs.build_p_js }} || ${{ needs.ci.outputs.build_workflows }}
+      should_run: ${{ needs.ci.outputs.build_p_js || needs.ci.outputs.build_workflows }}
       should_prerelease: ${{ 
           github.event_name != 'schedule' &&
           (github.ref_name == 'main' || contains(github.event.head_commit.message, '[do_publish]') || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         id: build-targets
         with:
           filters: |
-            workflows: '.github/workflows'
+            workflows: '.github/workflows/**'
             compact-js: 'compact-js/**'
             platform-js: 'platform-js/**'
             midnight-js: 'packages/**' 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
 
       - name: Determine Build Targets
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: build-targets
         with:
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     name: Build Midnight.js
     uses: ./.github/workflows/ci_mn_js.yml
     with:
-      should_run: ${{ needs.ci.outputs.build_mn_js || needs.ci.outputs.build_workflows }}
+      should_run: ${{ needs.ci.outputs.build_mn_js == 'true' || needs.ci.outputs.build_workflows == 'true' }}
       should_prerelease: ${{ 
           github.event_name != 'schedule' &&
           (github.ref_name == 'main' || contains(github.event.head_commit.message, '[do_publish]') || github.event_name == 'workflow_dispatch')
@@ -73,7 +73,7 @@ jobs:
     needs: ci
     name: Build Compact.js
     with:
-      should_run: ${{ needs.ci.outputs.build_c_js || needs.ci.outputs.build_workflows }}
+      should_run: ${{ needs.ci.outputs.build_c_js == 'true' || needs.ci.outputs.build_workflows == 'true' }}
       should_prerelease: ${{ 
           github.event_name != 'schedule' &&
           (github.ref_name == 'main' || contains(github.event.head_commit.message, '[do_publish]') || github.event_name == 'workflow_dispatch')
@@ -85,7 +85,7 @@ jobs:
     needs: ci
     name: Build Platform.js
     with:
-      should_run: ${{ needs.ci.outputs.build_p_js || needs.ci.outputs.build_workflows }}
+      should_run: ${{ needs.ci.outputs.build_p_js == 'true' || needs.ci.outputs.build_workflows == 'true' }}
       should_prerelease: ${{ 
           github.event_name != 'schedule' &&
           (github.ref_name == 'main' || contains(github.event.head_commit.message, '[do_publish]') || github.event_name == 'workflow_dispatch')

--- a/compact-js/compact-js-command/src/effect/internal/command.ts
+++ b/compact-js/compact-js-command/src/effect/internal/command.ts
@@ -46,7 +46,7 @@ const reportCausableError: (err: any) => Effect.Effect<void, never> =
         if (Doc.isDoc(errOrDoc)) {
           return docs.push(errOrDoc);
         }
-        docs.push(Doc.text(String(errOrDoc)));
+        docs.push(Doc.text(err.message));
         if (errOrDoc.cause) {
           buildCauseDoc(errOrDoc.cause);
         }

--- a/compact-js/compact-js-command/src/effect/internal/command.ts
+++ b/compact-js/compact-js-command/src/effect/internal/command.ts
@@ -65,7 +65,6 @@ const reportCausableError: (err: any) => Effect.Effect<void, never> =
       ) as Doc.AnsiDoc
     }
     yield* Console.log(Doc.render(errorDoc, {style: 'pretty'}));
-    process.exit(1); // Terminate with non-zero exit code on any causable error.
   });
 
 /**

--- a/compact-js/compact-js-command/src/effect/internal/command.ts
+++ b/compact-js/compact-js-command/src/effect/internal/command.ts
@@ -43,6 +43,7 @@ const reportCausableError: (err: any) => Effect.Effect<void, never> =
     const buildCauseDocs = () => {
       const docs: Doc.Doc<unknown>[] = [];
       const buildCauseDoc = (errOrDoc: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
+        if (!errOrDoc) return;
         if (Doc.isDoc(errOrDoc)) {
           return docs.push(errOrDoc);
         }

--- a/compact-js/compact-js-command/src/effect/internal/command.ts
+++ b/compact-js/compact-js-command/src/effect/internal/command.ts
@@ -43,11 +43,10 @@ const reportCausableError: (err: any) => Effect.Effect<void, never> =
     const buildCauseDocs = () => {
       const docs: Doc.Doc<unknown>[] = [];
       const buildCauseDoc = (errOrDoc: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
-        if (!errOrDoc) return;
         if (Doc.isDoc(errOrDoc)) {
           return docs.push(errOrDoc);
         }
-        docs.push(Doc.text(errOrDoc.message));
+        docs.push(Doc.text(String(errOrDoc)));
         if (errOrDoc.cause) {
           buildCauseDoc(errOrDoc.cause);
         }

--- a/compact-js/compact-js-command/src/effect/internal/command.ts
+++ b/compact-js/compact-js-command/src/effect/internal/command.ts
@@ -65,6 +65,7 @@ const reportCausableError: (err: any) => Effect.Effect<void, never> =
       ) as Doc.AnsiDoc
     }
     yield* Console.log(Doc.render(errorDoc, {style: 'pretty'}));
+    process.exit(1); // Terminate with non-zero exit code on any causable error.
   });
 
 /**

--- a/compact-js/compact-js-command/test/effect/Circuit.test.ts
+++ b/compact-js/compact-js-command/test/effect/Circuit.test.ts
@@ -27,8 +27,8 @@ import * as MockConsole from './MockConsole.js';
 
 const COUNTER_CONFIG_FILEPATH = resolve(import.meta.dirname, '../contract/counter/contract.config.ts');
 const COUNTER_STATE_FILEPATH = resolve(import.meta.dirname, '../contract/counter/state.bin');
-const COUNTER_OUTPUT_FILEPATH = resolve(import.meta.dirname, '../contract/counter/output.bin');
-const COUNTER_OUTPUT_PS_FILEPATH = resolve(import.meta.dirname, '../contract/counter/output.js');
+const COUNTER_OUTPUT_FILEPATH = resolve(import.meta.dirname, '../contract/counter/output_circuit.bin');
+const COUNTER_OUTPUT_PS_FILEPATH = resolve(import.meta.dirname, '../contract/counter/output_circuit.json');
 
 const testLayer: Layer.Layer<ConfigCompiler.ConfigCompiler | NodeContext.NodeContext | FileSystem.FileSystem> =
   Effect.gen(function* () {

--- a/compact-js/compact-js-command/test/effect/Deploy.test.ts
+++ b/compact-js/compact-js-command/test/effect/Deploy.test.ts
@@ -26,8 +26,8 @@ import { ensureRemovePath } from './cleanup.js';
 import * as MockConsole from './MockConsole.js';
 
 const COUNTER_CONFIG_FILEPATH = resolve(import.meta.dirname, '../contract/counter/contract.config.ts');
-const COUNTER_OUTPUT_FILEPATH = resolve(import.meta.dirname, '../contract/counter/output.bin');
-const COUNTER_OUTPUT_PS_FILEPATH = resolve(import.meta.dirname, '../contract/counter/output.js');
+const COUNTER_OUTPUT_FILEPATH = resolve(import.meta.dirname, '../contract/counter/output_deploy.bin');
+const COUNTER_OUTPUT_PS_FILEPATH = resolve(import.meta.dirname, '../contract/counter/output_deploy.json');
 
 const testLayer: Layer.Layer<ConfigCompiler.ConfigCompiler | NodeContext.NodeContext> =
   Effect.gen(function* () {


### PR DESCRIPTION
This PR updates the `'CD'` workflows to ensure that packages are only published if changes are detected in their associated _product_ folders.