### PR TITLE
fix: [PM-21766] Ensure `TransactionContext` is not included in circuit call arguments

### DIFF
--- a/packages/contracts/src/tx-interfaces.ts
+++ b/packages/contracts/src/tx-interfaces.ts
@@ -85,7 +85,7 @@ export const createCircuitCallTxInterface = <C extends Contract.Any>(
       ...acc,
       [circuitId]: (...args: unknown[]) => {
         const txCtx = args.length > 0 && Transaction.isTransactionContext(args[0]) ? args[0] : undefined;
-        const callArgs = !txCtx ? args : args as Contract.CircuitParameters<C, typeof circuitId>;
+        const callArgs = txCtx ? args.slice(1) : args;
         const callOptions = createCallTxOptions(
           compiledContract,
           circuitId,


### PR DESCRIPTION
[PM-21766](https://shielded.atlassian.net/browse/PM-21766)

Fixes the bug where if a `TransactionContext` is present in the received arguments it is also passed as part of the circuit call arguments. This PR ensures that if one is present, it is removed the circuit arguments.

[PM-21766]: https://shielded.atlassian.net/browse/PM-21766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ