### PR TITLE
fix: batched scoped calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@d2t/vitest-ctrf-json-reporter": "^1.3.0",
     "@effect/build-utils": "^0.8.9",
     "@eslint/js": "^9.39.2",
-    "@rollup/plugin-commonjs": "^28.0.9",
+    "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-replace": "^6.0.3",
     "@rollup/plugin-typescript": "^12.3.0",

--- a/packages/level-private-state-provider/README.md
+++ b/packages/level-private-state-provider/README.md
@@ -24,7 +24,7 @@ Please visit the [Midnight Developer Hub](https://midnight.network/developer-hub
 ### Security Features
 
 - **AES-256-GCM**: Industry-standard authenticated encryption
-- **PBKDF2**: 100,000 iterations with random salt per database
+- **PBKDF2**: 600,000 iterations with random salt per database
 - **Mandatory Password**: By default data is encrypted with wallets encryption key, developer can override this behavior 
 - **Password Validation**: Minimum 16 character length enforced
 - **Automatic Migration**: Existing unencrypted data is automatically encrypted on first access
@@ -44,6 +44,78 @@ If you have existing unencrypted data:
 3. All new writes are encrypted immediately
 
 **No data loss occurs during migration.**
+
+### Password Rotation
+
+The provider supports secure password rotation for both private states and signing keys:
+
+```typescript
+const provider = levelPrivateStateProvider({
+  privateStoragePasswordProvider: () => currentPassword
+});
+
+// Set contract address first (required for private state rotation)
+provider.setContractAddress(contractAddress);
+
+// Rotate password for private states
+await provider.changePassword(
+  () => 'old-password-here',
+  () => 'new-password-here'
+);
+
+// Rotate password for signing keys (separate method)
+await provider.changeSigningKeysPassword(
+  () => 'old-password-here',
+  () => 'new-password-here'
+);
+```
+
+**Key features:**
+- Atomic operation using LevelDB batch writes (all-or-nothing)
+- Verifies old password can decrypt existing data before migration
+- Re-encrypts all data in the store with new password
+- Invalidates encryption cache after successful rotation
+- Concurrent access protection: read/write operations wait for rotation to complete
+- Automatic V1→V2 encryption format migration during rotation
+
+**Important notes:**
+- For `changePassword()`, you must call `setContractAddress()` first
+- Both passwords must meet the minimum requirements (16+ characters, 3+ character classes)
+- The operation reads all data into memory before writing (suitable for typical use cases)
+- `changePassword()` re-encrypts ALL data in the private state store (not just the current contract's data) because all entries share the same encryption salt. This is by design to maintain encryption consistency.
+
+### Encryption Caching
+
+The provider caches derived encryption keys to avoid expensive PBKDF2 key derivation (600,000 iterations) on every operation. Without caching, each `get()`, `set()`, `getSigningKey()`, or `setSigningKey()` call would require key derivation, causing significant latency.
+
+**How it works:**
+- First operation derives the key from password + salt (slow, ~600ms)
+- Subsequent operations reuse the cached key (fast, <1ms)
+- Cache is keyed by database name and store name
+
+```typescript
+const provider = levelPrivateStateProvider({
+  privateStoragePasswordProvider: () => password
+});
+
+// All these operations benefit from caching
+await provider.set('state1', data);    // First call: derives key
+await provider.set('state2', data);    // Cached: instant
+await provider.get('state1');          // Cached: instant
+
+// Manually invalidate when needed
+provider.invalidateEncryptionCache();
+```
+
+**When to invalidate:**
+- After external password changes (if password is managed outside the provider)
+- When switching users or password sources at runtime
+- In testing scenarios to ensure fresh state between tests
+
+**Automatic invalidation:**
+- `changePassword()` and `changeSigningKeysPassword()` automatically invalidate the cache
+
+**Note:** The cache has no size limit. For typical usage with a small number of database/store combinations, this is acceptable. If using dynamic database names, call `invalidateEncryptionCache()` periodically to prevent unbounded memory growth.
 
 ### Error Handling
 

--- a/packages/level-private-state-provider/src/index.ts
+++ b/packages/level-private-state-provider/src/index.ts
@@ -16,9 +16,12 @@
 export {
   DEFAULT_CONFIG,
   levelPrivateStateProvider,
-  type LevelPrivateStateProviderConfig
+  type LevelPrivateStateProviderConfig,
+  type PasswordRotationOptions,
+  type PasswordRotationResult
 } from './level-private-state-provider';
 export {
+  decryptValue,
   type PrivateStoragePasswordProvider,
   StorageEncryption
 } from './storage-encryption';

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -40,7 +40,7 @@ import { Level } from 'level';
 import _ from 'lodash';
 import * as superjson from 'superjson';
 
-import { getPasswordFromProvider, type PrivateStoragePasswordProvider, StorageEncryption } from './storage-encryption';
+import { decryptValue, getPasswordFromProvider, type PrivateStoragePasswordProvider, StorageEncryption } from './storage-encryption';
 
 /**
  * The default name of the indexedDB database for Midnight.
@@ -140,7 +140,34 @@ const withSubLevel = async <K, V, A>(
 
 const METADATA_KEY = '__midnight_encryption_metadata__';
 
+const DEFAULT_MAX_ROTATION_ENTRIES = 10000;
+
 const encryptionInitPromises = new Map<string, Promise<Buffer>>();
+
+const passwordRotationLocks = new Map<string, Promise<void>>();
+
+export interface PasswordRotationResult {
+  readonly entriesMigrated: number;
+}
+
+export interface PasswordRotationOptions {
+  readonly maxEntries?: number;
+}
+
+interface EncryptionCacheEntry {
+  readonly encryption: StorageEncryption;
+  readonly saltHex: string;
+}
+
+/**
+ * Module-level cache for StorageEncryption instances, keyed by `${dbName}:${levelName}`.
+ * This cache avoids repeated PBKDF2 key derivation (600,000 iterations) on each operation.
+ *
+ * Note: This cache has no size limit. For typical usage with a small number of
+ * database/level combinations, this is acceptable. If using dynamic db/level names,
+ * call `invalidateEncryptionCache()` to prevent unbounded growth.
+ */
+const encryptionCache = new Map<string, EncryptionCacheEntry>();
 
 const getOrCreateSalt = async (dbName: string, levelName: string): Promise<Buffer> => {
   const lockKey = `${dbName}:${levelName}`;
@@ -186,9 +213,208 @@ const getOrCreateEncryption = async (
   levelName: string,
   passwordProvider: PrivateStoragePasswordProvider
 ): Promise<StorageEncryption> => {
-  const password = await getPasswordFromProvider(passwordProvider);
+  const cacheKey = `${dbName}:${levelName}`;
   const salt = await getOrCreateSalt(dbName, levelName);
-  return new StorageEncryption(password, salt);
+  const saltHex = salt.toString('hex');
+
+  const cached = encryptionCache.get(cacheKey);
+  if (cached && cached.saltHex === saltHex) {
+    const password = await getPasswordFromProvider(passwordProvider);
+    if (cached.encryption.verifyPassword(password)) {
+      return cached.encryption;
+    }
+    const encryption = new StorageEncryption(password, salt);
+    encryptionCache.set(cacheKey, { encryption, saltHex });
+    return encryption;
+  }
+
+  const password = await getPasswordFromProvider(passwordProvider);
+  const encryption = new StorageEncryption(password, salt);
+  encryptionCache.set(cacheKey, { encryption, saltHex });
+  return encryption;
+};
+
+const invalidateEncryptionCacheForDb = (dbName: string, privateStateStoreName: string, signingKeyStoreName: string): void => {
+  const privateStateKey = `${dbName}:${privateStateStoreName}`;
+  const signingKeyKey = `${dbName}:${signingKeyStoreName}`;
+  encryptionCache.delete(privateStateKey);
+  encryptionCache.delete(signingKeyKey);
+};
+
+const DEFAULT_LOCK_TIMEOUT_MS = 300000; // 5 minutes
+
+const withPasswordRotationLock = async <T>(
+  lockKey: string,
+  operation: () => Promise<T>,
+  timeoutMs: number = DEFAULT_LOCK_TIMEOUT_MS
+): Promise<T> => {
+  const startWait = Date.now();
+
+  while (passwordRotationLocks.has(lockKey)) {
+    if (Date.now() - startWait > timeoutMs) {
+      throw new Error(
+        `Timed out waiting for password rotation lock on "${lockKey}". ` +
+          `Another rotation may be stuck or taking longer than ${timeoutMs}ms.`
+      );
+    }
+    await passwordRotationLocks.get(lockKey);
+  }
+
+  let resolve!: () => void;
+  const lockPromise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  passwordRotationLocks.set(lockKey, lockPromise);
+
+  try {
+    return await operation();
+  } finally {
+    passwordRotationLocks.delete(lockKey);
+    resolve();
+  }
+};
+
+const waitForRotationLock = async (
+  dbName: string,
+  levelName: string,
+  timeoutMs: number = DEFAULT_LOCK_TIMEOUT_MS
+): Promise<void> => {
+  const lockKey = `${dbName}:${levelName}`;
+  const startWait = Date.now();
+
+  while (passwordRotationLocks.has(lockKey)) {
+    if (Date.now() - startWait > timeoutMs) {
+      throw new Error(
+        `Timed out waiting for password rotation to complete on "${lockKey}". ` +
+          `The rotation may be stuck or taking longer than ${timeoutMs}ms.`
+      );
+    }
+    await passwordRotationLocks.get(lockKey);
+  }
+};
+
+interface RotateStorePasswordParams {
+  readonly dbName: string;
+  readonly storeName: string;
+  readonly oldPasswordProvider: PrivateStoragePasswordProvider;
+  readonly newPasswordProvider: PrivateStoragePasswordProvider;
+  readonly maxEntries: number;
+  readonly shouldProceed?: (key: string) => boolean;
+}
+
+const isDecryptionError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+  const message = error.message.toLowerCase();
+  return (
+    message.includes('unsupported state') ||
+    message.includes('salt mismatch') ||
+    message.includes('invalid encrypted data') ||
+    message.includes('bad decrypt') ||
+    message.includes('unable to authenticate')
+  );
+};
+
+const rotateStorePassword = async (
+  params: RotateStorePasswordParams
+): Promise<PasswordRotationResult> => {
+  const { dbName, storeName, oldPasswordProvider, newPasswordProvider, maxEntries, shouldProceed } = params;
+
+  const oldPassword = await getPasswordFromProvider(oldPasswordProvider);
+  const newPassword = await getPasswordFromProvider(newPasswordProvider);
+
+  const salt = await getOrCreateSalt(dbName, storeName);
+  const oldEncryption = new StorageEncryption(oldPassword, salt);
+  const newEncryption = new StorageEncryption(newPassword);
+  const newSalt = newEncryption.getSalt();
+
+  return withSubLevel<string, string, PasswordRotationResult>(
+    dbName,
+    storeName,
+    async (subLevel) => {
+      const entriesToMigrate: { key: string; decryptedValue: string }[] = [];
+      let hasMatchingData = false;
+      let firstEntryValidated = false;
+
+      for await (const [key, encryptedValue] of subLevel.iterator()) {
+        if (key === METADATA_KEY) continue;
+
+        if (entriesToMigrate.length >= maxEntries) {
+          throw new Error(
+            `Entry count exceeds maximum allowed (${maxEntries}). ` +
+            `Use the maxEntries option to increase the limit if needed.`
+          );
+        }
+
+        if (shouldProceed && shouldProceed(key)) {
+          hasMatchingData = true;
+        }
+
+        if (!firstEntryValidated) {
+          try {
+            decryptValue(encryptedValue, oldEncryption, oldPassword);
+          } catch (error: unknown) {
+            if (isDecryptionError(error)) {
+              throw new Error('Old password is incorrect: failed to decrypt existing data');
+            }
+            throw error;
+          }
+          firstEntryValidated = true;
+        }
+
+        try {
+          const decryptedValue = decryptValue(encryptedValue, oldEncryption, oldPassword);
+          entriesToMigrate.push({ key, decryptedValue });
+        } catch (error: unknown) {
+          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+          throw new Error(
+            `Failed to decrypt entry "${key}": ${errorMessage}. ` +
+            `Successfully processed ${entriesToMigrate.length} entries before failure.`
+          );
+        }
+      }
+
+      if (entriesToMigrate.length === 0) {
+        return { entriesMigrated: 0 };
+      }
+
+      if (shouldProceed && !hasMatchingData) {
+        return { entriesMigrated: 0 };
+      }
+
+      const operations: { type: 'put'; key: string; value: string }[] = [];
+      for (const { key, decryptedValue } of entriesToMigrate) {
+        try {
+          const encryptedValue = newEncryption.encrypt(decryptedValue);
+          operations.push({ type: 'put', key, value: encryptedValue });
+        } catch (error: unknown) {
+          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+          throw new Error(
+            `Failed to re-encrypt entry "${key}": ${errorMessage}. ` +
+            `Original data is still encrypted with old password.`
+          );
+        }
+      }
+
+      const metadata = {
+        salt: newSalt.toString('hex'),
+        version: 1
+      };
+      operations.push({ type: 'put', key: METADATA_KEY, value: JSON.stringify(metadata) });
+
+      try {
+        await subLevel.batch(operations);
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        throw new Error(
+          `Failed to write re-encrypted data: ${errorMessage}. ` +
+          `Your data may be in an inconsistent state. ` +
+          `Keep both old and new passwords until you can verify data integrity.`
+        );
+      }
+
+      return { entriesMigrated: entriesToMigrate.length };
+    }
+  );
 };
 
 const subLevelMaybeGet = async <K, V>(
@@ -197,6 +423,7 @@ const subLevelMaybeGet = async <K, V>(
   key: K,
   passwordProvider: PrivateStoragePasswordProvider
 ): Promise<V | null> => {
+  await waitForRotationLock(dbName, levelName);
   const encryption = await getOrCreateEncryption(dbName, levelName, passwordProvider);
 
   return withSubLevel<K, string, V | null>(dbName, levelName, async (subLevel) => {
@@ -210,7 +437,15 @@ const subLevelMaybeGet = async <K, V>(
       let decryptedValue: string;
 
       if (StorageEncryption.isEncrypted(encryptedValue)) {
-        decryptedValue = encryption.decrypt(encryptedValue);
+        const version = StorageEncryption.getVersion(encryptedValue);
+        if (version === 1) {
+          const password = await getPasswordFromProvider(passwordProvider);
+          decryptedValue = encryption.decryptWithPassword(encryptedValue, password);
+          const reEncrypted = encryption.encrypt(decryptedValue);
+          await subLevel.put(key, reEncrypted);
+        } else {
+          decryptedValue = encryption.decrypt(encryptedValue);
+        }
       } else {
         decryptedValue = encryptedValue;
         const reEncrypted = encryption.encrypt(encryptedValue);
@@ -241,24 +476,40 @@ const getAllEntries = async <K extends string, V>(
   levelName: string,
   passwordProvider: PrivateStoragePasswordProvider
 ): Promise<Map<K, V>> => {
+  await waitForRotationLock(dbName, levelName);
   const encryption = await getOrCreateEncryption(dbName, levelName, passwordProvider);
 
   return withSubLevel<K, string, Map<K, V>>(dbName, levelName, async (subLevel) => {
     const entries = new Map<K, V>();
+    let password: string | null = null;
 
     for await (const [key, encryptedValue] of subLevel.iterator()) {
-      // Skip metadata key
       if (key === METADATA_KEY) {
         continue;
       }
 
       let decryptedValue: string;
+      let needsReEncryption = false;
 
       if (StorageEncryption.isEncrypted(encryptedValue)) {
-        decryptedValue = encryption.decrypt(encryptedValue);
+        const version = StorageEncryption.getVersion(encryptedValue);
+        if (version === 1) {
+          if (password === null) {
+            password = await getPasswordFromProvider(passwordProvider);
+          }
+          decryptedValue = encryption.decryptWithPassword(encryptedValue, password);
+          needsReEncryption = true;
+        } else {
+          decryptedValue = encryption.decrypt(encryptedValue);
+        }
       } else {
-        // Legacy unencrypted data
         decryptedValue = encryptedValue;
+        needsReEncryption = true;
+      }
+
+      if (needsReEncryption) {
+        const reEncrypted = encryption.encrypt(decryptedValue);
+        await subLevel.put(key, reEncrypted);
       }
 
       const value = superjson.parse<V>(decryptedValue);
@@ -365,8 +616,11 @@ const showBrowserWarning = (): void => {
       }
       storage.setItem(BROWSER_WARNING_KEY, 'true');
     }
-  } catch {
-    // sessionStorage may be unavailable in some contexts
+  } catch (error: unknown) {
+    console.debug(
+      'MIDNIGHT: Could not access sessionStorage for warning deduplication:',
+      error instanceof Error ? error.message : 'Unknown error'
+    );
   }
 
   console.warn(
@@ -393,7 +647,19 @@ const showBrowserWarning = (): void => {
  */
 export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
   config: Partial<LevelPrivateStateProviderConfig> & Pick<LevelPrivateStateProviderConfig, 'privateStoragePasswordProvider'>
-): PrivateStateProvider<PSI, PS> => {
+): PrivateStateProvider<PSI, PS> & {
+  invalidateEncryptionCache(): void;
+  changePassword(
+    oldPasswordProvider: PrivateStoragePasswordProvider,
+    newPasswordProvider: PrivateStoragePasswordProvider,
+    options?: PasswordRotationOptions
+  ): Promise<PasswordRotationResult>;
+  changeSigningKeysPassword(
+    oldPasswordProvider: PrivateStoragePasswordProvider,
+    newPasswordProvider: PrivateStoragePasswordProvider,
+    options?: PasswordRotationOptions
+  ): Promise<PasswordRotationResult>;
+} => {
   const fullConfig = _.defaults(config, DEFAULT_CONFIG);
 
   if (!config.privateStoragePasswordProvider) {
@@ -430,12 +696,14 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       );
     },
     async remove(privateStateId: PSI): Promise<void> {
+      await waitForRotationLock(fullConfig.midnightDbName, fullConfig.privateStateStoreName);
       const scopedKey = getScopedKey(privateStateId);
       return withSubLevel<string, string, void>(fullConfig.midnightDbName, fullConfig.privateStateStoreName, (subLevel) =>
         subLevel.del(scopedKey)
       );
     },
     async set(privateStateId: PSI, state: PS): Promise<void> {
+      await waitForRotationLock(fullConfig.midnightDbName, fullConfig.privateStateStoreName);
       const scopedKey = getScopedKey(privateStateId);
       const encryption = await getOrCreateEncryption(
         fullConfig.midnightDbName,
@@ -463,7 +731,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         passwordProvider
       );
     },
-    removeSigningKey(address: ContractAddress): Promise<void> {
+    async removeSigningKey(address: ContractAddress): Promise<void> {
+      await waitForRotationLock(fullConfig.midnightDbName, fullConfig.signingKeyStoreName);
       return withSubLevel<ContractAddress, string, void>(
         fullConfig.midnightDbName,
         fullConfig.signingKeyStoreName,
@@ -471,6 +740,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       );
     },
     async setSigningKey(address: ContractAddress, signingKey: SigningKey): Promise<void> {
+      await waitForRotationLock(fullConfig.midnightDbName, fullConfig.signingKeyStoreName);
       const encryption = await getOrCreateEncryption(
         fullConfig.midnightDbName,
         fullConfig.signingKeyStoreName,
@@ -813,6 +1083,72 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       }
 
       return { imported, skipped, overwritten };
+    },
+
+    async changePassword(
+      oldPasswordProvider: PrivateStoragePasswordProvider,
+      newPasswordProvider: PrivateStoragePasswordProvider,
+      options?: PasswordRotationOptions
+    ): Promise<PasswordRotationResult> {
+      if (contractAddress === null) {
+        throw new Error('Contract address not set. Call setContractAddress() before changing password.');
+      }
+
+      const lockKey = `${fullConfig.midnightDbName}:${fullConfig.privateStateStoreName}`;
+      const prefix = `${contractAddress}:`;
+
+      return withPasswordRotationLock(lockKey, async () => {
+        const result = await rotateStorePassword({
+          dbName: fullConfig.midnightDbName,
+          storeName: fullConfig.privateStateStoreName,
+          oldPasswordProvider,
+          newPasswordProvider,
+          maxEntries: options?.maxEntries ?? DEFAULT_MAX_ROTATION_ENTRIES,
+          shouldProceed: (key) => key.startsWith(prefix)
+        });
+
+        invalidateEncryptionCacheForDb(
+          fullConfig.midnightDbName,
+          fullConfig.privateStateStoreName,
+          fullConfig.signingKeyStoreName
+        );
+
+        return result;
+      });
+    },
+
+    async changeSigningKeysPassword(
+      oldPasswordProvider: PrivateStoragePasswordProvider,
+      newPasswordProvider: PrivateStoragePasswordProvider,
+      options?: PasswordRotationOptions
+    ): Promise<PasswordRotationResult> {
+      const lockKey = `${fullConfig.midnightDbName}:${fullConfig.signingKeyStoreName}`;
+
+      return withPasswordRotationLock(lockKey, async () => {
+        const result = await rotateStorePassword({
+          dbName: fullConfig.midnightDbName,
+          storeName: fullConfig.signingKeyStoreName,
+          oldPasswordProvider,
+          newPasswordProvider,
+          maxEntries: options?.maxEntries ?? DEFAULT_MAX_ROTATION_ENTRIES
+        });
+
+        invalidateEncryptionCacheForDb(
+          fullConfig.midnightDbName,
+          fullConfig.privateStateStoreName,
+          fullConfig.signingKeyStoreName
+        );
+
+        return result;
+      });
+    },
+
+    invalidateEncryptionCache(): void {
+      invalidateEncryptionCacheForDb(
+        fullConfig.midnightDbName,
+        fullConfig.privateStateStoreName,
+        fullConfig.signingKeyStoreName
+      );
     }
   };
 };

--- a/packages/level-private-state-provider/src/storage-encryption.ts
+++ b/packages/level-private-state-provider/src/storage-encryption.ts
@@ -14,7 +14,7 @@
  */
 
 import { Buffer } from 'buffer';
-import { createCipheriv, createDecipheriv, pbkdf2Sync, randomBytes } from 'crypto';
+import { createCipheriv, createDecipheriv, createHash, pbkdf2Sync, randomBytes, timingSafeEqual } from 'crypto';
 
 export type PrivateStoragePasswordProvider = () => string | Promise<string>;
 
@@ -32,6 +32,36 @@ const CURRENT_ENCRYPTION_VERSION = ENCRYPTION_VERSION_V2;
 const VERSION_PREFIX_LENGTH = 1;
 const HEADER_LENGTH = VERSION_PREFIX_LENGTH + SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH;
 
+interface EncryptedComponents {
+  version: number;
+  salt: Buffer;
+  iv: Buffer;
+  authTag: Buffer;
+  encrypted: Buffer;
+}
+
+const extractEncryptedComponents = (data: Buffer): EncryptedComponents => {
+  if (data.length < HEADER_LENGTH) {
+    throw new Error('Invalid encrypted data: too short');
+  }
+
+  const version = data[0];
+  if (version !== ENCRYPTION_VERSION_V1 && version !== ENCRYPTION_VERSION_V2) {
+    throw new Error(`Unsupported encryption version: ${version}`);
+  }
+
+  return {
+    version,
+    salt: data.subarray(VERSION_PREFIX_LENGTH, VERSION_PREFIX_LENGTH + SALT_LENGTH),
+    iv: data.subarray(VERSION_PREFIX_LENGTH + SALT_LENGTH, VERSION_PREFIX_LENGTH + SALT_LENGTH + IV_LENGTH),
+    authTag: data.subarray(
+      VERSION_PREFIX_LENGTH + SALT_LENGTH + IV_LENGTH,
+      VERSION_PREFIX_LENGTH + SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH
+    ),
+    encrypted: data.subarray(HEADER_LENGTH)
+  };
+};
+
 const getIterationsForVersion = (version: number): number => {
   switch (version) {
     case ENCRYPTION_VERSION_V1:
@@ -43,19 +73,29 @@ const getIterationsForVersion = (version: number): number => {
   }
 };
 
+const hashPassword = (password: string): string => {
+  return createHash('sha256').update(password).digest('hex');
+};
+
 export class StorageEncryption {
   private readonly encryptionKey: Buffer;
   private readonly salt: Buffer;
-  private readonly password: string;
+  private readonly passwordHash: string;
 
   constructor(password: string, existingSalt?: Buffer) {
-    this.password = password;
     this.salt = existingSalt ?? randomBytes(SALT_LENGTH);
     this.encryptionKey = this.deriveKey(password, this.salt, PBKDF2_ITERATIONS_V2);
+    this.passwordHash = hashPassword(password);
   }
 
   private deriveKey(password: string, salt: Buffer, iterations: number): Buffer {
     return pbkdf2Sync(password, salt, iterations, KEY_LENGTH, 'sha256');
+  }
+
+  verifyPassword(password: string): boolean {
+    const inputHash = Buffer.from(hashPassword(password), 'hex');
+    const storedHash = Buffer.from(this.passwordHash, 'hex');
+    return timingSafeEqual(inputHash, storedHash);
   }
 
   encrypt(data: string): string {
@@ -74,23 +114,26 @@ export class StorageEncryption {
 
   decrypt(encryptedData: string): string {
     const data = Buffer.from(encryptedData, 'base64');
+    const { version, salt, iv, authTag, encrypted } = extractEncryptedComponents(data);
 
-    if (data.length < HEADER_LENGTH) {
-      throw new Error('Invalid encrypted data: too short');
+    if (version === ENCRYPTION_VERSION_V1) {
+      throw new Error('V1 encrypted data requires password for decryption. Use decryptWithPassword() instead.');
     }
 
-    const version = data[0];
-    if (version !== ENCRYPTION_VERSION_V1 && version !== ENCRYPTION_VERSION_V2) {
-      throw new Error(`Unsupported encryption version: ${version}`);
+    if (!this.salt.equals(salt)) {
+      throw new Error('Salt mismatch: data was encrypted with a different password');
     }
 
-    const salt = data.subarray(VERSION_PREFIX_LENGTH, VERSION_PREFIX_LENGTH + SALT_LENGTH);
-    const iv = data.subarray(VERSION_PREFIX_LENGTH + SALT_LENGTH, VERSION_PREFIX_LENGTH + SALT_LENGTH + IV_LENGTH);
-    const authTag = data.subarray(
-      VERSION_PREFIX_LENGTH + SALT_LENGTH + IV_LENGTH,
-      VERSION_PREFIX_LENGTH + SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH
-    );
-    const encrypted = data.subarray(HEADER_LENGTH);
+    const decipher = createDecipheriv(ALGORITHM, this.encryptionKey, iv, { authTagLength: AUTH_TAG_LENGTH });
+    decipher.setAuthTag(authTag);
+
+    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+    return decrypted.toString('utf-8');
+  }
+
+  decryptWithPassword(encryptedData: string, password: string): string {
+    const data = Buffer.from(encryptedData, 'base64');
+    const { version, salt, iv, authTag, encrypted } = extractEncryptedComponents(data);
 
     if (!this.salt.equals(salt)) {
       throw new Error('Salt mismatch: data was encrypted with a different password');
@@ -99,7 +142,7 @@ export class StorageEncryption {
     const iterations = getIterationsForVersion(version);
     const decryptionKey = version === CURRENT_ENCRYPTION_VERSION
       ? this.encryptionKey
-      : this.deriveKey(this.password, salt, iterations);
+      : this.deriveKey(password, salt, iterations);
 
     const decipher = createDecipheriv(ALGORITHM, decryptionKey, iv, { authTagLength: AUTH_TAG_LENGTH });
     decipher.setAuthTag(authTag);
@@ -230,4 +273,21 @@ export const getPasswordFromProvider = async (provider: PrivateStoragePasswordPr
   const password = await provider();
   validatePassword(password);
   return password;
+};
+
+export const decryptValue = (
+  encryptedValue: string,
+  encryption: StorageEncryption,
+  password: string
+): string => {
+  if (!StorageEncryption.isEncrypted(encryptedValue)) {
+    console.debug('MIDNIGHT: Encountered unencrypted data during decryption - passing through as-is');
+    return encryptedValue;
+  }
+
+  const version = StorageEncryption.getVersion(encryptedValue);
+  if (version === 1) {
+    return encryption.decryptWithPassword(encryptedValue, password);
+  }
+  return encryption.decrypt(encryptedValue);
 };

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -27,6 +27,8 @@ import {
   SigningKeyExportError
 } from '@midnight-ntwrk/midnight-js-types';
 import * as crypto from 'crypto';
+import { Level } from 'level';
+import * as superjson from 'superjson';
 import { vi } from 'vitest';
 
 import { levelPrivateStateProvider } from '../index';
@@ -1528,6 +1530,749 @@ describe('Level Private State Provider', (): void => {
         const key = await verifyDb.getSigningKey(`post-clear-${i}` as ContractAddress);
         expect(key).toEqual(signingKeys[i]);
       }
+    });
+  });
+
+  describe('Encryption Cache', () => {
+    const CACHE_TEST_DB = 'midnight-cache-test-db';
+    const CACHE_CONTRACT_ADDRESS = 'cache-test-contract' as ContractAddress;
+
+    afterEach(async () => {
+      await fs.rm(path.join('.', CACHE_TEST_DB), { recursive: true, force: true });
+    });
+
+    test('invalidateEncryptionCache method exists on provider', () => {
+      const db = levelPrivateStateProvider<string, string>({
+        midnightDbName: CACHE_TEST_DB,
+        privateStoragePasswordProvider: () => TEST_PASSWORD
+      });
+
+      expect(typeof db.invalidateEncryptionCache).toBe('function');
+    });
+
+    test('encryption instance is reused for multiple operations (caching works)', async () => {
+      const verifyPasswordSpy = vi.spyOn(StorageEncryption.prototype, 'verifyPassword');
+      const config = {
+        midnightDbName: CACHE_TEST_DB,
+        privateStoragePasswordProvider: () => TEST_PASSWORD
+      };
+
+      const db = levelPrivateStateProvider<string, string>(config);
+      db.setContractAddress(CACHE_CONTRACT_ADDRESS);
+
+      await db.set('key-0', 'value-0');
+      expect(verifyPasswordSpy).not.toHaveBeenCalled();
+
+      await db.set('key-1', 'value-1');
+      expect(verifyPasswordSpy).toHaveBeenCalledTimes(1);
+      expect(verifyPasswordSpy).toHaveLastReturnedWith(true);
+
+      await db.set('key-2', 'value-2');
+      expect(verifyPasswordSpy).toHaveBeenCalledTimes(2);
+      expect(verifyPasswordSpy).toHaveLastReturnedWith(true);
+
+      verifyPasswordSpy.mockRestore();
+    });
+
+    test('cache is invalidated when password changes', async () => {
+      let currentPassword = TEST_PASSWORD;
+      const config = {
+        midnightDbName: CACHE_TEST_DB,
+        privateStoragePasswordProvider: () => currentPassword
+      };
+
+      const db = levelPrivateStateProvider<string, string>(config);
+      db.setContractAddress(CACHE_CONTRACT_ADDRESS);
+      await db.set('test-key', 'test-value');
+
+      const value1 = await db.get('test-key');
+      expect(value1).toBe('test-value');
+
+      currentPassword = 'Different-Pass-88!';
+
+      await expect(db.get('test-key')).rejects.toThrow();
+    });
+
+    test('invalidateEncryptionCache clears cache and forces re-derivation', async () => {
+      const config = {
+        midnightDbName: CACHE_TEST_DB,
+        privateStoragePasswordProvider: () => TEST_PASSWORD
+      };
+
+      const db = levelPrivateStateProvider<string, string>(config);
+      db.setContractAddress(CACHE_CONTRACT_ADDRESS);
+      await db.set('test-key', 'test-value');
+
+      db.invalidateEncryptionCache();
+
+      const value = await db.get('test-key');
+      expect(value).toBe('test-value');
+    });
+
+    test('private states and signing keys have separate cache entries', async () => {
+      const config = {
+        midnightDbName: CACHE_TEST_DB,
+        privateStoragePasswordProvider: () => TEST_PASSWORD
+      };
+
+      const db = levelPrivateStateProvider<string, string>(config);
+      db.setContractAddress(CACHE_CONTRACT_ADDRESS);
+
+      await db.set('state-key', 'state-value');
+      const signingKey = sampleSigningKey();
+      await db.setSigningKey('key-address' as ContractAddress, signingKey);
+
+      expect(await db.get('state-key')).toBe('state-value');
+      expect(await db.getSigningKey('key-address' as ContractAddress)).toEqual(signingKey);
+    });
+
+    test('cache survives multiple provider instances with same config', async () => {
+      const config = {
+        midnightDbName: CACHE_TEST_DB,
+        privateStoragePasswordProvider: () => TEST_PASSWORD
+      };
+
+      const db1 = levelPrivateStateProvider<string, string>(config);
+      db1.setContractAddress(CACHE_CONTRACT_ADDRESS);
+      await db1.set('shared-key', 'shared-value');
+
+      const db2 = levelPrivateStateProvider<string, string>(config);
+      db2.setContractAddress(CACHE_CONTRACT_ADDRESS);
+      const value = await db2.get('shared-key');
+
+      expect(value).toBe('shared-value');
+    });
+  });
+
+  describe('Password Rotation', () => {
+    const ROTATION_TEST_DB = 'midnight-rotation-test-db';
+    const ROTATION_CONTRACT_ADDRESS = 'rotation-test-contract' as ContractAddress;
+    const OLD_PASSWORD = 'Old-Password-Test8!';
+    const NEW_PASSWORD = 'New-Password-Test8!';
+
+    afterEach(async () => {
+      await fs.rm(path.join('.', ROTATION_TEST_DB), { recursive: true, force: true });
+    });
+
+    describe('changePassword', () => {
+      test('changePassword method exists on provider', () => {
+        const db = levelPrivateStateProvider<string, string>({
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD
+        });
+
+        expect(typeof db.changePassword).toBe('function');
+      });
+
+      test('throws error when contract address not set', async () => {
+        const db = levelPrivateStateProvider<string, string>({
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD
+        });
+
+        await expect(
+          db.changePassword(() => OLD_PASSWORD, () => NEW_PASSWORD)
+        ).rejects.toThrow('Contract address not set');
+      });
+
+      test('successfully rotates password for private states', async () => {
+        let currentPassword = OLD_PASSWORD;
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => currentPassword
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+        await db.set('key1', 'value1');
+        await db.set('key2', 'value2');
+
+        await db.changePassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+
+        currentPassword = NEW_PASSWORD;
+
+        const value1 = await db.get('key1');
+        const value2 = await db.get('key2');
+        expect(value1).toBe('value1');
+        expect(value2).toBe('value2');
+      });
+
+      test('throws error when old password is incorrect', async () => {
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+        await db.set('key1', 'value1');
+
+        await expect(
+          db.changePassword(() => 'Wrong-Password-88!', () => NEW_PASSWORD)
+        ).rejects.toThrow();
+
+        const value = await db.get('key1');
+        expect(value).toBe('value1');
+      });
+
+      test('handles empty database gracefully', async () => {
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+
+        await expect(
+          db.changePassword(() => OLD_PASSWORD, () => NEW_PASSWORD)
+        ).resolves.not.toThrow();
+      });
+
+      test('re-encrypts all contracts data in sublevel to prevent data loss', async () => {
+        const OTHER_CONTRACT = 'other-contract' as ContractAddress;
+        let currentPassword = OLD_PASSWORD;
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => currentPassword
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+        await db.set('key1', 'value1');
+
+        db.setContractAddress(OTHER_CONTRACT);
+        await db.set('other-key', 'other-value');
+
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+        await db.changePassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+
+        currentPassword = NEW_PASSWORD;
+        const value1 = await db.get('key1');
+        expect(value1).toBe('value1');
+
+        db.setContractAddress(OTHER_CONTRACT);
+        const otherValue = await db.get('other-key');
+        expect(otherValue).toBe('other-value');
+      });
+
+      test('invalidates encryption cache after rotation', async () => {
+        let currentPassword = OLD_PASSWORD;
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => currentPassword
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+        await db.set('key1', 'value1');
+
+        await db.changePassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+        currentPassword = NEW_PASSWORD;
+
+        const freshDb = levelPrivateStateProvider<string, string>(config);
+        freshDb.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+        const value = await freshDb.get('key1');
+        expect(value).toBe('value1');
+      });
+
+      test('validates new password meets requirements', async () => {
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+        await db.set('key1', 'value1');
+
+        await expect(
+          db.changePassword(() => OLD_PASSWORD, () => 'short')
+        ).rejects.toThrow();
+      });
+
+      test('migrates V1-encrypted data to V2 during rotation', async () => {
+        const V1_MIGRATION_DB = 'midnight-v1-migration-test-db';
+        const PRIVATE_STATE_STORE = 'private-states';
+        const METADATA_KEY = '__midnight_encryption_metadata__';
+
+        await fs.rm(path.join('.', V1_MIGRATION_DB), { recursive: true, force: true });
+
+        const salt = crypto.randomBytes(32);
+        const iv = crypto.randomBytes(12);
+        const testValue = superjson.stringify('v1-test-value');
+
+        const key = crypto.pbkdf2Sync(OLD_PASSWORD, salt, 100000, 32, 'sha256');
+        const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+        const encrypted = Buffer.concat([cipher.update(testValue, 'utf-8'), cipher.final()]);
+        const authTag = cipher.getAuthTag();
+
+        const version = Buffer.from([1]);
+        const v1EncryptedData = Buffer.concat([version, salt, iv, authTag, encrypted]).toString('base64');
+
+        const level = new Level(V1_MIGRATION_DB, { createIfMissing: true });
+        const subLevel = level.sublevel(PRIVATE_STATE_STORE, { valueEncoding: 'utf-8' });
+
+        try {
+          await level.open();
+          await subLevel.open();
+
+          const metadata = { salt: salt.toString('hex'), version: 1 };
+          await subLevel.put(METADATA_KEY, JSON.stringify(metadata));
+          await subLevel.put(`${ROTATION_CONTRACT_ADDRESS}:v1-key`, v1EncryptedData);
+        } finally {
+          await subLevel.close();
+          await level.close();
+        }
+
+        let currentPassword = OLD_PASSWORD;
+        const config = {
+          midnightDbName: V1_MIGRATION_DB,
+          privateStoragePasswordProvider: () => currentPassword
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+
+        const valueBefore = await db.get('v1-key');
+        expect(valueBefore).toBe('v1-test-value');
+
+        await db.changePassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+        currentPassword = NEW_PASSWORD;
+
+        const valueAfter = await db.get('v1-key');
+        expect(valueAfter).toBe('v1-test-value');
+
+        const levelAfter = new Level(V1_MIGRATION_DB, { createIfMissing: false });
+        const subLevelAfter = levelAfter.sublevel(PRIVATE_STATE_STORE, { valueEncoding: 'utf-8' });
+
+        try {
+          await levelAfter.open();
+          await subLevelAfter.open();
+
+          const encryptedAfter = await subLevelAfter.get(`${ROTATION_CONTRACT_ADDRESS}:v1-key`);
+          expect(encryptedAfter).toBeDefined();
+          const bufferAfter = Buffer.from(encryptedAfter as string, 'base64');
+          expect(bufferAfter[0]).toBe(2);
+        } finally {
+          await subLevelAfter.close();
+          await levelAfter.close();
+        }
+
+        await fs.rm(path.join('.', V1_MIGRATION_DB), { recursive: true, force: true });
+      });
+    });
+
+    describe('changeSigningKeysPassword', () => {
+      test('changeSigningKeysPassword method exists on provider', () => {
+        const db = levelPrivateStateProvider<string, string>({
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD
+        });
+
+        expect(typeof db.changeSigningKeysPassword).toBe('function');
+      });
+
+      test('successfully rotates password for signing keys', async () => {
+        let currentPassword = OLD_PASSWORD;
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => currentPassword
+        };
+
+        const signingKey1 = sampleSigningKey();
+        const signingKey2 = sampleSigningKey();
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        await db.setSigningKey('address1' as ContractAddress, signingKey1);
+        await db.setSigningKey('address2' as ContractAddress, signingKey2);
+
+        await db.changeSigningKeysPassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+
+        currentPassword = NEW_PASSWORD;
+
+        const key1 = await db.getSigningKey('address1' as ContractAddress);
+        const key2 = await db.getSigningKey('address2' as ContractAddress);
+        expect(key1).toEqual(signingKey1);
+        expect(key2).toEqual(signingKey2);
+      });
+
+      test('throws error when old password is incorrect', async () => {
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD
+        };
+
+        const signingKey = sampleSigningKey();
+        const db = levelPrivateStateProvider<string, string>(config);
+        await db.setSigningKey('address1' as ContractAddress, signingKey);
+
+        await expect(
+          db.changeSigningKeysPassword(() => 'Wrong-Password-88!', () => NEW_PASSWORD)
+        ).rejects.toThrow();
+
+        const key = await db.getSigningKey('address1' as ContractAddress);
+        expect(key).toEqual(signingKey);
+      });
+
+      test('handles empty signing keys gracefully', async () => {
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+
+        await expect(
+          db.changeSigningKeysPassword(() => OLD_PASSWORD, () => NEW_PASSWORD)
+        ).resolves.not.toThrow();
+      });
+
+      test('does not require contract address to be set', async () => {
+        let currentPassword = OLD_PASSWORD;
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => currentPassword
+        };
+
+        const signingKey = sampleSigningKey();
+        const db = levelPrivateStateProvider<string, string>(config);
+        await db.setSigningKey('address1' as ContractAddress, signingKey);
+
+        await db.changeSigningKeysPassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+        currentPassword = NEW_PASSWORD;
+
+        const key = await db.getSigningKey('address1' as ContractAddress);
+        expect(key).toEqual(signingKey);
+      });
+
+      test('invalidates encryption cache after rotation', async () => {
+        let currentPassword = OLD_PASSWORD;
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => currentPassword
+        };
+
+        const signingKey = sampleSigningKey();
+        const db = levelPrivateStateProvider<string, string>(config);
+        await db.setSigningKey('address1' as ContractAddress, signingKey);
+
+        await db.changeSigningKeysPassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+        currentPassword = NEW_PASSWORD;
+
+        const freshDb = levelPrivateStateProvider<string, string>(config);
+        const key = await freshDb.getSigningKey('address1' as ContractAddress);
+        expect(key).toEqual(signingKey);
+      });
+    });
+
+    describe('Rotation Result', () => {
+      test('changePassword returns entriesMigrated count', async () => {
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+        await db.set('key1', 'value1');
+        await db.set('key2', 'value2');
+        await db.set('key3', 'value3');
+
+        const result = await db.changePassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+
+        expect(result.entriesMigrated).toBe(3);
+      });
+
+      test('changePassword returns zero for empty database', async () => {
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+
+        const result = await db.changePassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+
+        expect(result.entriesMigrated).toBe(0);
+      });
+
+      test('changeSigningKeysPassword returns entriesMigrated count', async () => {
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        await db.setSigningKey('addr1' as ContractAddress, sampleSigningKey());
+        await db.setSigningKey('addr2' as ContractAddress, sampleSigningKey());
+
+        const result = await db.changeSigningKeysPassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+
+        expect(result.entriesMigrated).toBe(2);
+      });
+    });
+
+    describe('Concurrent Access', () => {
+      test('concurrent rotations are serialized correctly', async () => {
+        let currentPassword = OLD_PASSWORD;
+        const SECOND_PASSWORD = 'Second-Password-99!';
+        const THIRD_PASSWORD = 'Third-Password-100!';
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => currentPassword
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+        await db.set('key1', 'value1');
+
+        const rotation1 = db.changePassword(() => OLD_PASSWORD, () => SECOND_PASSWORD);
+        const rotation2 = db.changePassword(() => SECOND_PASSWORD, () => THIRD_PASSWORD);
+
+        await rotation1;
+        await rotation2;
+
+        currentPassword = THIRD_PASSWORD;
+        const value = await db.get('key1');
+        expect(value).toBe('value1');
+      });
+
+      test('remove waits for rotation lock before executing', async () => {
+        let currentPassword = OLD_PASSWORD;
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => currentPassword
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+        await db.set('key1', 'value1');
+        await db.set('key2', 'value2');
+
+        const rotationPromise = db.changePassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+        const removePromise = db.remove('key1');
+
+        await rotationPromise;
+        await removePromise;
+
+        currentPassword = NEW_PASSWORD;
+        const value1 = await db.get('key1');
+        const value2 = await db.get('key2');
+
+        expect(value1).toBeNull();
+        expect(value2).toBe('value2');
+      });
+
+      test('removeSigningKey waits for rotation lock before executing', async () => {
+        let currentPassword = OLD_PASSWORD;
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => currentPassword
+        };
+
+        const signingKey1 = sampleSigningKey();
+        const signingKey2 = sampleSigningKey();
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        await db.setSigningKey('addr1' as ContractAddress, signingKey1);
+        await db.setSigningKey('addr2' as ContractAddress, signingKey2);
+
+        const rotationPromise = db.changeSigningKeysPassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+        const removePromise = db.removeSigningKey('addr1' as ContractAddress);
+
+        await rotationPromise;
+        await removePromise;
+
+        currentPassword = NEW_PASSWORD;
+        const key1 = await db.getSigningKey('addr1' as ContractAddress);
+        const key2 = await db.getSigningKey('addr2' as ContractAddress);
+
+        expect(key1).toBeNull();
+        expect(key2).toEqual(signingKey2);
+      });
+
+      test('get waits for rotation lock before executing', async () => {
+        let currentPassword = OLD_PASSWORD;
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => currentPassword
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+        await db.set('key1', 'value1');
+
+        const rotationPromise = db.changePassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+        currentPassword = NEW_PASSWORD;
+        const getPromise = db.get('key1');
+
+        await rotationPromise;
+        const value = await getPromise;
+
+        expect(value).toBe('value1');
+      });
+
+      test('set waits for rotation lock before executing', async () => {
+        let currentPassword = OLD_PASSWORD;
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => currentPassword
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+        await db.set('key1', 'value1');
+
+        const rotationPromise = db.changePassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+        currentPassword = NEW_PASSWORD;
+        const setPromise = db.set('key2', 'value2');
+
+        await rotationPromise;
+        await setPromise;
+
+        const value1 = await db.get('key1');
+        const value2 = await db.get('key2');
+
+        expect(value1).toBe('value1');
+        expect(value2).toBe('value2');
+      });
+
+      test('getSigningKey waits for rotation lock before executing', async () => {
+        let currentPassword = OLD_PASSWORD;
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => currentPassword
+        };
+
+        const signingKey = sampleSigningKey();
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        await db.setSigningKey('addr1' as ContractAddress, signingKey);
+
+        const rotationPromise = db.changeSigningKeysPassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+        currentPassword = NEW_PASSWORD;
+        const getPromise = db.getSigningKey('addr1' as ContractAddress);
+
+        await rotationPromise;
+        const key = await getPromise;
+
+        expect(key).toEqual(signingKey);
+      });
+
+      test('setSigningKey waits for rotation lock before executing', async () => {
+        let currentPassword = OLD_PASSWORD;
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => currentPassword
+        };
+
+        const signingKey1 = sampleSigningKey();
+        const signingKey2 = sampleSigningKey();
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        await db.setSigningKey('addr1' as ContractAddress, signingKey1);
+
+        const rotationPromise = db.changeSigningKeysPassword(() => OLD_PASSWORD, () => NEW_PASSWORD);
+        currentPassword = NEW_PASSWORD;
+        const setPromise = db.setSigningKey('addr2' as ContractAddress, signingKey2);
+
+        await rotationPromise;
+        await setPromise;
+
+        const key1 = await db.getSigningKey('addr1' as ContractAddress);
+        const key2 = await db.getSigningKey('addr2' as ContractAddress);
+
+        expect(key1).toEqual(signingKey1);
+        expect(key2).toEqual(signingKey2);
+      });
+    });
+
+    describe('Memory Limit', () => {
+      test('throws error when entry count exceeds maxEntries option', async () => {
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+
+        await db.set('key1', 'value1');
+        await db.set('key2', 'value2');
+        await db.set('key3', 'value3');
+        await db.set('key4', 'value4');
+        await db.set('key5', 'value5');
+
+        await expect(
+          db.changePassword(() => OLD_PASSWORD, () => NEW_PASSWORD, { maxEntries: 3 })
+        ).rejects.toThrow(/exceeds maximum allowed/);
+
+        const value = await db.get('key1');
+        expect(value).toBe('value1');
+      });
+
+      test('changeSigningKeysPassword throws error when entry count exceeds limit', async () => {
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+
+        await db.setSigningKey('addr1' as ContractAddress, sampleSigningKey());
+        await db.setSigningKey('addr2' as ContractAddress, sampleSigningKey());
+        await db.setSigningKey('addr3' as ContractAddress, sampleSigningKey());
+        await db.setSigningKey('addr4' as ContractAddress, sampleSigningKey());
+        await db.setSigningKey('addr5' as ContractAddress, sampleSigningKey());
+
+        await expect(
+          db.changeSigningKeysPassword(() => OLD_PASSWORD, () => NEW_PASSWORD, { maxEntries: 3 })
+        ).rejects.toThrow(/exceeds maximum allowed/);
+
+        const key = await db.getSigningKey('addr1' as ContractAddress);
+        expect(key).not.toBeNull();
+      });
+    });
+
+    describe('Early Password Validation', () => {
+      test('fails fast with incorrect old password before iterating all entries', async () => {
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+        await db.set('key1', 'value1');
+
+        await expect(
+          db.changePassword(() => 'Wrong-Password-88!', () => NEW_PASSWORD)
+        ).rejects.toThrow(/incorrect|mismatch|decrypt/i);
+
+        const value = await db.get('key1');
+        expect(value).toBe('value1');
+      });
+
+      test('changeSigningKeysPassword fails fast with incorrect old password', async () => {
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD
+        };
+
+        const signingKey = sampleSigningKey();
+        const db = levelPrivateStateProvider<string, string>(config);
+        await db.setSigningKey('addr1' as ContractAddress, signingKey);
+
+        await expect(
+          db.changeSigningKeysPassword(() => 'Wrong-Password-88!', () => NEW_PASSWORD)
+        ).rejects.toThrow(/incorrect|mismatch|decrypt/i);
+
+        const key = await db.getSigningKey('addr1' as ContractAddress);
+        expect(key).toEqual(signingKey);
+      });
     });
   });
 });

--- a/packages/level-private-state-provider/src/test/storage-encryption.test.ts
+++ b/packages/level-private-state-provider/src/test/storage-encryption.test.ts
@@ -82,11 +82,11 @@ describe('StorageEncryption', () => {
   });
 
   describe('version migration', () => {
-    test('decrypts v1 encrypted data with 100k iterations', () => {
+    test('decrypts v1 encrypted data with 100k iterations using decryptWithPassword', () => {
       const salt = Buffer.from(V1_FIXTURES.salt, 'hex');
       const encryption = new StorageEncryption(V1_FIXTURES.password, salt);
 
-      const decrypted = encryption.decrypt(V1_FIXTURES.encrypted);
+      const decrypted = encryption.decryptWithPassword(V1_FIXTURES.encrypted, V1_FIXTURES.password);
 
       expect(decrypted).toBe(V1_FIXTURES.plaintext);
     });
@@ -115,6 +115,57 @@ describe('StorageEncryption', () => {
       const encryption = new StorageEncryption(testPassword);
       const v2Encrypted = encryption.encrypt(testData);
       expect(StorageEncryption.getVersion(v2Encrypted)).toBe(2);
+    });
+
+    test('decrypt throws when V1 data is encountered without password', () => {
+      const salt = Buffer.from(V1_FIXTURES.salt, 'hex');
+      const encryption = new StorageEncryption(V1_FIXTURES.password, salt);
+
+      expect(() => encryption.decrypt(V1_FIXTURES.encrypted)).toThrow(
+        'V1 encrypted data requires password for decryption'
+      );
+    });
+
+    test('decryptWithPassword works for V2 data as well', () => {
+      const encryption = new StorageEncryption(testPassword);
+
+      const encrypted = encryption.encrypt(testData);
+      const decrypted = encryption.decryptWithPassword(encrypted, testPassword);
+
+      expect(decrypted).toBe(testData);
+    });
+  });
+
+  describe('password verification', () => {
+    test('verifyPassword returns true for correct password', () => {
+      const encryption = new StorageEncryption(testPassword);
+
+      expect(encryption.verifyPassword(testPassword)).toBe(true);
+    });
+
+    test('verifyPassword returns false for incorrect password', () => {
+      const encryption = new StorageEncryption(testPassword);
+
+      expect(encryption.verifyPassword('Wrong-Password-1!')).toBe(false);
+    });
+
+    test('verifyPassword is case-sensitive', () => {
+      const encryption = new StorageEncryption(testPassword);
+
+      expect(encryption.verifyPassword(testPassword.toLowerCase())).toBe(false);
+      expect(encryption.verifyPassword(testPassword.toUpperCase())).toBe(false);
+    });
+
+    test('password is not stored in plaintext', () => {
+      const encryption = new StorageEncryption(testPassword);
+
+      const encryptionAsRecord = encryption as unknown as Record<string, unknown>;
+      const allValues = Object.values(encryptionAsRecord);
+      const hasPlaintextPassword = allValues.some(
+        (value) => value === testPassword
+      );
+
+      expect(hasPlaintextPassword).toBe(false);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2428,7 +2428,7 @@ __metadata:
     "@midnight-ntwrk/ledger-v7": "npm:7.0.2"
     "@midnight-ntwrk/onchain-runtime-v2": "npm:2.0.1"
     "@midnight-ntwrk/wallet-sdk-facade": "npm:2.0.0-rc.1"
-    "@rollup/plugin-commonjs": "npm:^28.0.9"
+    "@rollup/plugin-commonjs": "npm:^29.0.0"
     "@rollup/plugin-node-resolve": "npm:^16.0.3"
     "@rollup/plugin-replace": "npm:^6.0.3"
     "@rollup/plugin-typescript": "npm:^12.3.0"
@@ -3467,9 +3467,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/plugin-commonjs@npm:^28.0.9":
-  version: 28.0.9
-  resolution: "@rollup/plugin-commonjs@npm:28.0.9"
+"@rollup/plugin-commonjs@npm:^29.0.0":
+  version: 29.0.0
+  resolution: "@rollup/plugin-commonjs@npm:29.0.0"
   dependencies:
     "@rollup/pluginutils": "npm:^5.0.1"
     commondir: "npm:^1.0.1"
@@ -3483,7 +3483,7 @@ __metadata:
   peerDependenciesMeta:
     rollup:
       optional: true
-  checksum: 10/68b040339ac4476bc4e75444424e85f9d22726b23e54148b6e22b80c0a06d58b4cd8ccf8c1ccc8e768076b19c9c8474f53e58b11370ecaea2a4de748101bf87a
+  checksum: 10/9abffe07ebdd0aa5d412e7894c370b2c9d2f52e23d415c3e421ff2e05dc662d86f5b681b878463f468020360c477d74cc1476612facba0c5c987cc0b1ec6c06b
   languageName: node
   linkType: hard
 
@@ -13619,15 +13619,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.2":
-  version: 7.5.7
-  resolution: "tar@npm:7.5.7"
+  version: 7.5.9
+  resolution: "tar@npm:7.5.9"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10/0d6938dd32fe5c0f17c8098d92bd9889ee0ed9d11f12381b8146b6e8c87bb5aa49feec7abc42463f0597503d8e89e4c4c0b42bff1a5a38444e918b4878b7fd21
+  checksum: 10/1213cdde9c22d6acf8809ba5d2a025212ce3517bc99c4a4c6981b7dc0489bf3b164db9c826c9517680889194c9ba57448c8ff0da35eca9a60bb7689bf0b3897d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Implement fail fast pattern for cached scoped calls

### Behavior

- Cached states are associated with a specific contract address and optional private state ID
- Accessing cached states with a different identity throws `CacheIdentityMismatchError`
- Batching calls to different contracts or private states within a single scoped transaction is not supported