### PR TITLE
feat: remove `walletProvider` option and enforce `privateStoragePasswordProvider` for LevelDB provider configuration

### DIFF
--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/interfaces/LevelPrivateStateProviderConfig.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/interfaces/LevelPrivateStateProviderConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: LevelPrivateStateProviderConfig
 
-Optional properties for the indexedDB based private state provider configuration.
+Configuration properties for the LevelDB based private state provider.
 
 ## Properties
 
@@ -26,25 +26,21 @@ The name of the object store containing private states.
 
 ***
 
-### privateStoragePasswordProvider?
+### privateStoragePasswordProvider
 
-> `readonly` `optional` **privateStoragePasswordProvider**: [`PrivateStoragePasswordProvider`](../type-aliases/PrivateStoragePasswordProvider.md)
+> `readonly` **privateStoragePasswordProvider**: [`PrivateStoragePasswordProvider`](../type-aliases/PrivateStoragePasswordProvider.md)
 
 Provider function that returns the password used for encrypting private state.
 The password must be at least 16 characters long.
 
-If not provided, defaults to using walletProvider.getEncryptionPublicKey().
+**SECURITY**: Use a strong, secret password. Never use public key material
+or other non-secret values as the password source.
 
 #### Example
 
 ```typescript
-// Using default (wallet's encryption public key)
-{ walletProvider: wallet }
-
-// Using custom password provider
 {
-  walletProvider: wallet,
-  privateStoragePasswordProvider: async () => await getUserPassword()
+  privateStoragePasswordProvider: async () => await getSecretPassword()
 }
 ```
 
@@ -55,13 +51,3 @@ If not provided, defaults to using walletProvider.getEncryptionPublicKey().
 > `readonly` **signingKeyStoreName**: `string`
 
 The name of the object store containing signing keys.
-
-***
-
-### walletProvider?
-
-> `readonly` `optional` **walletProvider**: `WalletProvider`
-
-Wallet provider used to get the encryption public key for password derivation.
-If privateStoragePasswordProvider is not provided, the wallet's encryption public key
-will be used as the password.

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -25,8 +25,7 @@ import {
   type PrivateStateExport,
   PrivateStateExportError,
   type PrivateStateId,
-  type PrivateStateProvider,
-  type WalletProvider
+  type PrivateStateProvider
 } from '@midnight-ntwrk/midnight-js-types';
 import { type AbstractSublevel } from 'abstract-level';
 import { Buffer } from 'buffer';
@@ -52,7 +51,7 @@ export const MN_LDB_DEFAULT_PRIS_STORE_NAME = 'private-states';
 export const MN_LDB_DEFAULT_KEY_STORE_NAME = 'signing-keys';
 
 /**
- * Optional properties for the indexedDB based private state provider configuration.
+ * Configuration properties for the LevelDB based private state provider.
  */
 export interface LevelPrivateStateProviderConfig {
   /**
@@ -68,30 +67,20 @@ export interface LevelPrivateStateProviderConfig {
    */
   readonly signingKeyStoreName: string;
   /**
-   * Wallet provider used to get the encryption public key for password derivation.
-   * If privateStoragePasswordProvider is not provided, the wallet's encryption public key
-   * will be used as the password.
-   */
-  readonly walletProvider?: WalletProvider;
-  /**
    * Provider function that returns the password used for encrypting private state.
    * The password must be at least 16 characters long.
    *
-   * If not provided, defaults to using walletProvider.getEncryptionPublicKey().
+   * SECURITY: Use a strong, secret password. Never use public key material
+   * or other non-secret values as the password source.
    *
    * @example
    * ```typescript
-   * // Using default (wallet's encryption public key)
-   * { walletProvider: wallet }
-   *
-   * // Using custom password provider
    * {
-   *   walletProvider: wallet,
-   *   privateStoragePasswordProvider: async () => await getUserPassword()
+   *   privateStoragePasswordProvider: async () => await getSecretPassword()
    * }
    * ```
    */
-  readonly privateStoragePasswordProvider?: PrivateStoragePasswordProvider;
+  readonly privateStoragePasswordProvider: PrivateStoragePasswordProvider;
 }
 
 /**
@@ -304,26 +293,18 @@ const validateSalt = (salt: string): void => {
  * @param config Database configuration options.
  */
 export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
-  config: Partial<LevelPrivateStateProviderConfig>
+  config: Partial<LevelPrivateStateProviderConfig> & Pick<LevelPrivateStateProviderConfig, 'privateStoragePasswordProvider'>
 ): PrivateStateProvider<PSI, PS> => {
   const fullConfig = _.defaults(config, DEFAULT_CONFIG);
 
-  if (config.privateStoragePasswordProvider && config.walletProvider) {
+  if (!config.privateStoragePasswordProvider) {
     throw new Error(
-      'Cannot provide both privateStoragePasswordProvider and walletProvider.\n' +
-      'Provide only one: walletProvider for default behavior, or privateStoragePasswordProvider for custom password.'
+      'privateStoragePasswordProvider is required.\n' +
+      'Provide a function that returns a strong, secret password (minimum 16 characters).'
     );
   }
 
-  if (!config.privateStoragePasswordProvider && !config.walletProvider) {
-    throw new Error(
-      'Either privateStoragePasswordProvider or walletProvider must be provided.\n' +
-      'Provide walletProvider to use wallet encryption key, or privateStoragePasswordProvider for custom password.'
-    );
-  }
-
-  const passwordProvider: PrivateStoragePasswordProvider = config.privateStoragePasswordProvider ||
-    (() => config.walletProvider!.getEncryptionPublicKey());
+  const passwordProvider: PrivateStoragePasswordProvider = config.privateStoragePasswordProvider;
 
   let contractAddress: ContractAddress | null = null;
 

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -17,7 +17,6 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/compact-runtime';
-import { type FinalizedTransaction } from '@midnight-ntwrk/ledger-v7';
 import {
   ExportDecryptionError,
   ImportConflictError,
@@ -246,39 +245,19 @@ describe('Level Private State Provider', (): void => {
   });
 
   describe('Password provider configuration', () => {
-    test('uses wallet encryption public key when only walletProvider is provided', async () => {
-      const mockWallet = {
-        getEncryptionPublicKey: () => TEST_PASSWORD,
-        getCoinPublicKey: () => 'mock-coin-public-key',
-        balanceTx: async () => ({} as unknown as FinalizedTransaction)
-      };
+    test('throws error when privateStoragePasswordProvider is not provided', () => {
+      expect(() => {
+        // @ts-expect-error - intentionally testing missing required field
+        levelPrivateStateProvider<PID, PS>({});
+      }).toThrow('privateStoragePasswordProvider is required');
+    });
 
-      const db = levelPrivateStateProvider<PID, PS>({ walletProvider: mockWallet });
+    test('works correctly when privateStoragePasswordProvider is provided', async () => {
+      const db = levelPrivateStateProvider<PID, PS>(testConfig);
       db.setContractAddress(TEST_CONTRACT_ADDRESS);
       await db.set('stringValue', testStates.stringValue);
       const value = await db.get('stringValue');
       expect(value).toEqual(testStates.stringValue);
-    });
-
-    test('throws error when neither walletProvider nor privateStoragePasswordProvider is provided', () => {
-      expect(() => {
-        levelPrivateStateProvider<PID, PS>({});
-      }).toThrow('Either privateStoragePasswordProvider or walletProvider must be provided');
-    });
-
-    test('throws error when both privateStoragePasswordProvider and walletProvider are provided', () => {
-      const mockWallet = {
-        getEncryptionPublicKey: () => TEST_PASSWORD,
-        getCoinPublicKey: () => 'mock-coin-public-key',
-        balanceTx: async () => ({} as unknown as FinalizedTransaction)
-      };
-
-      expect(() => {
-        levelPrivateStateProvider<PID, PS>({
-          walletProvider: mockWallet,
-          privateStoragePasswordProvider: () => TEST_PASSWORD
-        });
-      }).toThrow('Cannot provide both privateStoragePasswordProvider and walletProvider');
     });
   });
 


### PR DESCRIPTION
Simplified configuration by deprecating `walletProvider` and requiring `privateStoragePasswordProvider` for secure password management. Updated tests and documentation to align with the new API requirements.