### PR TITLE
feat: automated indexer schema update

### DIFF
--- a/.github/workflows/update-indexer-schema.yml
+++ b/.github/workflows/update-indexer-schema.yml
@@ -1,0 +1,87 @@
+name: Update Indexer GraphQL Schema
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Every Monday at 9 AM UTC
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Download latest schema
+        run: |
+          curl -sSL \
+            https://raw.githubusercontent.com/midnightntwrk/midnight-indexer/main/indexer-api/graphql/schema-v3.graphql \
+            -o packages/indexer-public-data-provider/schema.graphql
+
+          if [ ! -s packages/indexer-public-data-provider/schema.graphql ]; then
+            echo "Error: Downloaded schema is empty"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Generate types
+        working-directory: packages/indexer-public-data-provider
+        run: yarn gen
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No changes detected"
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Changes detected"
+          fi
+
+      - name: Create Pull Request
+        if: steps.check_changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore(midnight-js): update GraphQL schema from midnight-indexer'
+          branch: chore/update-indexer-schema-${{ github.run_number }}
+          delete-branch: true
+          title: 'chore: Update indexer GraphQL schema (auto-generated)'
+          body: |
+            ## Automated Schema Update
+
+            This PR updates the GraphQL schema from the `midnight-indexer` repository.
+
+            **Source:** `midnight-indexer/indexer-api/graphql/schema-v3.graphql`
+            **Generated:** ${{ github.event.repository.updated_at }}
+
+            ### Changes
+            - Updated `packages/indexer-public-data-provider/schema.graphql`
+            - Regenerated TypeScript types in `packages/indexer-public-data-provider/src/gen/`
+
+            ### Verification
+            - [ ] Review schema changes
+            - [ ] Check for breaking changes
+          labels: |
+            dependencies
+            automated
+            chore
+
+      - name: Log completion
+        if: steps.check_changes.outputs.has_changes == 'false'
+        run: echo "✅ Schema is up to date - no PR created"


### PR DESCRIPTION
Automated Update Indexer GraphQL Schema workflow

Resolves https://shielded.atlassian.net/issues/?filter=13860&selectedIssue=PM-20230 

---

Currently we manually copy the schema which is prone to errors, ideally we would automate getting the last stable graphql schema and update our indexer client accordingly.

Schema location: [midnight-indexer/indexer-api/graphql/schema-v3.graphql at main · midnightntwrk/midnight-indexer](https://github.com/midnightntwrk/midnight-indexer/blob/main/indexer-api/graphql/schema-v3.graphql)

