### PR TITLE
chore(deps): remove outdated @opentelemetry/semantic-conventions

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3000,13 +3000,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/semantic-conventions@npm:^1.33.0":
-  version: 1.36.0
-  resolution: "@opentelemetry/semantic-conventions@npm:1.36.0"
-  checksum: 10/f1939066c30147348b326840d67cc48e73072b762f2e2af5c3ea894268d64c62fc4e73fad49a72ed4a52a543b2fa0824c969a676e658ae727f75182f52104007
-  languageName: node
-  linkType: hard
-
 "@parcel/watcher-android-arm64@npm:2.5.1":
   version: 2.5.1
   resolution: "@parcel/watcher-android-arm64@npm:2.5.1"


### PR DESCRIPTION
chore(deps): remove outdated @opentelemetry/semantic-conventions entry from yarn.lock