### PR TITLE
chore(compact-js/platform-js): Set package version numbers to correct value

### DIFF
--- a/compact-js/compact-js-command/package.json
+++ b/compact-js/compact-js-command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/compact-js-command",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "description": "Command line utilities for working with smart contracts compiled with the Compact language",
   "type": "module",
   "exports": {
@@ -21,11 +21,11 @@
     "@effect/rpc": "^0.68.4",
     "@effect/sql": "^0.44.1",
     "@effect/typeclass": "^0.36.0",
-    "@midnight-ntwrk/compact-js": "^0.0.0",
-    "@midnight-ntwrk/compact-js-node": "^0.0.0",
+    "@midnight-ntwrk/compact-js": "^2.0.0",
+    "@midnight-ntwrk/compact-js-node": "^2.0.0",
     "@midnight-ntwrk/compact-runtime": "0.9.0-rc.2",
     "@midnight-ntwrk/ledger": "npm:@midnight-ntwrk/ledger-v6@6.1.0-alpha.2",
-    "@midnight-ntwrk/platform-js": "^1.0.0",
+    "@midnight-ntwrk/platform-js": "^2.0.0",
     "effect": "^3.17.7",
     "json5": "^2.2.3",
     "ts-node": "^10.9.2"

--- a/compact-js/compact-js-node/package.json
+++ b/compact-js/compact-js-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/compact-js-node",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "description": "Platform specific types and utilities for working with the Compact language on a Node.js runtime",
   "type": "module",
   "exports": {
@@ -16,7 +16,7 @@
     "effect": "^3.17.7"
   },
   "peerDependencies": {
-    "@midnight-ntwrk/compact-js": ">=0.0.0"
+    "@midnight-ntwrk/compact-js": ">=2.0.0"
   },
   "repository": {
     "type": "git",

--- a/compact-js/compact-js/package.json
+++ b/compact-js/compact-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/compact-js",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "description": "Typescript-based execution environment for smart contracts compiled with the Compact language",
   "type": "module",
   "exports": {
@@ -14,7 +14,7 @@
     "@effect/platform": "^0.90.2",
     "@midnight-ntwrk/compact-runtime": "0.9.0-rc.2",
     "@midnight-ntwrk/ledger": "npm:@midnight-ntwrk/ledger-v6@6.1.0-alpha.2",
-    "@midnight-ntwrk/platform-js": "^1.0.0",
+    "@midnight-ntwrk/platform-js": "^2.0.0",
     "effect": "^3.17.7"
   },
   "devDependencies": {

--- a/platform-js/platform-js/package.json
+++ b/platform-js/platform-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/platform-js",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Provides a set of core abstractions, utilities, and types for building services and libraries that work with the Midnight blockchain",
   "type": "module",
   "exports": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2178,19 +2178,19 @@ __metadata:
     "@effect/sql": "npm:^0.44.1"
     "@effect/typeclass": "npm:^0.36.0"
     "@effect/vitest": "npm:^0.24.1"
-    "@midnight-ntwrk/compact-js": "npm:^0.0.0"
-    "@midnight-ntwrk/compact-js-node": "npm:^0.0.0"
+    "@midnight-ntwrk/compact-js": "npm:^2.0.0"
+    "@midnight-ntwrk/compact-js-node": "npm:^2.0.0"
     "@midnight-ntwrk/compact-runtime": "npm:0.9.0-rc.2"
     "@midnight-ntwrk/ledger": "npm:@midnight-ntwrk/ledger-v6@6.1.0-alpha.2"
     "@midnight-ntwrk/midnight-js-compact": "workspace:*"
-    "@midnight-ntwrk/platform-js": "npm:^1.0.0"
+    "@midnight-ntwrk/platform-js": "npm:^2.0.0"
     effect: "npm:^3.17.7"
     json5: "npm:^2.2.3"
     ts-node: "npm:^10.9.2"
   languageName: unknown
   linkType: soft
 
-"@midnight-ntwrk/compact-js-node@npm:^0.0.0, @midnight-ntwrk/compact-js-node@workspace:*, @midnight-ntwrk/compact-js-node@workspace:compact-js/compact-js-node":
+"@midnight-ntwrk/compact-js-node@npm:^2.0.0, @midnight-ntwrk/compact-js-node@workspace:*, @midnight-ntwrk/compact-js-node@workspace:compact-js/compact-js-node":
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/compact-js-node@workspace:compact-js/compact-js-node"
   dependencies:
@@ -2198,11 +2198,11 @@ __metadata:
     "@effect/platform-node": "npm:^0.95.0"
     effect: "npm:^3.17.7"
   peerDependencies:
-    "@midnight-ntwrk/compact-js": ">=0.0.0"
+    "@midnight-ntwrk/compact-js": ">=2.0.0"
   languageName: unknown
   linkType: soft
 
-"@midnight-ntwrk/compact-js@npm:^0.0.0, @midnight-ntwrk/compact-js@workspace:compact-js/compact-js":
+"@midnight-ntwrk/compact-js@npm:^2.0.0, @midnight-ntwrk/compact-js@workspace:compact-js/compact-js":
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/compact-js@workspace:compact-js/compact-js"
   dependencies:
@@ -2218,7 +2218,7 @@ __metadata:
     "@midnight-ntwrk/compact-runtime": "npm:0.9.0-rc.2"
     "@midnight-ntwrk/ledger": "npm:@midnight-ntwrk/ledger-v6@6.1.0-alpha.2"
     "@midnight-ntwrk/midnight-js-compact": "workspace:*"
-    "@midnight-ntwrk/platform-js": "npm:^1.0.0"
+    "@midnight-ntwrk/platform-js": "npm:^2.0.0"
     effect: "npm:^3.17.7"
   languageName: unknown
   linkType: soft
@@ -2454,7 +2454,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/platform-js@npm:^1.0.0, @midnight-ntwrk/platform-js@workspace:platform-js/platform-js":
+"@midnight-ntwrk/platform-js@npm:^2.0.0, @midnight-ntwrk/platform-js@workspace:platform-js/platform-js":
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/platform-js@workspace:platform-js/platform-js"
   dependencies:


### PR DESCRIPTION
Small chore PR that sets the package version numbers in Platform.js and Compact.js to what they should be based on the currently made releases.