### PR TITLE
chore: indexer-standalone:3.0.0-alpha.11 and midnight-node:0.18.0-rc.6

### DIFF
--- a/testkit-js/compose.yml
+++ b/testkit-js/compose.yml
@@ -15,7 +15,7 @@ services:
       start_period: 10s
 
   indexer:
-    image: 'ghcr.io/midnight-ntwrk/indexer-standalone:3.0.0-alpha.10'
+    image: 'ghcr.io/midnight-ntwrk/indexer-standalone:3.0.0-alpha.11'
     container_name: indexer_$TESTCONTAINERS_UID
     ports:
       - '8088'


### PR DESCRIPTION
- update to indexer-standalone:3.0.0-alpha.10
- update to midnight-node:0.18.0-rc.6