### PR TITLE
bug(compact-js): Allow support for Zswap local state

### DIFF
--- a/compact-js/compact-js-command/src/effect/internal/encodedZswapLocalStateSchema.ts
+++ b/compact-js/compact-js-command/src/effect/internal/encodedZswapLocalStateSchema.ts
@@ -1,0 +1,53 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Schema from 'effect/Schema';
+
+export const EncodedCoinPublicKeySchema = Schema.Struct({
+  bytes: Schema.Uint8Array
+});
+
+export const EncodedContractAddressSchema = Schema.Struct({
+  bytes: Schema.Uint8Array
+});
+
+export const EncodedQualifiedShieldedCoinInfoSchema = Schema.Struct({
+  nonce: Schema.Uint8Array,
+  color: Schema.Uint8Array,
+  value: Schema.BigInt,
+  mt_index: Schema.BigInt
+});
+
+export const EncodedShieldedCoinInfoSchema = Schema.Struct({
+  nonce: Schema.Uint8Array,
+  color: Schema.Uint8Array,
+  value: Schema.BigInt
+});
+
+export const EncodedRecipientSchema = Schema.Struct({
+  is_left: Schema.Boolean,
+  left: EncodedCoinPublicKeySchema,
+  right: EncodedContractAddressSchema
+});
+
+export const EncodedZswapLocalStateSchema = Schema.Struct({
+  coinPublicKey: EncodedCoinPublicKeySchema,
+  currentIndex: Schema.BigInt,
+  inputs: Schema.Array(EncodedQualifiedShieldedCoinInfoSchema),
+  outputs: Schema.Array(Schema.Struct({
+    coinInfo: EncodedShieldedCoinInfoSchema,
+    recipient: EncodedRecipientSchema
+  }))
+});

--- a/compact-js/compact-js-command/src/effect/internal/options.ts
+++ b/compact-js/compact-js-command/src/effect/internal/options.ts
@@ -58,6 +58,12 @@ export const outputPrivateStateFilePath = Options.file('output-ps').pipe(
 );
 
 /** @internal */
+export const outputZswapLocalStateFilePath = Options.file('output-zswap').pipe(
+  Options.withDescription('A file path of where the generated \'ZswapLocalState\' data should be written.'),
+  Options.withDefault('zswap.json')
+);
+
+/** @internal */
 export const network = Options.text('network').pipe(
   Options.withAlias('n'),
   Options.withDescription('Optional network identifier. Defaults to the Midnight \'MainNet\' if not specified.'),
@@ -72,6 +78,12 @@ export const stateFilePath = Options.file('state-file-path').pipe(
 /** @internal */
 export const privateStateFilePath = Options.file('ps-state-file-path').pipe(
   Options.withDescription('A file path of where the current private state data can be read.')
+);
+
+/** @internal */
+export const zswapLocalStateFilePath = Options.file('zswap-state-file-path').pipe(
+  Options.withDescription('A file path of where the current Zswap local state data can be read.'),
+  Options.optional
 );
 
 export type ConfigOptionInput = Command.Command.ParseConfig<{

--- a/compact-js/compact-js-command/test/effect/Circuit.test.ts
+++ b/compact-js/compact-js-command/test/effect/Circuit.test.ts
@@ -29,6 +29,7 @@ const COUNTER_CONFIG_FILEPATH = resolve(import.meta.dirname, '../contract/counte
 const COUNTER_STATE_FILEPATH = resolve(import.meta.dirname, '../contract/counter/state.bin');
 const COUNTER_OUTPUT_FILEPATH = resolve(import.meta.dirname, '../contract/counter/output_circuit.bin');
 const COUNTER_OUTPUT_PS_FILEPATH = resolve(import.meta.dirname, '../contract/counter/output_circuit.json');
+const COUNTER_OUTPUT_ZSWAP_FILEPATH = resolve(import.meta.dirname, '../contract/counter/output_zswap.json');
 
 const testLayer: Layer.Layer<ConfigCompiler.ConfigCompiler | NodeContext.NodeContext | FileSystem.FileSystem> =
   Effect.gen(function* () {
@@ -55,6 +56,7 @@ describe('Circuit Command', () => {
         '-c', COUNTER_CONFIG_FILEPATH,
         '--output', COUNTER_OUTPUT_FILEPATH,
         '--output-ps', COUNTER_OUTPUT_PS_FILEPATH,
+        '--output-zswap', COUNTER_OUTPUT_ZSWAP_FILEPATH,
         '--state-file-path', COUNTER_STATE_FILEPATH,
         '--ps-state-file-path', COUNTER_OUTPUT_PS_FILEPATH,
         '0a2d0e34db258f640dc2ec410fb0e4eea9cd6f9661ba6a86f0c35a708e1b811a', 'increment'
@@ -68,6 +70,7 @@ describe('Circuit Command', () => {
       Effect.ensuring(ensureRemovePath(COUNTER_CONFIG_FILEPATH.replace('.ts', '.js'))),
       Effect.ensuring(ensureRemovePath(COUNTER_OUTPUT_FILEPATH)),
       Effect.ensuring(ensureRemovePath(COUNTER_OUTPUT_PS_FILEPATH)),
+      Effect.ensuring(ensureRemovePath(COUNTER_OUTPUT_ZSWAP_FILEPATH)),
       Effect.provide(testLayer)
     ),
     30_000

--- a/compact-js/compact-js-command/test/effect/Deploy.test.ts
+++ b/compact-js/compact-js-command/test/effect/Deploy.test.ts
@@ -28,6 +28,7 @@ import * as MockConsole from './MockConsole.js';
 const COUNTER_CONFIG_FILEPATH = resolve(import.meta.dirname, '../contract/counter/contract.config.ts');
 const COUNTER_OUTPUT_FILEPATH = resolve(import.meta.dirname, '../contract/counter/output_deploy.bin');
 const COUNTER_OUTPUT_PS_FILEPATH = resolve(import.meta.dirname, '../contract/counter/output_deploy.json');
+const COUNTER_OUTPUT_ZSWAP_FILEPATH = resolve(import.meta.dirname, '../contract/counter/output_zswap.json');
 
 const testLayer: Layer.Layer<ConfigCompiler.ConfigCompiler | NodeContext.NodeContext> =
   Effect.gen(function* () {
@@ -47,7 +48,8 @@ describe('Deploy Command', () => {
         'node', 'deploy.ts',
         '-c', COUNTER_CONFIG_FILEPATH,
         '--output', COUNTER_OUTPUT_FILEPATH,
-        '--output-ps', COUNTER_OUTPUT_PS_FILEPATH
+        '--output-ps', COUNTER_OUTPUT_PS_FILEPATH,
+        '--output-zswap', COUNTER_OUTPUT_ZSWAP_FILEPATH
       ]);
 
       const lines = yield* MockConsole.getLines({ stripAnsi: true });
@@ -57,6 +59,7 @@ describe('Deploy Command', () => {
       Effect.ensuring(ensureRemovePath(COUNTER_CONFIG_FILEPATH.replace('.ts', '.js'))),
       Effect.ensuring(ensureRemovePath(COUNTER_OUTPUT_FILEPATH)),
       Effect.ensuring(ensureRemovePath(COUNTER_OUTPUT_PS_FILEPATH)),
+      Effect.ensuring(ensureRemovePath(COUNTER_OUTPUT_ZSWAP_FILEPATH)),
       Effect.provide(testLayer)
     ),
     30_000

--- a/compact-js/compact-js/src/effect/ContractExecutable.ts
+++ b/compact-js/compact-js/src/effect/ContractExecutable.ts
@@ -23,6 +23,7 @@ import {
   createConstructorContext,
   decodeZswapLocalState,
   emptyZswapLocalState,
+  encodeZswapLocalState,
   type Op,
   QueryContext,
   sampleSigningKey,
@@ -102,6 +103,8 @@ export declare namespace ContractExecutable {
     readonly contractState: ContractState;
 
     readonly privateState: PS;
+
+    readonly zswapLocalState?: ZswapLocalState;
   };
 
   export type DeployResultPublic = {
@@ -314,7 +317,9 @@ class ContractExecutableImpl<C extends Contract.Contract<PS>, PS, E, R> implemen
               ...circuit(
                 {
                   currentPrivateState: circuitContext.privateState,
-                  currentZswapLocalState: emptyZswapLocalState(CoinPublicKey.asHex(keyConfig.coinPublicKey)),
+                  currentZswapLocalState: circuitContext.zswapLocalState
+                    ? encodeZswapLocalState(circuitContext.zswapLocalState)
+                    : emptyZswapLocalState(CoinPublicKey.asHex(keyConfig.coinPublicKey)),
                   transactionContext: initialTxContext,
                   costModel: CostModel.initialCostModel()
                 },


### PR DESCRIPTION
This PR modifies the `deploy` and `circuit` commands so that they accept as input, and generate as output, the Zswap local state that can be modified during contract execution. This is required in order to correctly report the usage of coins during circuit execution for example.