### PR TITLE
chore: add e2e scoped test for circuit fail

### DIFF
--- a/packages/contracts/src/internal/transaction.ts
+++ b/packages/contracts/src/internal/transaction.ts
@@ -190,6 +190,9 @@ export const scoped: {
   try {
     await fn(innerTxCtx);
   } catch (err: unknown) {
+    if (outerTxCtx) {
+      throw err;
+    }
     const execErr = new Error(
       `Unexpected error executing scoped transaction '${options?.scopeName ?? '<unnamed>'}': ${String(err)}`,
       { cause: err }

--- a/testkit-js/testkit-js-e2e/test/contracts.scopedtx.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/contracts.scopedtx.it.test.ts
@@ -211,7 +211,7 @@ describe('Scoped Transaction Contract Tests', () => {
         await submitCallTx(providers, invalidCallTxOptions, txCtx);
       })
     ).rejects.toThrow(
-      "Unexpected error executing scoped transaction '<unnamed>': Error: Unexpected error executing scoped transaction '<unnamed>': CompactError: type error: increment1 argument 1 (argument 2 as invoked from Typescript) at double-counter.compact line 8 char 1; expected value of type Uint<0..65536> but received 65536n"
+      "Unexpected error executing scoped transaction '<unnamed>': CompactError: type error: increment1 argument 1 (argument 2 as invoked from Typescript) at double-counter.compact line 8 char 1; expected value of type Uint<0..65536> but received 65536n"
     );
 
     const counterValue2 = await api.getCounterLedgerState(providers, contractAddress);


### PR DESCRIPTION
Add additional test to cover behaviour of scoped tx when circuit call fails