### PR TITLE
feat(compact-js): Support typed arguments on circuit invocation

### DIFF
--- a/compact-js/compact-js-command/package.json
+++ b/compact-js/compact-js-command/package.json
@@ -27,6 +27,7 @@
     "@midnight-ntwrk/ledger": "npm:@midnight-ntwrk/ledger-v6@6.1.0-alpha.2",
     "@midnight-ntwrk/platform-js": "^1.0.0",
     "effect": "^3.17.7",
+    "json5": "^2.2.3",
     "ts-node": "^10.9.2"
   },
   "devDependencies": {

--- a/compact-js/compact-js-command/src/effect/CompiledContractReflection.ts
+++ b/compact-js/compact-js-command/src/effect/CompiledContractReflection.ts
@@ -1,0 +1,97 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type FileSystem, type Path } from '@effect/platform';
+import { type PlatformError } from '@effect/platform/Error';
+import { type CompiledContract, type Contract, type ContractRuntimeError } from '@midnight-ntwrk/compact-js/effect';
+import { Context, type Effect,type Layer } from 'effect';
+
+import * as internal from './internal/compiledContractReflection.js';
+
+/**
+ * Provides utilities for inspecting a compiled Compact contract.
+ * 
+ * @category services
+ */
+export class CompiledContractReflection extends Context.Tag('compact-js-command/CompiledContractReflection')<
+  CompiledContractReflection,
+  CompiledContractReflection.Service
+>() {}
+
+export declare namespace CompiledContractReflection {
+  /**
+   * Provides utilities for inspecting a compiled Compact contract.
+   */
+  export interface Service {
+    /**
+     * Creates a parser that transforms an array of string, into an array of values, typed by the reflected
+     * argument types of the compiled Compact contract's initializer or circuits.
+     * 
+     * @param compiledContract The Compact compiled contract.
+     * @returns An `Effect` that yields an {@link ArgumentParser} for `compiledContract`; or a `PlatformError` 
+     * if the Compact generated TypeScript declaration file could not be found.
+     */
+    readonly createArgumentParser: <C extends Contract.Contract<PS>, PS>(
+      compiledContract: CompiledContract.CompiledContract<C, PS, never>
+    ) => Effect.Effect<ArgumentParser<C, PS>, PlatformError>
+  }
+
+  /**
+   * Uses the argument types of a compiled Compact contract's initializer or circuits, to transform an array
+   * of string into an array of values that can be used when executing the contract.
+   */
+  export interface ArgumentParser<C extends Contract.Contract<PS>, PS> {
+    /**
+     * Transforms an array of strings into an array of contract initialization arguments.
+     * 
+     * @param args The array of strings to be transformed.
+     * @returns An `Effect` that yields an array of initialization arguments; or fails with a 
+     * {@link ContractRuntimeError.ContractRuntimeError | ContractRuntimeError}.
+     */
+    parseInitializationArgs(args: string[]): Effect.Effect<Contract.Contract.InitializeParameters<C>, ContractRuntimeError.ContractRuntimeError>;
+
+    /**
+     * Transforms an array of strings into an array of circuit arguments.
+     * 
+     * @param impureCircuitId The identifier of the circuit that will be invoked with `args`.
+     * @param args The array of strings to be transformed.
+     * @returns An `Effect` that yields an array of circuit arguments; or fails with a 
+     * {@link ContractRuntimeError.ContractRuntimeError | ContractRuntimeError}.
+     */
+    parseCircuitArgs<K extends Contract.ImpureCircuitId<C>>(
+      impureCircuitId: K,
+      args: string[]
+    ): Effect.Effect<Contract.Contract.CircuitParameters<C, K>, ContractRuntimeError.ContractRuntimeError>;
+  }
+
+  /**
+   * Represents an {@link ArgumentParser} for any contract.
+   */
+  export type AnyArgumentParser = ArgumentParser<any, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+/**
+ * A {@link CompiledContractReflection} implementation that uses a TypeScript declaration file (*.d.ts) produced
+ * by the Compact compiler, to reflect over an associated contract's types.
+ * 
+ * @param baseAssetFolderPath A base path to a folder containing the compiled contract assets.
+ * 
+ * @category layers
+ */
+export const layer: (baseAssetFolderPath?: string) => Layer.Layer<
+  CompiledContractReflection,
+  PlatformError,
+  FileSystem.FileSystem | Path.Path
+> = internal.layer;

--- a/compact-js/compact-js-command/src/effect/index.ts
+++ b/compact-js/compact-js-command/src/effect/index.ts
@@ -39,6 +39,7 @@ export const circuitCommand = Command.make(
     Command.withHandler(InternalCommand.invocationHandler(InternalCircuitCommand.handler))
   );
 
+export * as CompiledContractReflection from './CompiledContractReflection.js';
 export * as ConfigCompilationError from './ConfigCompilationError.js';
 export * as ConfigCompiler from './ConfigCompiler.js';
 export * as ConfigError from './ConfigError.js';

--- a/compact-js/compact-js-command/src/effect/internal/command.ts
+++ b/compact-js/compact-js-command/src/effect/internal/command.ts
@@ -48,7 +48,7 @@ const reportCausableError: (err: any) => Effect.Effect<void, never> =
         if (Doc.isDoc(errOrDoc)) {
           return docs.push(errOrDoc);
         }
-        docs.push(Doc.text(err.message));
+        docs.push(Doc.text(errOrDoc.message));
         if (errOrDoc.cause) {
           buildCauseDoc(errOrDoc.cause);
         }
@@ -66,7 +66,6 @@ const reportCausableError: (err: any) => Effect.Effect<void, never> =
         ]))
       ) as Doc.AnsiDoc
     }
-    const _a = Doc.render(errorDoc, {style: 'pretty'});
     yield* Console.log(Doc.render(errorDoc, {style: 'pretty'}));
     process.exit(1); // Terminate with non-zero exit code on any causable error.
   });

--- a/compact-js/compact-js-command/src/effect/internal/command.ts
+++ b/compact-js/compact-js-command/src/effect/internal/command.ts
@@ -208,7 +208,7 @@ export const invocationHandler: <
       const { moduleImportDirectoryPath, module: { default: contractModule } } = moduleSpec;
       const contractRuntime = ContractExecutableRuntime.make(
         layer(
-          CommandConfigProvider.make(contractModule.config, InternalOptions.asConfigProvider(inputs)),
+          CommandConfigProvider.make(contractModule.config ?? {}, InternalOptions.asConfigProvider(inputs)),
           moduleImportDirectoryPath
         )
       );

--- a/compact-js/compact-js-command/src/effect/internal/command.ts
+++ b/compact-js/compact-js-command/src/effect/internal/command.ts
@@ -20,7 +20,7 @@ import * as Doc from '@effect/printer-ansi/AnsiDoc';
 import { type ContractExecutable, ContractExecutableRuntime,type ZKConfiguration } from '@midnight-ntwrk/compact-js/effect';
 import { ZKFileConfiguration } from '@midnight-ntwrk/compact-js-node/effect';
 import * as Configuration from '@midnight-ntwrk/platform-js/effect/Configuration';
-import { ConfigError as EffectConfigError, type ConfigProvider, Console, DateTime, type Duration,Effect,Layer } from 'effect';
+import { ConfigError as EffectConfigError, type ConfigProvider, Console, DateTime, type Duration, Effect, Layer } from 'effect';
 
 import * as CommandConfigProvider from '../CommandConfigProvider.js';
 import * as ConfigCompilationError from '../ConfigCompilationError.js';

--- a/compact-js/compact-js-command/src/effect/internal/compiledContractReflection.ts
+++ b/compact-js/compact-js-command/src/effect/internal/compiledContractReflection.ts
@@ -17,15 +17,14 @@ import { FileSystem, Path } from '@effect/platform';
 import { CompiledContract, type Contract, ContractRuntimeError } from '@midnight-ntwrk/compact-js/effect';
 import * as Hex from '@midnight-ntwrk/platform-js/effect/Hex'
 import { Effect, Either, identity, Layer } from 'effect';
-import TS from 'typescript';
 import * as JSON5 from 'json5';
+import TS from 'typescript';
 
 import * as CompiledContractReflection from "../CompiledContractReflection.js";
 
 const CONTRACT_FOLDER = 'contract';
 const CONTRACT_DECLARATION_FILE = 'index.d.cts';
 const TRUE_OR_FALSE_REGEXP = /^true|false$/;
-const TUPLE_REGEXP = /('[^']*'|\d+|true|false)/gm
 
 type FileSnapshot = {
   file: TS.IScriptSnapshot;

--- a/compact-js/compact-js-command/src/effect/internal/compiledContractReflection.ts
+++ b/compact-js/compact-js-command/src/effect/internal/compiledContractReflection.ts
@@ -94,6 +94,10 @@ const transformParams: (
       const type = types[idx];
       
       try {
+        if (type!.kind === TS.SyntaxKind.NumberKeyword) {
+          transformedArgs.push(Number(args[idx]))
+          continue;
+        }
         if (type!.kind === TS.SyntaxKind.BigIntKeyword) {
           transformedArgs.push(BigInt(args[idx]))
           continue;

--- a/compact-js/compact-js-command/src/effect/internal/compiledContractReflection.ts
+++ b/compact-js/compact-js-command/src/effect/internal/compiledContractReflection.ts
@@ -16,7 +16,7 @@
 import { FileSystem, Path } from '@effect/platform';
 import { CompiledContract, type Contract, ContractRuntimeError } from '@midnight-ntwrk/compact-js/effect';
 import * as Hex from '@midnight-ntwrk/platform-js/effect/Hex'
-import { Effect, Either, Layer } from 'effect';
+import { Effect, Either, identity, Layer } from 'effect';
 import TS from 'typescript';
 import * as JSON5 from 'json5';
 
@@ -109,14 +109,15 @@ const transformParams: (
           continue;
         }
         if (type!.kind === TS.SyntaxKind.TupleType) {
-          const tupleElems = args[idx].match(TUPLE_REGEXP);
+          const tupleElems = JSON5.parse(args[idx]);
           transformedArgs.push(
-            Either.getOrThrow(
+            Either.getOrThrowWith(
               transformParams(
-                tupleElems as string[],
+                tupleElems.map(JSON5.stringify),
                 (type as TS.TupleTypeNode).elements.map((_) => _ as TS.TypeNode),
                 true
-              )
+              ),
+              identity // Rethrow the error from `transformParams`.
             )
           );
           continue;
@@ -127,15 +128,10 @@ const transformParams: (
           for (const member of typeLiteral.members) {
             const propKey = ((member as TS.PropertySignature).name as TS.Identifier).escapedText.valueOf() as string;
             const propType = (member as TS.PropertySignature).type!;
-            const memberValue = Either.getOrThrow(transformParams(
-              [
-                propType.kind === TS.SyntaxKind.TypeLiteral || propType.kind === TS.SyntaxKind.TupleType
-                  ? JSON5.stringify(srcObj[propKey]) 
-                  : String(srcObj[propKey])
-              ],
-              [propType],
-              true
-            ));
+            const memberValue = Either.getOrThrowWith(
+              transformParams([JSON5.stringify(srcObj[propKey])], [propType], true),
+              identity // Rethrow the error from `transformParams`.
+            );
             srcObj[propKey] = memberValue[0];
           }
           transformedArgs.push(srcObj);
@@ -144,7 +140,7 @@ const transformParams: (
         if (type!.kind === TS.SyntaxKind.TypeReference) {
           const typeName = (type as TS.TypeReferenceNode).typeName;
           if (TS.isIdentifier(typeName) && typeName.escapedText === 'Uint8Array') {
-            transformedArgs.push(Either.match(Hex.parseHex(args[idx]), {
+            transformedArgs.push(Either.match(Hex.parseHex(quotedStrings ? args[idx].replaceAll('\'', '') : args[idx]), {
               onRight: (parsedHex) => Buffer.from(parsedHex.byteChars, 'hex'),
               onLeft: (parseErr) => { 
                 throw new SyntaxError(`Cannot convert ${args[idx]} to a Uint8Array: ${parseErr.message}`);

--- a/compact-js/compact-js-command/src/effect/internal/compiledContractReflection.ts
+++ b/compact-js/compact-js-command/src/effect/internal/compiledContractReflection.ts
@@ -1,0 +1,189 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FileSystem, Path } from '@effect/platform';
+import { CompiledContract, type Contract, ContractRuntimeError } from '@midnight-ntwrk/compact-js/effect';
+import { Effect, Either, Layer } from 'effect';
+import TS from 'typescript';
+
+import * as CompiledContractReflection from "../CompiledContractReflection.js";
+
+const CONTRACT_FOLDER = 'contract';
+const CONTRACT_DECLARATION_FILE = 'index.d.cts';
+const TRUE_OR_FALSE_REGEXP = /^true|false$/;
+const TUPLE_REGEXP = /('[^']*'|\d+|true|false)/gm
+
+type FileSnapshot = {
+  file: TS.IScriptSnapshot;
+  version: number;
+}
+
+class BasicHost implements TS.LanguageServiceHost {
+  #files: Record<string, FileSnapshot>;
+
+  constructor(readonly files: Record<string, FileSnapshot>) {
+    this.#files = {...files};
+  }
+
+  getCurrentDirectory(): string {
+    return '';
+  }
+  getDefaultLibFileName(_: TS.CompilerOptions): string {
+    return 'lib';
+  }
+  getCompilationSettings(): TS.CompilerOptions {
+    return TS.getDefaultCompilerOptions();
+  }
+  getScriptVersion(fileName: string): string {
+    return String(this.files[fileName].version);
+  }
+  getScriptSnapshot(fileName: string): TS.IScriptSnapshot | undefined {
+    return this.files[fileName]?.file;
+  }
+  getScriptFileNames(): string[] {
+    return Object.keys(this.#files);
+  }
+  fileExists(path: string): boolean {
+    return !!this.files[path];
+  }
+  readFile(path: string): string | undefined {
+    const file = this.files[path].file
+    return file?.getText(0, file?.getLength())
+  }
+}
+
+const typeNodeName: (type: TS.TypeNode) => string =
+  (type) => {
+    if (type.kind === TS.SyntaxKind.BigIntKeyword) return 'bigint';
+    if (type.kind === TS.SyntaxKind.StringKeyword) return 'string';
+    if (type.kind === TS.SyntaxKind.BooleanKeyword) return 'boolean';
+    if (type.kind === TS.SyntaxKind.TupleType) {
+      return `[${(type as TS.TupleTypeNode).elements.map((_) => typeNodeName(_ as TS.TypeNode)).join(', ')}]`;
+    }
+    return '<unknown>';
+  };
+
+const transformParams: (
+  args: string[],
+  types: TS.TypeNode[],
+  quotedStrings?: boolean
+) => Either.Either<any[], ContractRuntimeError.ContractRuntimeError> = // eslint-disable-line @typescript-eslint/no-explicit-any
+  (args, types, quotedStrings = false) => {
+    if (args.length !== types.length) {
+      return Either.left(
+        ContractRuntimeError.make(
+          `Invalid number of arguments. Expected ${types.length} arguments, but got ${args.length}`
+        )
+      );
+    }
+    const transformedArgs: any[] = []; // eslint-disable-line @typescript-eslint/no-explicit-any
+    for (let idx = 0; idx < types.length; idx++) {
+      const type = types[idx];
+      
+      try {
+        if (type!.kind === TS.SyntaxKind.BigIntKeyword) {
+          transformedArgs.push(BigInt(args[idx]))
+          continue;
+        }
+        if (type!.kind === TS.SyntaxKind.StringKeyword) {
+          transformedArgs.push(quotedStrings ? args[idx].replaceAll('\'', '') : args[idx]);
+          continue;
+        }
+        if (type!.kind === TS.SyntaxKind.BooleanKeyword) {
+          if (!TRUE_OR_FALSE_REGEXP.test(args[idx])) throw new SyntaxError(`Cannot convert ${args[idx]} to a Boolean`);
+          transformedArgs.push(args[idx] === 'true');
+          continue;
+        }
+        if (type!.kind === TS.SyntaxKind.TupleType) {
+          const tupleElems = args[idx].match(TUPLE_REGEXP);
+          transformedArgs.push(
+            Either.getOrThrow(
+              transformParams(
+                tupleElems as string[],
+                (type as TS.TupleTypeNode).elements.map((_) => _ as TS.TypeNode),
+                true
+              )
+            )
+          );
+          continue;
+        }
+      }
+      catch (err: unknown) {
+        return Either.left(
+          ContractRuntimeError.make(
+            `Failed to parse argument with index ${idx}`,
+            ContractRuntimeError.make(
+              `Failed to parse string '${args[idx]}' as type of ${typeNodeName(type!)}`,
+              err
+            )
+          )
+        );
+      }
+    }
+    return Either.right(transformedArgs);
+  };
+
+const makeArgumentParser =
+  <C extends Contract.Contract<PS>, PS>(path: Path.Path, fs: FileSystem.FileSystem, baseAssetFolderPath: string) =>
+  (compiledContract: CompiledContract.CompiledContract<C, PS>) =>
+    Effect.gen(function* () {
+      const assetsPath = CompiledContract.getCompiledAssetsPath(compiledContract);
+      const tsDeclFilePath = path.join(path.resolve(baseAssetFolderPath, assetsPath), CONTRACT_FOLDER, CONTRACT_DECLARATION_FILE);
+      const tsHost = new BasicHost({
+        [tsDeclFilePath]: {
+          file: TS.ScriptSnapshot.fromString(yield* fs.readFileString(tsDeclFilePath)),
+          version: 1
+        }
+      });
+      const tsLangService = TS.createLanguageService(tsHost, TS.createDocumentRegistry());
+      const sourceFile = tsLangService.getProgram()!.getSourceFile(tsDeclFilePath);
+      const impureCircuitsTypeNode = sourceFile?.statements.find(
+        (_) => TS.isTypeAliasDeclaration(_)
+          && _.name.escapedText === 'ImpureCircuits'
+          && _.type.kind === TS.SyntaxKind.TypeLiteral
+      ) as TS.TypeAliasDeclaration;
+      const circuitMethodSignatureNodes =
+        (impureCircuitsTypeNode.type as TS.TypeLiteralNode).members as TS.NodeArray<TS.MethodSignature>;
+      const contractClassNode = sourceFile?.statements.find(
+        (_) => TS.isClassDeclaration(_) && _.name!.escapedText === 'Contract'
+      ) as TS.ClassDeclaration;
+      const initialStateMethodSignatureNode = contractClassNode.members.find(
+        (_) => TS.isMethodDeclaration(_)
+          && (_.name as TS.Identifier).escapedText === 'initialState'
+      );
+
+      return {
+        parseInitializationArgs: (args) => transformParams(args, (initialStateMethodSignatureNode as TS.MethodDeclaration).parameters.slice(1).map((_) => _.type!)) as Either.Either<Contract.Contract.InitializeParameters<C>, ContractRuntimeError.ContractRuntimeError>,
+        parseCircuitArgs: (circuitId, args) => {
+          const circuitNode = circuitMethodSignatureNodes.find((_) => (_.name as TS.Identifier)!.escapedText === circuitId);
+          if (!circuitNode) {
+            return Either.left(ContractRuntimeError.make(`Circuit '${circuitId}' not found on the Compact generated TypeScript declaration.`))
+          }
+          return transformParams(args, circuitNode.parameters.slice(1).map((_) => _.type!)) as Either.Either<Contract.Contract.CircuitParameters<C, Contract.ImpureCircuitId>, ContractRuntimeError.ContractRuntimeError>;
+        }
+      } satisfies CompiledContractReflection.CompiledContractReflection.ArgumentParser<C, PS>;
+    });
+
+export const layer = (baseAssetFolderPath = '.') => Layer.effect(
+  CompiledContractReflection.CompiledContractReflection,
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const fs = yield* FileSystem.FileSystem;
+
+    return CompiledContractReflection.CompiledContractReflection.of({
+      createArgumentParser: makeArgumentParser(path, fs, baseAssetFolderPath)
+    })
+  })
+);

--- a/compact-js/compact-js-command/test/contract/counter/contract.config.ts
+++ b/compact-js/compact-js-command/test/contract/counter/contract.config.ts
@@ -35,7 +35,7 @@ const createInitialPrivateState: () => PrivateState = () => ({
 export default {
   contractExecutable: CompiledContract.make<CounterContract>('CounterContract', CounterContract).pipe(
     CompiledContract.withWitnesses(witnesses),
-    CompiledContract.withZKConfigFileAssets('../../../../compact-js/test/contract/managed/counter'),
+    CompiledContract.withCompiledFileAssets('../../../../compact-js/test/contract/managed/counter'),
     ContractExecutable.make
   ),
   createInitialPrivateState,

--- a/compact-js/compact-js-command/test/effect/CompiledContractReflection.test.ts
+++ b/compact-js/compact-js-command/test/effect/CompiledContractReflection.test.ts
@@ -1,0 +1,133 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { join } from 'node:path';
+
+import { FileSystem } from '@effect/platform';
+import { type PlatformError } from '@effect/platform/Error';
+import { NodeContext } from '@effect/platform-node';
+import { describe, it } from '@effect/vitest';
+import { ContractRuntimeError } from '@midnight-ntwrk/compact-js/effect';
+import * as CompiledContract from '@midnight-ntwrk/compact-js/effect/CompiledContract';
+import { CompiledContractReflection } from '@midnight-ntwrk/compact-js-command/effect';
+import { Effect, Layer, String } from 'effect';
+
+import { ensureRemovePath } from './cleanup.js';
+
+const BASE_PATH = join(import.meta.dirname);
+const DECLARATION_FILEPATH = join(BASE_PATH, 'contract', 'index.d.cts');
+const testLayer: Layer.Layer<
+  CompiledContractReflection.CompiledContractReflection
+  | NodeContext.NodeContext,
+  PlatformError
+> = CompiledContractReflection.layer(BASE_PATH).pipe(Layer.provideMerge(NodeContext.layer));
+
+/**
+ * Sets up a dummy contract and context for an `ArgumentParser` test fixture.
+ * 
+ * @param argText A string defining on or more JS/TS arguments (in the form `'argName: argType'`).
+ * @param fn A function receiving an `ArgumentParser` that should return an array  from arguments
+ * called with it.
+ * @returns An `Effect` that yields the parsed arguments defined by `argText`, or fails with a `ContractRuntimeError`
+ * if the invocation failed.
+ */
+const parseArgumentsTest = (
+  argText: string,
+  fn: (argsParser: CompiledContractReflection.CompiledContractReflection.AnyArgumentParser)
+    => Effect.Effect<any[], ContractRuntimeError.ContractRuntimeError> // eslint-disable-line @typescript-eslint/no-explicit-any
+) => Effect.gen(function* () {
+      const NullContract = (() => ({} as any)) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+      const fs = yield* FileSystem.FileSystem;
+
+      yield* fs.makeDirectory(join(BASE_PATH, 'contract'));
+      yield* fs.writeFileString(DECLARATION_FILEPATH, String.stripMargin(`
+        |export type ImpureCircuits<T> = {
+        | circuit(_: any, ${argText}): void;
+        |}
+        |
+        |export declare class Contract<T, W> {
+        | initialState(_: any, ${argText}): void;
+        |}
+      `));
+
+      const contractReflection = yield* CompiledContractReflection.CompiledContractReflection;
+      const argsParser = yield* contractReflection.createArgumentParser(
+        CompiledContract.make('NullContract', NullContract).pipe(
+          CompiledContract.withWitnesses({} as never),
+          CompiledContract.withCompiledFileAssets(BASE_PATH)
+        )
+      );
+      return yield* fn(argsParser);
+  }).pipe(
+    Effect.ensuring(ensureRemovePath(join(BASE_PATH, 'contract')))
+  );
+
+describe.sequential('CompiledContractReflection', () => {
+  it.each([
+    ['bigint', 'abc'],
+    ['boolean', 'maybe']
+  ])('should fail to parse with an invalid argument (%s)', async (type, invalidValue) => {
+    await Effect.runPromise(Effect.gen(function* () {
+      expect(yield* parseArgumentsTest(
+          `a: ${type}`,
+          (_) => _.parseInitializationArgs([invalidValue])
+        ).pipe(Effect.flip)
+      ).toBeInstanceOf(ContractRuntimeError.ContractRuntimeError);
+    }).pipe(Effect.provide(testLayer)));
+  });
+
+  it.each([
+    ['bigint', '100'],
+    ['boolean', 'true'],
+    ['boolean', 'false'],
+    ['string', 'hosky']
+  ])('should parse with a valid argument (%s)', async (type, validString) => {
+    await Effect.runPromise(Effect.gen(function* () {
+      expect(yield* parseArgumentsTest(
+          `a: ${type}`,
+          (_) => _.parseInitializationArgs([validString])
+        )
+      ).toHaveLength(1);
+    }).pipe(Effect.provide(testLayer)));
+  });
+
+  it('should parse multiple arguments', async () => {
+    await Effect.runPromise(Effect.gen(function* () {
+      expect(yield* parseArgumentsTest(
+        'a: bigint, b: string, c: boolean',
+        (_) => _.parseInitializationArgs(['100', 'hosky', 'true'])
+      )).toStrictEqual([100n, 'hosky', true]);
+    }).pipe(Effect.provide(testLayer)));
+  });
+
+  it('should fail when parsing an invalid tuple element', async () => {
+    await Effect.runPromise(Effect.gen(function* () {
+        expect(yield* parseArgumentsTest(
+          'a: [bigint, boolean]',
+          (_) => _.parseInitializationArgs(['[100, maybe]'])
+        ).pipe(Effect.flip)
+      ).toBeInstanceOf(ContractRuntimeError.ContractRuntimeError)
+    }).pipe(Effect.provide(testLayer)));
+  });
+
+  it('should parse multiple valid tuple type elements', async () => {
+    await Effect.runPromise(Effect.gen(function* () {
+      expect(yield* parseArgumentsTest(
+        'a: [bigint, string, boolean]',
+        (_) => _.parseInitializationArgs(["[100, 'hosky', true]"])
+      )).toStrictEqual([[100n, 'hosky', true]]);
+    }).pipe(Effect.provide(testLayer)));
+  });
+});

--- a/compact-js/compact-js-command/test/effect/CompiledContractReflection.test.ts
+++ b/compact-js/compact-js-command/test/effect/CompiledContractReflection.test.ts
@@ -133,6 +133,16 @@ describe.sequential('CompiledContractReflection', () => {
       }).pipe(Effect.provide(testLayer)));
     });
 
+    it('should parse nested tuple type elements', async () => {
+      await Effect.runPromise(Effect.gen(function* () {
+        expect(yield* parseArgumentsTest(
+          'a: [bigint, [string, boolean], boolean]',
+          (_) => _.parseInitializationArgs(["[100, ['hosky', false], true]"])
+        )).toStrictEqual([[100n, ['hosky', false], true]]);
+      }).pipe(Effect.provide(testLayer)));
+    });
+
+
     it('should parse object literal type elements', async () => {
       await Effect.runPromise(Effect.gen(function* () {
         const parsedArgs = yield* parseArgumentsTest(
@@ -149,7 +159,7 @@ describe.sequential('CompiledContractReflection', () => {
         expect(yield* parseArgumentsTest(
           'a: { x: [bigint, string]; y: string; }',
           (_) => _.parseInitializationArgs(["{ x: [100, 'doggo'], y: 'hosky' }"])
-        )).toStrictEqual({ x: [100n, 'doggo'], y: 'hosky' });
+        )).toStrictEqual([{ x: [100n, 'doggo'], y: 'hosky' }]);
       }).pipe(Effect.provide(testLayer)));
     });
 

--- a/compact-js/compact-js-command/test/effect/CompiledContractReflection.test.ts
+++ b/compact-js/compact-js-command/test/effect/CompiledContractReflection.test.ts
@@ -90,6 +90,7 @@ describe.sequential('CompiledContractReflection', () => {
     });
 
     it.each([
+      ['number', '3'],
       ['bigint', '100'],
       ['boolean', 'true'],
       ['boolean', 'false'],

--- a/compact-js/compact-js-command/test/effect/cleanup.ts
+++ b/compact-js/compact-js-command/test/effect/cleanup.ts
@@ -24,7 +24,7 @@ import { Effect } from 'effect';
  */
 export const ensureRemovePath = (path: string) =>
   FileSystem.FileSystem.pipe(
-    Effect.flatMap((fs) => fs.remove(path, { force: true }).pipe(
+    Effect.flatMap((fs) => fs.remove(path, { force: true, recursive: true }).pipe(
       Effect.catchAll((_) => Effect.void)
     ))
   );

--- a/compact-js/compact-js-node/src/effect/ZKFileConfiguration.ts
+++ b/compact-js/compact-js-node/src/effect/ZKFileConfiguration.ts
@@ -34,7 +34,7 @@ const makeFileSystemReader =
   (compiledContract: CompiledContract.CompiledContract<C, PS>) =>
     // eslint-disable-next-line require-yield
     Effect.gen(function* () {
-      const zkConfigAssetsPath = CompiledContract.getZkConfigAssetsPath(compiledContract);
+      const zkConfigAssetsPath = CompiledContract.getCompiledAssetsPath(compiledContract);
       const getVerifierKey = (impureCircuitId: Contract.ImpureCircuitId<C>) =>
         Effect.gen(function* () {
           const data = yield* fs.readFile(

--- a/compact-js/compact-js-node/src/effect/ZKFileConfiguration.ts
+++ b/compact-js/compact-js-node/src/effect/ZKFileConfiguration.ts
@@ -30,15 +30,15 @@ const VERIFIER_EXT = '.verifier';
  * @internal
  */
 const makeFileSystemReader =
-  <C extends Contract.Contract<PS>, PS>(path: Path.Path, fs: FileSystem.FileSystem, baseFolderPath: string) =>
+  <C extends Contract.Contract<PS>, PS>(path: Path.Path, fs: FileSystem.FileSystem, baseAssetFolderPath: string) =>
   (compiledContract: CompiledContract.CompiledContract<C, PS>) =>
     // eslint-disable-next-line require-yield
     Effect.gen(function* () {
-      const zkConfigAssetsPath = CompiledContract.getCompiledAssetsPath(compiledContract);
+      const assetsPath = CompiledContract.getCompiledAssetsPath(compiledContract);
       const getVerifierKey = (impureCircuitId: Contract.ImpureCircuitId<C>) =>
         Effect.gen(function* () {
           const data = yield* fs.readFile(
-            path.join(path.resolve(baseFolderPath, zkConfigAssetsPath), KEYS_FOLDER, `${impureCircuitId}${VERIFIER_EXT}`)
+            path.join(path.resolve(baseAssetFolderPath, assetsPath), KEYS_FOLDER, `${impureCircuitId}${VERIFIER_EXT}`)
           );
           return Contract.VerifierKey(data);
         }).pipe(
@@ -65,18 +65,18 @@ const makeFileSystemReader =
  * A {@link ZKConfiguration.ZKConfiguration | ZKConfiguration} implementation that reads ZK assets from the
  * file system.
  *
- * @param baseFolderPath A base path to a folder containing the ZK assets.
+ * @param baseAssetFolderPath A base path to a folder containing the compiled contract assets.
  *
  * @category layers
  */
-export const layer = (baseFolderPath = '.') => Layer.effect(
+export const layer = (baseAssetFolderPath = '.') => Layer.effect(
   ZKConfiguration.ZKConfiguration,
   Effect.gen(function* () {
     const path = yield* Path.Path;
     const fs = yield* FileSystem.FileSystem;
 
     return ZKConfiguration.ZKConfiguration.of({
-      createReader: makeFileSystemReader(path, fs, baseFolderPath)
+      createReader: makeFileSystemReader(path, fs, baseAssetFolderPath)
     });
   })
 );

--- a/compact-js/compact-js/src/effect/CompactContext.ts
+++ b/compact-js/compact-js/src/effect/CompactContext.ts
@@ -26,11 +26,11 @@ export type Witnesses<in C extends Contract.Any, W = Contract.Witnesses<C>> = {
 };
 
 /**
- * ZK asset path configuration.
+ * Compiled asset path configuration.
  */
-export type ZKConfigAssetsPath = {
+export type CompiledAssetsPath = {
   /**
-   * A path to the compiled ZK assets produced by the Compact compiler.
+   * A path to the compiled assets produced by the Compact compiler.
    */
-  readonly zkConfigAssetsPath: string;
+  readonly compiledAssetsPath: string;
 };

--- a/compact-js/compact-js/src/effect/CompiledContract.ts
+++ b/compact-js/compact-js/src/effect/CompiledContract.ts
@@ -177,10 +177,10 @@ export const withCompiledFileAssets: {
 );
 
 /**
- * Retrieves a path to the ZK assets associated with a compiled contract.
+ * Retrieves a path to file based assets associated with a compiled contract.
  *
  * @param self The {@link CompiledContract} from which the assets path should be retrieved.
- * @returns A string representing a path to the ZK assets configured for `self`.
+ * @returns A string representing a path to the file assets configured for `self`.
  */
 export const getCompiledAssetsPath: <C extends Contract<PS>, PS>(self: CompiledContract<C, PS>) => string =
   <C extends Contract<PS>, PS>(self: CompiledContract<C, PS>) => {

--- a/compact-js/compact-js/src/effect/CompiledContract.ts
+++ b/compact-js/compact-js/src/effect/CompiledContract.ts
@@ -62,7 +62,7 @@ export declare namespace CompiledContract {
    * information to where the generated ZK assets can be found, along with an implementation of the witnesses
    * expected by the contract.
    */
-  export type Context<C extends Contract.Any> = CompactContext.Witnesses<C> | CompactContext.ZKConfigAssetsPath;
+  export type Context<C extends Contract.Any> = CompactContext.Witnesses<C> | CompactContext.CompiledAssetsPath;
 }
 
 const CompiledContractProto = {
@@ -136,37 +136,41 @@ export const withWitnesses: {
 );
 
 /**
- * Associates a file path where the ZK assets can be found for the Compact compiled contract.
+ * Associates a file path of where to find the compiled assets for the Compact compiled contract.
+ * 
+ * @remarks
+ * Relative file paths will be resolved relative to the base paths provided to each service that accesses
+ * the compiled file assets. 
  *
  * @category combinators
  */
-export const withZKConfigFileAssets: {
+export const withCompiledFileAssets: {
   /**
-   * @param zkConfigAssetsPath The file path.
-   * @returns A function that receives the {@link CompiledContract} that `zkConfigAssetsPath` will be attached to.
+   * @param compiledAssetsPath The file path.
+   * @returns A function that receives the {@link CompiledContract} that `compiledAssetsPath` will be attached to.
    */
   <C extends Contract<PS>, PS, R>(
-    zkConfigAssetsPath: R extends CompactContext.ZKConfigAssetsPath ? string : never
-  ): (self: CompiledContract<C, PS, R>) => CompiledContract<C, PS, Exclude<R, CompactContext.ZKConfigAssetsPath>>;
+    compiledAssetsPath: R extends CompactContext.CompiledAssetsPath ? string : never
+  ): (self: CompiledContract<C, PS, R>) => CompiledContract<C, PS, Exclude<R, CompactContext.CompiledAssetsPath>>;
   /**
-   * @param self The {@link CompiledContract} that `zkConfigAssetsPath` will be attached to.
-   * @param zkConfigAssetsPath The file path.
+   * @param self The {@link CompiledContract} that `compiledAssetsPath` will be attached to.
+   * @param compiledAssetsPath The file path.
    */
   <C extends Contract<PS>, PS, R>(
     self: CompiledContract<C, PS, R>,
-    zkConfigAssetsPath: R extends CompactContext.ZKConfigAssetsPath ? string : never
-  ): CompiledContract<C, PS, Exclude<R, CompactContext.ZKConfigAssetsPath>>;
+    compiledAssetsPath: R extends CompactContext.CompiledAssetsPath ? string : never
+  ): CompiledContract<C, PS, Exclude<R, CompactContext.CompiledAssetsPath>>;
 } = dual(
   2,
   <C extends Contract<PS>, PS, R>(
     self: CompiledContract<C, PS, R>,
-    zkConfigAssetsPath: R extends CompactContext.ZKConfigAssetsPath ? string : never
+    compiledAssetsPath: R extends CompactContext.CompiledAssetsPath ? string : never
   ) => {
     return {
       ...self,
       [CompactContextInternal.TypeId]: {
         ...self[CompactContextInternal.TypeId],
-        zkConfigAssetsPath
+        compiledAssetsPath
       }
     };
   }
@@ -178,8 +182,8 @@ export const withZKConfigFileAssets: {
  * @param self The {@link CompiledContract} from which the assets path should be retrieved.
  * @returns A string representing a path to the ZK assets configured for `self`.
  */
-export const getZkConfigAssetsPath: <C extends Contract<PS>, PS>(self: CompiledContract<C, PS>) => string =
+export const getCompiledAssetsPath: <C extends Contract<PS>, PS>(self: CompiledContract<C, PS>) => string =
   <C extends Contract<PS>, PS>(self: CompiledContract<C, PS>) => {
     const context = CompactContextInternal.getContractContext(self);
-    return context.zkConfigAssetsPath;
+    return context.compiledAssetsPath;
   };

--- a/compact-js/compact-js/src/effect/ZKConfiguration.ts
+++ b/compact-js/compact-js/src/effect/ZKConfiguration.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Context,type Effect } from 'effect';
+import { Context, type Effect } from 'effect';
 
 import type { CompiledContract } from './CompiledContract.js';
 import type * as Contract from './Contract.js';

--- a/compact-js/compact-js/src/effect/internal/compactContext.ts
+++ b/compact-js/compact-js/src/effect/internal/compactContext.ts
@@ -26,7 +26,7 @@ export type TypeId = typeof TypeId;
 
 /** @internal */
 export interface Context<C extends Contract.Any>
-  extends CompactContext.Witnesses<C>, CompactContext.ZKConfigAssetsPath {
+  extends CompactContext.Witnesses<C>, CompactContext.CompiledAssetsPath {
     readonly ctor: Types.Ctor<C>;
   }
 

--- a/compact-js/compact-js/test/contract/counter.compact
+++ b/compact-js/compact-js/test/contract/counter.compact
@@ -9,7 +9,7 @@ export circuit increment(): [] {
   private_increment();
 }
 
-export circuit decrement(amount: Uint<16>, other: [Uint<16>, Opaque<"string">]): [] {
+export circuit decrement(amount: Uint<16>): [] {
   round.decrement(disclose(amount));
   private_increment();
 }

--- a/compact-js/compact-js/test/contract/counter.compact
+++ b/compact-js/compact-js/test/contract/counter.compact
@@ -9,7 +9,7 @@ export circuit increment(): [] {
   private_increment();
 }
 
-export circuit decrement(amount: Uint<16>): [] {
+export circuit decrement(amount: Uint<16>, other: [Uint<16>, Opaque<"string">]): [] {
   round.decrement(disclose(amount));
   private_increment();
 }

--- a/compact-js/compact-js/test/effect/ContractExecutable.test.ts
+++ b/compact-js/compact-js/test/effect/ContractExecutable.test.ts
@@ -60,7 +60,7 @@ describe('ContractExecutable', () => {
     CompiledContract.withWitnesses({
       private_increment: ({ privateState }) => [{ count: privateState.count + 1 }, []]
     }),
-    CompiledContract.withZKConfigFileAssets(COUNTER_ASSETS_PATH),
+    CompiledContract.withCompiledFileAssets(COUNTER_ASSETS_PATH),
     ContractExecutable.make
   );
 

--- a/compact-js/compact-js/test/effect/ContractExecutableRuntime.test.ts
+++ b/compact-js/compact-js/test/effect/ContractExecutableRuntime.test.ts
@@ -46,7 +46,7 @@ describe('ContractExecutableRuntime', () => {
     CompiledContract.withWitnesses({
       private_increment: ({ privateState }) => [{ count: privateState.count + 1 }, []]
     }),
-    CompiledContract.withZKConfigFileAssets(COUNTER_ASSETS_PATH),
+    CompiledContract.withCompiledFileAssets(COUNTER_ASSETS_PATH),
     ContractExecutable.make
   );
 

--- a/compact-js/compact-js/test/typetests/effect/CompiledContract.tst.ts
+++ b/compact-js/compact-js/test/typetests/effect/CompiledContract.tst.ts
@@ -35,7 +35,7 @@ describe('CompiledContract', () => {
 
     it('should require ZK path configuration', () => {
       expect(compiledContract).type.toBeAssignableWith<
-        CompiledContract.CompiledContract<MockCounterContract, any, CompactContext.ZKConfigAssetsPath>
+        CompiledContract.CompiledContract<MockCounterContract, any, CompactContext.CompiledAssetsPath>
       >();
     });
 
@@ -52,11 +52,11 @@ describe('CompiledContract', () => {
     });
 
     describe('with resolved ZK path configuration', () => {
-      const contract = compiledContract.pipe(CompiledContract.withZKConfigFileAssets('~/contracts'));
+      const contract = compiledContract.pipe(CompiledContract.withCompiledFileAssets('~/contracts'));
 
       it('should not require further witnesses', () => {
         expect(contract).type.not.toBeAssignableWith<
-          CompiledContract.CompiledContract<MockCounterContract, any, CompactContext.ZKConfigAssetsPath>
+          CompiledContract.CompiledContract<MockCounterContract, any, CompactContext.CompiledAssetsPath>
         >();
       });
     });
@@ -64,7 +64,7 @@ describe('CompiledContract', () => {
     describe('as fully resolved', () => {
       const contract = compiledContract.pipe(
         CompiledContract.withWitnesses({} as Contract.Contract.Witnesses<MockCounterContract>),
-        CompiledContract.withZKConfigFileAssets('/Users/hosky/compact_contracts/counter')
+        CompiledContract.withCompiledFileAssets('/Users/hosky/compact_contracts/counter')
       );
 
       it('should require no further context', () => {

--- a/compact-js/compact-js/test/typetests/effect/ContractExecutable.tst.ts
+++ b/compact-js/compact-js/test/typetests/effect/ContractExecutable.tst.ts
@@ -37,7 +37,7 @@ class StringDep extends Context.Tag('StringDep')<StringDep, string>() {}
 describe('ContractExecutable', () => {
   const compiledContract = CompiledContract.make<MockCounterContract>('MockCounter', MockCounterContract).pipe(
     CompiledContract.withWitnesses({} as Contract.Contract.Witnesses<MockCounterContract>),
-    CompiledContract.withZKConfigFileAssets('/Users/hosky/compact_contracts/counter')
+    CompiledContract.withCompiledFileAssets('/Users/hosky/compact_contracts/counter')
   );
   const contractExecutable = ContractExecutable.make(compiledContract);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2185,6 +2185,7 @@ __metadata:
     "@midnight-ntwrk/midnight-js-compact": "workspace:*"
     "@midnight-ntwrk/platform-js": "npm:^1.0.0"
     effect: "npm:^3.17.7"
+    json5: "npm:^2.2.3"
     ts-node: "npm:^10.9.2"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This PR adds support for typed arguments for both contract initialization, and circuit invocation. Prior to the PR, arguments were simply passed "_as is_" into the Compact runtime when executing a Compact contract. Consequently, this would only work if the expected type was a string. 

It introduces a new `CompiledContractReflection` service that uses an underlying TypeScript language service host to load the Compact generated TypeScript declaration file. It then queries the language service for the `'initialState'` method on the `'Contract'` class, along with the methods defined on the `'ImpureCircuits'` type. The parameter types of these methods are then used to transform the given array of strings (i.e., those received off of the command line), into a strongly typed array of values required at runtime.

The following TypeScript primitives (as documented in the [Compactc Language Reference](https://github.com/midnightntwrk/compactc/blob/main/doc/lang-ref.mdx)), are supported:

- **Intrinsic Types**
  - [X] string
  - [X] boolean
  - [X] bigint

- **Tuples**
  - [X] multiple values
  - [x] support nested tuples

- **Compact structs & Binary**
  - [x] literal objects
  - [x] support nested literal objects
  - [x] `Uint8Array`
  - [x] enums (supplied as `number`s)