### PR TITLE
release(Platform.js): Platform.js version `1.0`

### DIFF
--- a/.github/workflows/cd_c_js.yml
+++ b/.github/workflows/cd_c_js.yml
@@ -74,27 +74,34 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "on_release_branch=${on_release_branch}" >> "$GITHUB_OUTPUT"
 
-          echo "### Summary" >> $GITHUB_STEP_SUMMARY
-          [[ '$on_release_branch' = 'true' ]] && echo "Releasing v$target_version (tagged as $tag)." >> $GITHUB_OUTPUT || echo "Unlisted release branch, following steps will be skipped." >> $GITHUB_OUTPUT
-
       - name: Determine Build Targets
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: changes
         with:
           filters: |
+            vinfo: 'version.compactjs.json'
             compact-js: 'compact-js/**' 
 
       - name: Bump versions
-        if: steps.vars.outputs.on_release_branch steps.changes.outputs.compact-js == 'true'
+        if: ${{
+            steps.vars.outputs.on_release_branch == 'true' &&
+            (steps.changes.outputs.compact-js == 'true' || steps.changes.outputs.vinfo == 'true')
+          }}
         run: yarn workspaces foreach --all version ${{ steps.vars.outputs.target_version }}
 
       - name: Publish packages
-        if: steps.vars.outputs.on_release_branch steps.changes.outputs.compact-js == 'true'
+        if: ${{
+            steps.vars.outputs.on_release_branch == 'true' &&
+            (steps.changes.outputs.compact-js == 'true' || steps.changes.outputs.vinfo == 'true')
+          }}
         run: yarn deploy --filter="./compact-js/*" --cache-dir ./turbo -- --tag ${{ steps.vars.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
           NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
 
       - name: Set build instance version number
-        if: steps.vars.outputs.on_release_branch steps.changes.outputs.compact-js == 'true'
+        if: ${{
+            steps.vars.outputs.on_release_branch == 'true' &&
+            (steps.changes.outputs.compact-js == 'true' || steps.changes.outputs.vinfo == 'true')
+          }}
         run: echo "id=${{ steps.vars.outputs.target_version }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cd_p_js.yml
+++ b/.github/workflows/cd_p_js.yml
@@ -74,27 +74,34 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "on_release_branch=${on_release_branch}" >> "$GITHUB_OUTPUT"
 
-          echo "### Summary" >> $GITHUB_STEP_SUMMARY
-          [[ '$on_release_branch' = 'true' ]] && echo "Releasing v$target_version (tagged as $tag)." >> $GITHUB_OUTPUT || echo "Unlisted release branch, following steps will be skipped." >> $GITHUB_OUTPUT
-
       - name: Determine Build Targets
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: changes
         with:
           filters: |
+            vinfo: 'version.platformjs.json'
             platform-js: 'platform-js/**' 
 
       - name: Bump versions
-        if: steps.vars.outputs.on_release_branch steps.changes.outputs.platform-js == 'true'
+        if: ${{
+            steps.vars.outputs.on_release_branch == 'true' &&
+            (steps.changes.outputs.platform-js == 'true' || steps.changes.outputs.vinfo == 'true')
+          }}
         run: yarn workspaces foreach --all version ${{ steps.vars.outputs.target_version }}
 
       - name: Publish packages
-        if: steps.vars.outputs.on_release_branch steps.changes.outputs.platform-js == 'true'
+        if: ${{
+            steps.vars.outputs.on_release_branch == 'true' &&
+            (steps.changes.outputs.platform-js == 'true' || steps.changes.outputs.vinfo == 'true')
+          }}
         run: yarn deploy --filter="./platform-js/*" --cache-dir ./turbo -- --tag ${{ steps.vars.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
           NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
 
       - name: Set build instance version number
-        if: steps.vars.outputs.on_release_branch steps.changes.outputs.platform-js == 'true'
+        if: ${{
+            steps.vars.outputs.on_release_branch == 'true' &&
+            (steps.changes.outputs.platform-js == 'true' || steps.changes.outputs.vinfo == 'true')
+          }}
         run: echo "id=${{ steps.vars.outputs.target_version }}" >> "$GITHUB_OUTPUT"

--- a/version.platformjs.json
+++ b/version.platformjs.json
@@ -1,8 +1,8 @@
 {
   "v_info": {
-    "version": "1.0.0",
-    "preRelease": "-rc",
-    "tag": "rc",
+    "version": "1.0",
+    "preRelease": "",
+    "tag": "latest",
     "releaseBranches": [
       "main",
       "release/pjs/.*"

--- a/version.platformjs.json
+++ b/version.platformjs.json
@@ -1,8 +1,8 @@
 {
   "v_info": {
     "version": "1.0.0",
-    "preRelease": "-pre",
-    "tag": "pre",
+    "preRelease": "-rc",
+    "tag": "rc",
     "releaseBranches": [
       "main",
       "release/pjs/.*"


### PR DESCRIPTION
This PR brings in some changes made to the `CD` pipelines for both Compact.js and Platform.js.

> [!NOTE]
> Post merge, the `version.platform.js`, file should be rewritten to reflect the next _major_ version.