### PR TITLE
refactor(compact-js): Add type handling for array types in `transformParams`

### DIFF
--- a/compact-js/compact-js-command/src/effect/internal/compiledContractReflection.ts
+++ b/compact-js/compact-js-command/src/effect/internal/compiledContractReflection.ts
@@ -71,6 +71,9 @@ const typeNodeName: (type: TS.TypeNode) => string =
     if (type.kind === TS.SyntaxKind.BigIntKeyword) return 'bigint';
     if (type.kind === TS.SyntaxKind.StringKeyword) return 'string';
     if (type.kind === TS.SyntaxKind.BooleanKeyword) return 'boolean';
+    if (type.kind === TS.SyntaxKind.ArrayType) {
+      return `${typeNodeName((type as TS.ArrayTypeNode).elementType)}[]`;
+    }
     if (type.kind === TS.SyntaxKind.TupleType) {
       return `[${(type as TS.TupleTypeNode).elements.map((_) => typeNodeName(_ as TS.TypeNode)).join(', ')}]`;
     }


### PR DESCRIPTION
While arguments in the Tuple form are correctly handled when transforming string arguments, Compact also support a vector type (e.g., `Vector<5, Field>`), that becomes a `T[]` type in the generated TypeScript declaration file. This PR adds specific support for handling these array types by treating them much like a Tuple, but with a single element type that is repeated, instead of the individual Tuple element types.