### PR TITLE
refactor(compact-js): Ensure Schema based options/args report their names with errors

### DIFF
--- a/compact-js/compact-js-command/src/effect/internal/args.ts
+++ b/compact-js/compact-js-command/src/effect/internal/args.ts
@@ -25,12 +25,12 @@ export const contractArgs = Args.text({ name: 'arg' }).pipe(
 
 export const contractAddress = Args.text({ name: 'contract_address' }).pipe(
   Args.withDescription('A contract address, hex-encoded.'),
-  Args.withSchema(Schema.String.pipe(Schema.fromBrand(ContractAddress.ContractAddress)))
+  Args.withSchema(Schema.String.pipe(Schema.fromBrand(ContractAddress.ContractAddress)).annotations({ title: 'contract_address' }))
 );
 
 export const signingKey = Args.text({ name: 'signing_key' }).pipe(
   Args.withDescription('A signing key, hex-encoded.'),
-  Args.withSchema(Schema.String.pipe(Schema.fromBrand(SigningKey.SigningKey)))
+  Args.withSchema(Schema.String.pipe(Schema.fromBrand(SigningKey.SigningKey)).annotations({ title: 'signing_key' }))
 );
 
 export const circuitId = Args.text({ name: 'circuit_id'}).pipe(

--- a/compact-js/compact-js-command/src/effect/internal/circuitCommand.ts
+++ b/compact-js/compact-js-command/src/effect/internal/circuitCommand.ts
@@ -24,7 +24,7 @@ import {
   type ContractOperation as LedgerContractOption,
   Intent
 } from '@midnight-ntwrk/ledger';
-import { type ConfigError, Duration, Effect, Option } from 'effect';
+import { type ConfigError, Console,Duration, Effect, Option } from 'effect';
 
 import * as CompiledContractReflection from '../CompiledContractReflection.js';
 import { type ConfigCompiler } from '../ConfigCompiler.js';
@@ -102,6 +102,13 @@ export const handler: (inputs: Args & Options, moduleSpec: ConfigCompiler.Module
           : undefined 
       },
       ...(yield* argsParser.parseCircuitArgs(Contract.ImpureCircuitId(circuitId), args))
+    );
+    yield* Console.log(
+      JSON.stringify(
+        result.private.result,
+        (_, value) => typeof value === 'bigint' ? value.toString() : value,
+        2
+      )
     );
     const intent = Intent.new(yield* InternalCommand.ttl(Duration.minutes(10)))
       .addCall(new ContractCallPrototype(

--- a/compact-js/compact-js-command/src/effect/internal/options.ts
+++ b/compact-js/compact-js-command/src/effect/internal/options.ts
@@ -33,7 +33,7 @@ export const coinPublicKey = Options.text('coin-public').pipe(
   Options.withSchema(Schema.Union(
     Schema.String.pipe(Schema.fromBrand(CoinPublicKey.Hex)),
     Schema.String.pipe(Schema.fromBrand(CoinPublicKey.Bech32m))
-  )),
+  ).annotations({ title: 'coin-public' })),
   Options.optional
 );
 
@@ -41,7 +41,7 @@ export const coinPublicKey = Options.text('coin-public').pipe(
 export const signingKey = Options.text('signing').pipe(
   Options.withAlias('s'),
   Options.withDescription('A public BIP-340 signing key, hex encoded.'),
-  Options.withSchema(Schema.String.pipe(Schema.fromBrand(SigningKey.SigningKey))),
+  Options.withSchema(Schema.String.pipe(Schema.fromBrand(SigningKey.SigningKey)).annotations({ title: 'signing' })),
   Options.optional
 );
 


### PR DESCRIPTION
With this PR, whenever an un-parsable Schema based option or argument is encountered, the error message will now include the name of the option or argument.

The `circuit` command will now also write the result of the circuit invocation to stdout. For circuits that do not return anything (i.e., `[]` in Compact), then an empty array will be written.