### PR TITLE
chore: remove `newCoins` parameter and related logic from `balanceTx`

### DIFF
--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/WalletProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/WalletProvider.md
@@ -13,7 +13,7 @@ transaction balancing and finalization, and provides access to cryptographic sec
 
 ### balanceTx()
 
-> **balanceTx**(`tx`, `newCoins?`, `ttl?`): `Promise`\<`FinalizedTransaction`\>
+> **balanceTx**(`tx`, `ttl?`): `Promise`\<`FinalizedTransaction`\>
 
 Balances a transaction
 
@@ -24,10 +24,6 @@ Balances a transaction
 [`UnboundTransaction`](../type-aliases/UnboundTransaction.md)
 
 The transaction to balance.
-
-##### newCoins?
-
-`ShieldedCoinInfo`[]
 
 ##### ttl?
 

--- a/docs/api/testkit-js/classes/MidnightWalletProvider.md
+++ b/docs/api/testkit-js/classes/MidnightWalletProvider.md
@@ -50,7 +50,7 @@ Handles transaction balancing, submission, and wallet state management.
 
 ### balanceTx()
 
-> **balanceTx**(`tx`, `_newCoins`, `ttl`): `Promise`\<`FinalizedTransaction`\>
+> **balanceTx**(`tx`, `ttl`): `Promise`\<`FinalizedTransaction`\>
 
 Balances a transaction
 
@@ -61,10 +61,6 @@ Balances a transaction
 `UnboundTransaction`
 
 The transaction to balance.
-
-##### \_newCoins
-
-`ShieldedCoinInfo`[]
 
 ##### ttl
 

--- a/docs/releases/v3.0.0/api-changes.md
+++ b/docs/releases/v3.0.0/api-changes.md
@@ -65,10 +65,9 @@ interface WalletProvider {
 ```typescript
 interface WalletProvider {
   balanceTx(
-    tx: UnprovenTransaction, 
-    newCoins?: ShieldedCoinInfo[], 
+    tx: UnboundTransaction,
     ttl?: Date
-  ): Promise<BalancedProvingRecipe>;
+  ): Promise<FinalizedTransaction>;
 }
 ```
 
@@ -311,7 +310,7 @@ interface CircuitContext {
 
   interface WalletProvider {
 -   balanceTx(tx: UnprovenTransaction): Promise<BalancedProvingRecipe>;
-+   balanceTx(tx: UnprovenTransaction, newCoins?: ShieldedCoinInfo[], ttl?: Date): Promise<BalancedProvingRecipe>;
++   balanceTx(tx: UnboundTransaction, ttl?: Date): Promise<FinalizedTransaction>;
   }
 
 + type TransactionToProve = {

--- a/packages/contracts/src/internal/transaction.ts
+++ b/packages/contracts/src/internal/transaction.ts
@@ -16,7 +16,7 @@
 import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
 import { ZswapOffer as LedgerZswapOffer } from '@midnight-ntwrk/ledger-v7';
 import { type PrivateStateId, SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
-import { ChargedState,type ShieldedCoinInfo } from '@midnight-ntwrk/onchain-runtime-v2';
+import { ChargedState } from '@midnight-ntwrk/onchain-runtime-v2';
 
 import { type CallResult } from '../call';
 import { type ContractProviders } from '../contract-providers';
@@ -42,18 +42,6 @@ const mergeSubmitTxOptions = <ICK extends Contract.ImpureCircuitId<Contract.Any>
   if (!current) {
     return next;
   }
-  const newCoins = [
-      ...(current.newCoins ?? []),
-      ...(next.newCoins ?? [])
-    ].reduce((map, coin) => {
-      const existing = map.get(coin.type);
-      if (existing) {
-        map.set(coin.type, { ...existing, value: existing.value + coin.value });
-      } else {
-        map.set(coin.type, { ...coin });
-      }
-      return map;
-    }, new Map<string, ShieldedCoinInfo>());
   const circuitIds = new Set([
       ...(Array.isArray(current.circuitId) ? current.circuitId! : [current.circuitId!]),
       ...(Array.isArray(next.circuitId) ? next.circuitId! : [next.circuitId!])
@@ -61,7 +49,6 @@ const mergeSubmitTxOptions = <ICK extends Contract.ImpureCircuitId<Contract.Any>
 
   return {
     unprovenTx: current.unprovenTx.merge(next.unprovenTx),
-    newCoins: Array.from(newCoins.values()),
     circuitId: Array.from(circuitIds)
   };
 };
@@ -123,7 +110,6 @@ export class TransactionContextImpl<
       this.submitTxOptions,
       {
         unprovenTx: callData.private.unprovenTx,
-        newCoins: callData.private.newCoins,
         circuitId
        }
     );

--- a/packages/contracts/src/submit-call-tx.ts
+++ b/packages/contracts/src/submit-call-tx.ts
@@ -211,7 +211,6 @@ export async function submitCallTxAsync<C extends Contract.Any, ICK extends Cont
 
   const txId = await submitTxAsync(providers, {
     unprovenTx: unprovenCallTxData.private.unprovenTx,
-    newCoins: unprovenCallTxData.private.newCoins,
     circuitId: options.circuitId
   });
 

--- a/packages/contracts/src/submit-deploy-tx.ts
+++ b/packages/contracts/src/submit-deploy-tx.ts
@@ -86,8 +86,7 @@ export async function submitDeployTx<C extends Contract.Any>(
 ): Promise<FinalizedDeployTxData<C>> {
   const unprovenDeployTxData = await createUnprovenDeployTx(providers, options);
   const finalizedTxData = await submitTx(providers, {
-    unprovenTx: unprovenDeployTxData.private.unprovenTx,
-    newCoins: unprovenDeployTxData.private.newCoins
+    unprovenTx: unprovenDeployTxData.private.unprovenTx
   });
   if (finalizedTxData.status !== SucceedEntirely) {
     throw new DeployTxFailedError(finalizedTxData);

--- a/packages/contracts/src/submit-tx.ts
+++ b/packages/contracts/src/submit-tx.ts
@@ -14,7 +14,6 @@
  */
 
 import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
-import type { ShieldedCoinInfo } from '@midnight-ntwrk/compact-runtime';
 import {
   type Transaction,
   type UnprovenTransaction,
@@ -39,11 +38,6 @@ export type SubmitTxOptions<ICK extends Contract.ImpureCircuitId<Contract.Any>> 
    * The transaction to prove, balance, and submit.
    */
   readonly unprovenTx: UnprovenTransaction;
-  /**
-   * Any new coins created during the construction of the transaction. Only defined
-   * if the transaction being submitted is a call or deploy transaction.
-   */
-  readonly newCoins?: ShieldedCoinInfo[];
   /**
    * A circuit identifier to use to fetch the ZK artifacts needed to prove the
    * transaction. Only defined if a call transaction is being submitted.
@@ -104,7 +98,7 @@ async function submitTxCore<C extends Contract.Any, ICK extends Contract.ImpureC
   options: SubmitTxOptions<ICK>
 ): Promise<string> {
   const provenTx = await providers.proofProvider.proveTx(options.unprovenTx);
-  const toSubmit = await providers.walletProvider.balanceTx(provenTx, options.newCoins);
+  const toSubmit = await providers.walletProvider.balanceTx(provenTx);
   if (__DEBUG__) {
     logTransaction(options.circuitId, toSubmit);
   }

--- a/packages/contracts/src/test/submit-call-tx.test.ts
+++ b/packages/contracts/src/test/submit-call-tx.test.ts
@@ -113,7 +113,6 @@ describe('submit-call-tx', () => {
     );
     expect(submitTx).toHaveBeenCalledWith(mockProviders, {
       unprovenTx: mockUnprovenCallTxData.private.unprovenTx,
-      newCoins: mockUnprovenCallTxData.private.newCoins,
       circuitId: 'testCircuit'
     });
     expect(result).toEqual({
@@ -376,7 +375,6 @@ describe('submit-call-tx', () => {
 
         expect(submitTx).toHaveBeenCalledWith(mockProviders, {
           unprovenTx: mockUnprovenCallTxData.private.unprovenTx,
-          newCoins: [],
           circuitId: 'testCircuit'
         });
         expect(result).toEqual({
@@ -434,7 +432,6 @@ describe('submit-call-tx', () => {
         expect(createUnprovenCallTx).toHaveBeenCalledWith(mockProviders, options);
         expect(submitTxAsync).toHaveBeenCalledWith(mockProviders, {
           unprovenTx: mockUnprovenCallTxData.private.unprovenTx,
-          newCoins: mockUnprovenCallTxData.private.newCoins,
           circuitId: 'testCircuit'
         });
         expect(result).toEqual({
@@ -546,7 +543,6 @@ describe('submit-call-tx', () => {
 
         expect(submitTxAsync).toHaveBeenCalledWith(mockProviders, {
           unprovenTx: mockUnprovenCallTxData.private.unprovenTx,
-          newCoins: [],
           circuitId: 'testCircuit'
         });
         expect(result.txId).toBe(mockTxId);

--- a/packages/contracts/src/test/submit-deploy-tx.test.ts
+++ b/packages/contracts/src/test/submit-deploy-tx.test.ts
@@ -76,8 +76,7 @@ describe('submit-deploy-tx', () => {
 
         expect(createUnprovenDeployTx).toHaveBeenCalledWith(mockProviders, options);
         expect(submitTx).toHaveBeenCalledWith(mockProviders, {
-          unprovenTx: mockUnprovenDeployTxData.private.unprovenTx,
-          newCoins: mockUnprovenDeployTxData.private.newCoins
+          unprovenTx: mockUnprovenDeployTxData.private.unprovenTx
         });
         expect(mockProviders.privateStateProvider.setSigningKey).toHaveBeenCalledWith(
           mockContractAddress,
@@ -302,8 +301,7 @@ describe('submit-deploy-tx', () => {
         const result = await submitDeployTx(mockProviders, options);
 
         expect(submitTx).toHaveBeenCalledWith(mockProviders, {
-          unprovenTx: mockUnprovenTx,
-          newCoins: []
+          unprovenTx: mockUnprovenTx
         });
         expect(result).toEqual({
           private: mockUnprovenDeployTxData.private,

--- a/packages/contracts/src/test/submit-tx.test.ts
+++ b/packages/contracts/src/test/submit-tx.test.ts
@@ -14,7 +14,6 @@
  */
 
 import type { Contract } from '@midnight-ntwrk/compact-js';
-import { type ShieldedCoinInfo } from '@midnight-ntwrk/ledger-v7';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { submitTx, submitTxAsync, type SubmitTxOptions } from '../submit-tx';
@@ -55,7 +54,7 @@ describe('submit-tx', () => {
         const result = await submitTx(mockProviders, options);
 
         expect(mockProviders.proofProvider.proveTx).toHaveBeenCalledWith(mockUnprovenTx);
-        expect(mockProviders.walletProvider.balanceTx).toHaveBeenCalledWith(mockProvenTx, undefined);
+        expect(mockProviders.walletProvider.balanceTx).toHaveBeenCalledWith(mockProvenTx);
         expect(mockProviders.midnightProvider.submitTx).toHaveBeenCalled();
         expect(mockProviders.publicDataProvider.watchForTxData).toHaveBeenCalledWith('test-tx-id');
         expect(result).toBe(mockFinalizedTxData);
@@ -78,7 +77,7 @@ describe('submit-tx', () => {
         const result = await submitTx(mockProviders, options);
 
         expect(mockProviders.proofProvider.proveTx).toHaveBeenCalledWith(mockUnprovenTx);
-        expect(mockProviders.walletProvider.balanceTx).toHaveBeenCalledWith(mockProvenTx, undefined);
+        expect(mockProviders.walletProvider.balanceTx).toHaveBeenCalledWith(mockProvenTx);
         expect(mockProviders.midnightProvider.submitTx).toHaveBeenCalled();
         expect(mockProviders.publicDataProvider.watchForTxData).toHaveBeenCalledWith('test-tx-id');
         expect(result).toBe(mockFinalizedTxData);
@@ -113,7 +112,7 @@ describe('submit-tx', () => {
         const result = await submitTxAsync(mockProviders, options);
 
         expect(mockProviders.proofProvider.proveTx).toHaveBeenCalledWith(mockUnprovenTx);
-        expect(mockProviders.walletProvider.balanceTx).toHaveBeenCalledWith(mockProvenTx, undefined);
+        expect(mockProviders.walletProvider.balanceTx).toHaveBeenCalledWith(mockProvenTx);
         expect(mockProviders.midnightProvider.submitTx).toHaveBeenCalled();
         expect(mockProviders.publicDataProvider.watchForTxData).not.toHaveBeenCalled();
         expect(result).toBe(expectedTxId);
@@ -135,31 +134,12 @@ describe('submit-tx', () => {
         const result = await submitTxAsync(mockProviders, options);
 
         expect(mockProviders.proofProvider.proveTx).toHaveBeenCalledWith(mockUnprovenTx);
-        expect(mockProviders.walletProvider.balanceTx).toHaveBeenCalledWith(mockProvenTx, undefined);
+        expect(mockProviders.walletProvider.balanceTx).toHaveBeenCalledWith(mockProvenTx);
         expect(mockProviders.midnightProvider.submitTx).toHaveBeenCalled();
         expect(mockProviders.publicDataProvider.watchForTxData).not.toHaveBeenCalled();
         expect(result).toBe(expectedTxId);
       });
 
-      it('should handle newCoins parameter', async () => {
-        const mockNewCoins = [] as ShieldedCoinInfo[];
-        const expectedTxId = 'test-tx-id-coins';
-
-        mockProviders.walletProvider.balanceTx = vi.fn().mockResolvedValue(mockProvenTx);
-        mockProviders.proofProvider.proveTx = vi.fn().mockResolvedValue(mockProvenTx);
-        mockProviders.midnightProvider.submitTx = vi.fn().mockResolvedValue(expectedTxId);
-
-        const options: SubmitTxOptions<Contract.ImpureCircuitId<Contract.Any>> = {
-          unprovenTx: mockUnprovenTx,
-          newCoins: mockNewCoins
-        };
-
-        const result = await submitTxAsync(mockProviders, options);
-
-        expect(mockProviders.proofProvider.proveTx).toHaveBeenCalledWith(mockUnprovenTx);
-        expect(mockProviders.walletProvider.balanceTx).toHaveBeenCalledWith(mockProvenTx, mockNewCoins);
-        expect(result).toBe(expectedTxId);
-      });
     });
 
     describe('error handling', () => {

--- a/packages/types/src/wallet-provider.ts
+++ b/packages/types/src/wallet-provider.ts
@@ -17,7 +17,6 @@ import {
   type CoinPublicKey,
   type EncPublicKey,
   type FinalizedTransaction,
-  type ShieldedCoinInfo,
 } from '@midnight-ntwrk/ledger-v7';
 
 import { type UnboundTransaction } from './proof-provider';
@@ -31,10 +30,9 @@ export interface WalletProvider {
   /**
    * Balances a transaction
    * @param tx The transaction to balance.
-   * @param newCoins
    * @param ttl
    */
-  balanceTx(tx: UnboundTransaction, newCoins?: ShieldedCoinInfo[], ttl?: Date): Promise<FinalizedTransaction>;
+  balanceTx(tx: UnboundTransaction, ttl?: Date): Promise<FinalizedTransaction>;
 
   getCoinPublicKey(): CoinPublicKey;
 

--- a/testkit-js/testkit-js/src/wallet/midnight-wallet-provider.ts
+++ b/testkit-js/testkit-js/src/wallet/midnight-wallet-provider.ts
@@ -18,7 +18,6 @@ import {
   DustSecretKey,
   type EncPublicKey,
   type FinalizedTransaction,
-  type ShieldedCoinInfo,
   shieldedToken,
   type TokenType,
   ZswapSecretKeys
@@ -72,7 +71,6 @@ export class MidnightWalletProvider implements MidnightProvider, WalletProvider 
 
   async balanceTx(
     tx: UnboundTransaction,
-    _newCoins: ShieldedCoinInfo[],
     ttl: Date = ttlOneHour()
   ): Promise<FinalizedTransaction> {
     const bound = tx.bind();


### PR DESCRIPTION
- remove `newCoins` parameter and related logic from 'balanceTx' method and update affected tests, docs, and types