### PR TITLE
chore: Bump major version number on Platform.js and Compact.js

### DIFF
--- a/.github/workflows/ci_c_js.yml
+++ b/.github/workflows/ci_c_js.yml
@@ -130,6 +130,7 @@ jobs:
         uses: MishaKav/jest-coverage-comment@aa3935cf9ee61efc40d9e47dcc8a523a49a70b96 # ratchet:MishaKav/jest-coverage-comment@v1
         with:
           hide-comment: false
+          unique-id-for-comment: 'compact-js-coverage'
           multiple-files: |
             compact-js, ./compact-js/compact-js/coverage/coverage-summary.json
             compact-js-node, ./compact-js/compact-js-node/coverage/coverage-summary.json

--- a/.github/workflows/ci_p_js.yml
+++ b/.github/workflows/ci_p_js.yml
@@ -130,6 +130,7 @@ jobs:
         uses: MishaKav/jest-coverage-comment@aa3935cf9ee61efc40d9e47dcc8a523a49a70b96 # ratchet:MishaKav/jest-coverage-comment@v1
         with:
           hide-comment: false
+          unique-id-for-comment: 'platform-js-coverage'
           multiple-files: |
             platform-js, ./platform-js/platform-js/coverage/coverage-summary.json
 

--- a/version.compactjs.json
+++ b/version.compactjs.json
@@ -1,8 +1,8 @@
 {
   "v_info": {
-    "version": "1.0",
-    "preRelease": "",
-    "tag": "latest",
+    "version": "2.0.0",
+    "preRelease": "-pre",
+    "tag": "pre",
     "releaseBranches": [
       "main",
       "release/cjs/.*"

--- a/version.platformjs.json
+++ b/version.platformjs.json
@@ -1,8 +1,8 @@
 {
   "v_info": {
-    "version": "1.0",
-    "preRelease": "",
-    "tag": "latest",
+    "version": "2.0.0",
+    "preRelease": "-pre",
+    "tag": "pre",
     "releaseBranches": [
       "main",
       "release/pjs/.*"


### PR DESCRIPTION
Small PR that:

- Bumps the major version number on Platform.js and Compact.js (to `2.0.0`), and
- Ensures that a unique ID is used with the `MishaKav/jest-coverage-comment` action within the CI builds for Compact.js/Platform.js. This will ensure that all coverage comments are reported in the associated PRs. 