### PR TITLE
release(Compact.js): Compact.js version 1.0

### DIFF
--- a/.github/workflows/cd_c_js.yml
+++ b/.github/workflows/cd_c_js.yml
@@ -87,7 +87,7 @@ jobs:
             steps.vars.outputs.on_release_branch == 'true' &&
             (steps.changes.outputs.compact-js == 'true' || steps.changes.outputs.vinfo == 'true')
           }}
-        run: yarn workspaces foreach --all version ${{ steps.vars.outputs.target_version }}
+        run: yarn workspaces foreach -R --from "./compact-js/*" --exclude "./platform-js/*" --exclude "./packages/*" version ${{ steps.vars.outputs.target_version }}
 
       - name: Publish packages
         if: ${{

--- a/.github/workflows/cd_p_js.yml
+++ b/.github/workflows/cd_p_js.yml
@@ -87,7 +87,7 @@ jobs:
             steps.vars.outputs.on_release_branch == 'true' &&
             (steps.changes.outputs.platform-js == 'true' || steps.changes.outputs.vinfo == 'true')
           }}
-        run: yarn workspaces foreach --all version ${{ steps.vars.outputs.target_version }}
+        run: yarn workspaces foreach -R --from "./platform-js/*" --exclude "./compact-js/*" --exclude "./packages/*" version ${{ steps.vars.outputs.target_version }}
 
       - name: Publish packages
         if: ${{

--- a/.github/workflows/ci_c_js.yml
+++ b/.github/workflows/ci_c_js.yml
@@ -206,7 +206,7 @@ jobs:
           echo "tag=$tag" >> $GITHUB_OUTPUT
 
       - name: Bump versions
-        run: yarn workspaces foreach --all version ${{ steps.vars.outputs.target_version }}
+        run: yarn workspaces foreach -R --from "./compact-js/*" --exclude "./platform-js/*" --exclude "./packages/*" version ${{ steps.vars.outputs.target_version }}
 
       - name: Publish packages
         run: yarn deploy ${{ inputs.yarn_filter }} --cache-dir ./turbo -- --tag ${{ steps.vars.outputs.tag }}

--- a/.github/workflows/ci_p_js.yml
+++ b/.github/workflows/ci_p_js.yml
@@ -204,7 +204,7 @@ jobs:
           echo "tag=$tag" >> $GITHUB_OUTPUT
 
       - name: Bump versions
-        run: yarn workspaces foreach --all version ${{ steps.vars.outputs.target_version }}
+        run: yarn workspaces foreach -R --from "./platform-js/*" --exclude "./compact-js/*" --exclude "./packages/*" version ${{ steps.vars.outputs.target_version }}
 
       - name: Publish packages
         run: yarn deploy ${{ inputs.yarn_filter }} --cache-dir ./turbo -- --tag ${{ steps.vars.outputs.tag }}

--- a/compact-js/compact-js-command/package.json
+++ b/compact-js/compact-js-command/package.json
@@ -25,7 +25,7 @@
     "@midnight-ntwrk/compact-js-node": "^0.0.0",
     "@midnight-ntwrk/compact-runtime": "0.9.0-rc.0",
     "@midnight-ntwrk/ledger": "5.0.0-alpha.3",
-    "@midnight-ntwrk/platform-js": "^0.0.0",
+    "@midnight-ntwrk/platform-js": "^1.0.0",
     "effect": "^3.17.7",
     "ts-node": "^10.9.2"
   },

--- a/compact-js/compact-js/package.json
+++ b/compact-js/compact-js/package.json
@@ -14,7 +14,7 @@
     "@effect/platform": "^0.90.2",
     "@midnight-ntwrk/compact-runtime": "0.9.0-rc.0",
     "@midnight-ntwrk/ledger": "5.0.0-alpha.3",
-    "@midnight-ntwrk/platform-js": "^0.0.0",
+    "@midnight-ntwrk/platform-js": "^1.0.0",
     "effect": "^3.17.7"
   },
   "devDependencies": {

--- a/platform-js/platform-js/package.json
+++ b/platform-js/platform-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/platform-js",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Provides a set of core abstractions, utilities, and types for building services and libraries that work with the Midnight blockchain",
   "type": "module",
   "exports": {

--- a/version.compactjs.json
+++ b/version.compactjs.json
@@ -1,8 +1,8 @@
 {
   "v_info": {
     "version": "1.0.0",
-    "preRelease": "-pre",
-    "tag": "pre",
+    "preRelease": "-rc",
+    "tag": "rc",
     "releaseBranches": [
       "main",
       "release/cjs/.*"

--- a/version.compactjs.json
+++ b/version.compactjs.json
@@ -1,8 +1,8 @@
 {
   "v_info": {
-    "version": "1.0.0",
-    "preRelease": "-rc",
-    "tag": "rc",
+    "version": "1.0",
+    "preRelease": "",
+    "tag": "latest",
     "releaseBranches": [
       "main",
       "release/cjs/.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,7 +2183,7 @@ __metadata:
     "@midnight-ntwrk/compact-runtime": "npm:0.9.0-rc.0"
     "@midnight-ntwrk/ledger": "npm:5.0.0-alpha.3"
     "@midnight-ntwrk/midnight-js-compact": "workspace:*"
-    "@midnight-ntwrk/platform-js": "npm:^0.0.0"
+    "@midnight-ntwrk/platform-js": "npm:^1.0.0"
     effect: "npm:^3.17.7"
     ts-node: "npm:^10.9.2"
   languageName: unknown
@@ -2217,7 +2217,7 @@ __metadata:
     "@midnight-ntwrk/compact-runtime": "npm:0.9.0-rc.0"
     "@midnight-ntwrk/ledger": "npm:5.0.0-alpha.3"
     "@midnight-ntwrk/midnight-js-compact": "workspace:*"
-    "@midnight-ntwrk/platform-js": "npm:^0.0.0"
+    "@midnight-ntwrk/platform-js": "npm:^1.0.0"
     effect: "npm:^3.17.7"
   languageName: unknown
   linkType: soft
@@ -2473,7 +2473,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/platform-js@npm:^0.0.0, @midnight-ntwrk/platform-js@workspace:platform-js/platform-js":
+"@midnight-ntwrk/platform-js@npm:^1.0.0, @midnight-ntwrk/platform-js@workspace:platform-js/platform-js":
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/platform-js@workspace:platform-js/platform-js"
   dependencies:


### PR DESCRIPTION
This PR brings in some changes made to the `CD` pipelines for both Compact.js and Platform.js. Specifically, these changes ensure that the version numbers are only bumped for the particular workspace being released.

> [!NOTE]
> Post merge, the `version.compactjs.js`, file should be rewritten to reflect the next _major_ version.