### PR TITLE
chore: tweak testkit-js default configuration

### DIFF
--- a/testkit-js/testkit-js/src/configuration.ts
+++ b/testkit-js/testkit-js/src/configuration.ts
@@ -27,7 +27,7 @@ export const defaultContainersConfiguration: ContainersConfiguration = {
     container: {
       name: 'proof-server',
       port: 6300,
-      waitStrategy: Wait.forLogMessage('Actix runtime found; starting in Actix runtime')
+      waitStrategy: Wait.forListeningPorts().withStartupTimeout(3 * 60_000)
     }
   },
   standalone: {


### PR DESCRIPTION
Update the configuration of testkit-js : proof-server waitStrategy on standalone execution