### PR TITLE
fix: add SARIF message validation for codeql-action compatibility

### DIFF
--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -94,6 +94,10 @@ jobs:
         run: |
           mv ./cx_result.sarif ./cx_result.sarif.orig
           jq '.runs |= map(.results |= map(.locations |= map(if .physicalLocation.artifactLocation.uri == "" then .physicalLocation.artifactLocation.uri = "file:/README.md" else . end)))' cx_result.sarif.orig > cx_result.sarif
+          # Fix missing message text that causes codeql-action to fail
+          mv ./cx_result.sarif ./cx_result.sarif.tmp
+          jq '.runs[].results[] |= (if .message.text == null or .message.text == "" then .message.text = ("Security issue detected by " + .ruleId) else . end)' cx_result.sarif.tmp > cx_result.sarif
+          rm -f cx_result.sarif.tmp cx_result.sarif.orig
 
       # Upload report so security issues are viewable from within the github ui
       - name: Upload SARIF file


### PR DESCRIPTION
## Problem
The CI pipeline is failing after PR #68 upgraded github/codeql-action. The newer version has stricter SARIF validation and requires all results to have a message property.

Error:
```
Error: Code Scanning could not process the submitted SARIF file:
expected a result message, expected a result message, expected a result message
```

## Solution
Added a jq filter to ensure all SARIF results have valid message text. If a result is missing a message or has an empty message, it now gets a default message based on the rule ID.

## Changes
- Added jq transformation to validate and fix missing message.text properties in SARIF results
- Cleaned up temporary files after processing

## Testing
- The jq filter ensures compatibility with the stricter codeql-action validation
- Existing results with valid messages are unchanged
- Results without messages get a descriptive default message

This fixes the immediate CI blocker while we work on open-sourcing the upload-sarif-github-action for a more comprehensive solution.