### PR TITLE
feat: implement consistent salt generation to prevent race conditionsi n private state operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ logs
 .eslintcache
 .rollup.cache
 .DS_Store
+
+midnight-concurrent-test-db

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -35,6 +35,7 @@ import {
 } from '@midnight-ntwrk/midnight-js-types';
 import { type AbstractSublevel } from 'abstract-level';
 import { Buffer } from 'buffer';
+import { randomBytes } from 'crypto';
 import { Level } from 'level';
 import _ from 'lodash';
 import * as superjson from 'superjson';
@@ -139,32 +140,55 @@ const withSubLevel = async <K, V, A>(
 
 const METADATA_KEY = '__midnight_encryption_metadata__';
 
+const encryptionInitPromises = new Map<string, Promise<Buffer>>();
+
+const getOrCreateSalt = async (dbName: string, levelName: string): Promise<Buffer> => {
+  const lockKey = `${dbName}:${levelName}`;
+
+  const existingPromise = encryptionInitPromises.get(lockKey);
+  if (existingPromise) {
+    return existingPromise;
+  }
+
+  const initPromise = withSubLevel<string, string, Buffer>(dbName, levelName, async (subLevel) => {
+    try {
+      const metadataJson = await subLevel.get(METADATA_KEY);
+      if (metadataJson) {
+        const metadata = JSON.parse(metadataJson);
+        return Buffer.from(metadata.salt, 'hex');
+      }
+    } catch (error: unknown) {
+      if (!(error && typeof error === 'object' && 'code' in error && error.code === 'LEVEL_NOT_FOUND')) {
+        throw error;
+      }
+    }
+
+    const salt = randomBytes(32);
+    const metadata = {
+      salt: salt.toString('hex'),
+      version: 1
+    };
+    await subLevel.put(METADATA_KEY, JSON.stringify(metadata));
+    return salt;
+  });
+
+  encryptionInitPromises.set(lockKey, initPromise);
+
+  try {
+    return await initPromise;
+  } finally {
+    encryptionInitPromises.delete(lockKey);
+  }
+};
+
 const getOrCreateEncryption = async (
   dbName: string,
   levelName: string,
   passwordProvider: PrivateStoragePasswordProvider
 ): Promise<StorageEncryption> => {
   const password = await getPasswordFromProvider(passwordProvider);
-
-  return withSubLevel<string, string, StorageEncryption>(dbName, levelName, async (subLevel) => {
-    try {
-      const metadataJson = await subLevel.get(METADATA_KEY);
-      if (!metadataJson) {
-        throw new Error('Metadata not found');
-      }
-      const metadata = JSON.parse(metadataJson);
-      const salt = Buffer.from(metadata.salt, 'hex');
-      return new StorageEncryption(password, salt);
-    } catch {
-      const encryption = new StorageEncryption(password);
-      const metadata = {
-        salt: encryption.getSalt().toString('hex'),
-        version: 1
-      };
-      await subLevel.put(METADATA_KEY, JSON.stringify(metadata));
-      return encryption;
-    }
-  });
+  const salt = await getOrCreateSalt(dbName, levelName);
+  return new StorageEncryption(password, salt);
 };
 
 const subLevelMaybeGet = async <K, V>(

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -1399,5 +1399,136 @@ describe('Level Private State Provider', (): void => {
       expect(consoleWarnSpy).toHaveBeenCalled();
     });
   });
+
+  describe('Salt Consistency (Race Condition Prevention)', () => {
+    const SALT_TEST_DB = 'midnight-salt-test-db';
+    const SALT_CONTRACT_ADDRESS = 'salt-test-contract' as ContractAddress;
+
+    afterEach(async () => {
+      await fs.rm(path.join('.', SALT_TEST_DB), { recursive: true, force: true });
+    });
+
+    test('multiple sequential operations maintain consistent salt for private states', async () => {
+      const config = {
+        midnightDbName: SALT_TEST_DB,
+        privateStoragePasswordProvider: () => TEST_PASSWORD
+      };
+
+      for (let i = 0; i < 5; i++) {
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(SALT_CONTRACT_ADDRESS);
+        await db.set(`key-${i}`, `value-${i}`);
+      }
+
+      const verifyDb = levelPrivateStateProvider<string, string>(config);
+      verifyDb.setContractAddress(SALT_CONTRACT_ADDRESS);
+      for (let i = 0; i < 5; i++) {
+        const value = await verifyDb.get(`key-${i}`);
+        expect(value).toBe(`value-${i}`);
+      }
+    });
+
+    test('multiple sequential operations maintain consistent salt for signing keys', async () => {
+      const config = {
+        midnightDbName: SALT_TEST_DB,
+        privateStoragePasswordProvider: () => TEST_PASSWORD
+      };
+
+      const signingKeys = Array.from({ length: 5 }, () => sampleSigningKey());
+
+      for (let i = 0; i < 5; i++) {
+        const db = levelPrivateStateProvider<string, string>(config);
+        await db.setSigningKey(`address-${i}` as ContractAddress, signingKeys[i]);
+      }
+
+      const verifyDb = levelPrivateStateProvider<string, string>(config);
+      for (let i = 0; i < 5; i++) {
+        const key = await verifyDb.getSigningKey(`address-${i}` as ContractAddress);
+        expect(key).toEqual(signingKeys[i]);
+      }
+    });
+
+    test('operations after clear() create new consistent salt', async () => {
+      const config = {
+        midnightDbName: SALT_TEST_DB,
+        privateStoragePasswordProvider: () => TEST_PASSWORD
+      };
+
+      const db = levelPrivateStateProvider<string, string>(config);
+      db.setContractAddress(SALT_CONTRACT_ADDRESS);
+      await db.set('initial-key', 'initial-value');
+
+      await db.clear();
+
+      for (let i = 0; i < 3; i++) {
+        const freshDb = levelPrivateStateProvider<string, string>(config);
+        freshDb.setContractAddress(SALT_CONTRACT_ADDRESS);
+        await freshDb.set(`post-clear-${i}`, `value-${i}`);
+      }
+
+      const verifyDb = levelPrivateStateProvider<string, string>(config);
+      verifyDb.setContractAddress(SALT_CONTRACT_ADDRESS);
+      for (let i = 0; i < 3; i++) {
+        const value = await verifyDb.get(`post-clear-${i}`);
+        expect(value).toBe(`value-${i}`);
+      }
+    });
+
+    test('mixed operations on private states and signing keys use separate consistent salts', async () => {
+      const config = {
+        midnightDbName: SALT_TEST_DB,
+        privateStoragePasswordProvider: () => TEST_PASSWORD
+      };
+
+      const signingKey = sampleSigningKey();
+
+      const db1 = levelPrivateStateProvider<string, string>(config);
+      db1.setContractAddress(SALT_CONTRACT_ADDRESS);
+      await db1.set('state-1', 'value-1');
+
+      const db2 = levelPrivateStateProvider<string, string>(config);
+      await db2.setSigningKey('key-address-1' as ContractAddress, signingKey);
+
+      const db3 = levelPrivateStateProvider<string, string>(config);
+      db3.setContractAddress(SALT_CONTRACT_ADDRESS);
+      await db3.set('state-2', 'value-2');
+
+      const db4 = levelPrivateStateProvider<string, string>(config);
+      await db4.setSigningKey('key-address-2' as ContractAddress, signingKey);
+
+      const verifyDb = levelPrivateStateProvider<string, string>(config);
+      verifyDb.setContractAddress(SALT_CONTRACT_ADDRESS);
+
+      expect(await verifyDb.get('state-1')).toBe('value-1');
+      expect(await verifyDb.get('state-2')).toBe('value-2');
+      expect(await verifyDb.getSigningKey('key-address-1' as ContractAddress)).toEqual(signingKey);
+      expect(await verifyDb.getSigningKey('key-address-2' as ContractAddress)).toEqual(signingKey);
+    });
+
+    test('operations after clearSigningKeys() create new consistent salt for signing keys', async () => {
+      const config = {
+        midnightDbName: SALT_TEST_DB,
+        privateStoragePasswordProvider: () => TEST_PASSWORD
+      };
+
+      const signingKey1 = sampleSigningKey();
+      const db = levelPrivateStateProvider<string, string>(config);
+      await db.setSigningKey('initial-address' as ContractAddress, signingKey1);
+
+      await db.clearSigningKeys();
+
+      const signingKeys = Array.from({ length: 3 }, () => sampleSigningKey());
+      for (let i = 0; i < 3; i++) {
+        const freshDb = levelPrivateStateProvider<string, string>(config);
+        await freshDb.setSigningKey(`post-clear-${i}` as ContractAddress, signingKeys[i]);
+      }
+
+      const verifyDb = levelPrivateStateProvider<string, string>(config);
+      for (let i = 0; i < 3; i++) {
+        const key = await verifyDb.getSigningKey(`post-clear-${i}` as ContractAddress);
+        expect(key).toEqual(signingKeys[i]);
+      }
+    });
+  });
 });
 


### PR DESCRIPTION
Added `getOrCreateSalt` utility to synchronize salt initialization for private states and signing keys. Introduced tests to verify salt consistency across sequential operations, after clear operations, and in mixed use cases. Updated relevant `.gitignore` entries.