### PR TITLE
docs: add release notes for v3.2.0

### DIFF
--- a/docs/releases/v3.2.0/README.md
+++ b/docs/releases/v3.2.0/README.md
@@ -1,0 +1,101 @@
+# midnight-js v3.2.0 Release Documentation
+
+**Release Date:** February 26, 2026
+**Previous Version:** v3.1.0
+**Migration Complexity:** Medium
+
+## Quick Links
+
+- [Release Notes](./release-notes.md) - High-level changelog
+- [Breaking Changes](./breaking-changes.md) - Detailed breaking changes
+- [New Features](./new-features.md) - Complete feature documentation
+- [Migration Guide](./migration-guide.md) - Step-by-step upgrade
+- [API Changes](./api-changes.md) - Complete API reference
+
+## Breaking Changes (2)
+
+1. **LevelPrivateStateProvider: `walletProvider` removed** - Must use `privateStoragePasswordProvider` (#528)
+2. **LevelPrivateStateProvider: `accountId` required** - Mandatory for account isolation (#545)
+
+## Security Enhancements (7)
+
+1. Multi-version encryption with 600k PBKDF2 iterations (#530)
+2. Consistent salt generation for race condition prevention (#534)
+3. Encryption caching with invalidation API (#538)
+4. Secure password rotation with atomic writes (#542)
+5. Account-scoped storage isolation (#545)
+6. Scoped transaction identity validation (#555)
+7. CI/CD shell injection fixes (#493)
+
+## New Features (5)
+
+1. Signing key export/import with encryption (#526)
+2. Private state export/import with conflict resolution (#526)
+3. Password rotation APIs for states and keys (#542)
+4. Account migration support (#545)
+5. Mnemonic-based wallet generation in testkit (#524)
+
+## Quick Migration
+
+### Before (v3.1.0)
+```typescript
+import { levelPrivateStateProvider } from '@midnight-ntwrk/level-private-state-provider';
+
+const provider = levelPrivateStateProvider({
+  walletProvider: myWalletProvider
+});
+```
+
+### After (v3.2.0)
+```typescript
+import { levelPrivateStateProvider } from '@midnight-ntwrk/level-private-state-provider';
+
+const provider = levelPrivateStateProvider({
+  privateStoragePasswordProvider: () => process.env.STORAGE_PASSWORD!,
+  accountId: walletAddress // Now required
+});
+```
+
+## Requirements
+
+- **Node.js:** 22+
+- **TypeScript:** 5.0+
+- **Yarn:** 4.10.3 (recommended)
+
+## Dependencies
+
+```json
+{
+  "@midnight-ntwrk/wallet-sdk-facade": "2.0.0-rc.2",
+  "@midnight-ntwrk/compactc": "0.29.0"
+}
+```
+
+## Upgrade Difficulty
+
+| Component | Difficulty |
+|-----------|-----------|
+| LevelPrivateStateProvider config | Medium |
+| Account-scoped migration | Low (automatic) |
+| Encryption version migration | None (automatic) |
+
+## Testing Checklist
+
+- [ ] TypeScript compilation passes
+- [ ] Unit tests pass
+- [ ] Integration tests pass
+- [ ] Private state encryption works
+- [ ] Account isolation verified
+- [ ] Password rotation works
+- [ ] Export/import functionality works
+
+## Support
+
+- [GitHub Issues](https://github.com/midnightntwrk/midnight-js/issues)
+- [GitHub Discussions](https://github.com/midnightntwrk/midnight-js/discussions)
+- [Documentation](https://docs.midnight.network/)
+
+---
+
+**Last Updated:** February 26, 2026
+**License:** Apache-2.0

--- a/docs/releases/v3.2.0/api-changes.md
+++ b/docs/releases/v3.2.0/api-changes.md
@@ -1,0 +1,417 @@
+# API Changes Reference v3.2.0
+
+## Package: @midnight-ntwrk/level-private-state-provider
+
+### Modified Exports
+
+#### LevelPrivateStateProviderConfig
+
+**v3.1.0:**
+```typescript
+interface LevelPrivateStateProviderConfig {
+  readonly midnightDbName?: string;
+  readonly privateStateStoreName?: string;
+  readonly signingKeyStoreName?: string;
+  readonly walletProvider?: WalletProvider; // Supported
+  readonly privateStoragePasswordProvider?: PrivateStoragePasswordProvider;
+}
+```
+
+**v3.2.0:**
+```typescript
+interface LevelPrivateStateProviderConfig {
+  readonly midnightDbName?: string;
+  readonly privateStateStoreName?: string;
+  readonly signingKeyStoreName?: string;
+  // walletProvider REMOVED
+  readonly privateStoragePasswordProvider: PrivateStoragePasswordProvider; // Required
+  readonly accountId: string; // NEW - Required
+}
+```
+
+**Breaking:** `walletProvider` removed, `privateStoragePasswordProvider` and `accountId` now required.
+
+### New Exports
+
+#### migrateToAccountScoped (#545)
+
+```typescript
+function migrateToAccountScoped(options: {
+  accountId: string;
+  midnightDbName?: string;
+  privateStateStoreName?: string;
+  signingKeyStoreName?: string;
+}): Promise<MigrationResult>;
+
+interface MigrationResult {
+  privateStatesMigrated: number;
+  signingKeysMigrated: number;
+}
+```
+
+**Usage:**
+```typescript
+import { migrateToAccountScoped } from '@midnight-ntwrk/level-private-state-provider';
+
+const result = await migrateToAccountScoped({ accountId: walletAddress });
+```
+
+#### PasswordRotationOptions / PasswordRotationResult (#542)
+
+```typescript
+interface PasswordRotationOptions {
+  maxEntries?: number;
+  timeout?: number;
+}
+
+interface PasswordRotationResult {
+  entriesProcessed: number;
+  entriesMigrated: number;
+}
+```
+
+### New Methods on LevelPrivateStateProvider
+
+#### changePassword (#542)
+
+```typescript
+changePassword(
+  oldPasswordProvider: PrivateStoragePasswordProvider,
+  newPasswordProvider: PrivateStoragePasswordProvider,
+  options?: PasswordRotationOptions
+): Promise<PasswordRotationResult>;
+```
+
+#### changeSigningKeysPassword (#542)
+
+```typescript
+changeSigningKeysPassword(
+  oldPasswordProvider: PrivateStoragePasswordProvider,
+  newPasswordProvider: PrivateStoragePasswordProvider,
+  options?: PasswordRotationOptions
+): Promise<PasswordRotationResult>;
+```
+
+#### invalidateEncryptionCache (#538)
+
+```typescript
+invalidateEncryptionCache(): void;
+```
+
+#### exportPrivateStates (#526)
+
+```typescript
+exportPrivateStates(options?: ExportPrivateStatesOptions): Promise<PrivateStateExport>;
+```
+
+#### importPrivateStates (#526)
+
+```typescript
+importPrivateStates(
+  exportData: PrivateStateExport,
+  options?: ImportPrivateStatesOptions
+): Promise<ImportPrivateStatesResult>;
+```
+
+#### exportSigningKeys (#526)
+
+```typescript
+exportSigningKeys(options?: ExportSigningKeysOptions): Promise<SigningKeyExport>;
+```
+
+#### importSigningKeys (#526)
+
+```typescript
+importSigningKeys(
+  exportData: SigningKeyExport,
+  options?: ImportSigningKeysOptions
+): Promise<ImportSigningKeysResult>;
+```
+
+---
+
+## Package: @midnight-ntwrk/midnight-js-types
+
+### New Types (#526)
+
+#### PrivateStateExport
+
+```typescript
+interface PrivateStateExport {
+  readonly format: 'midnight-private-state-export';
+  readonly encryptedPayload: string;
+  readonly salt: string;
+}
+```
+
+#### SigningKeyExport
+
+```typescript
+interface SigningKeyExport {
+  readonly format: 'midnight-signing-key-export';
+  readonly encryptedPayload: string;
+  readonly salt: string;
+}
+```
+
+#### ExportPrivateStatesOptions
+
+```typescript
+interface ExportPrivateStatesOptions {
+  readonly password?: string;
+  readonly maxStates?: number;
+}
+```
+
+#### ImportPrivateStatesOptions
+
+```typescript
+interface ImportPrivateStatesOptions {
+  readonly password?: string;
+  readonly conflictStrategy?: 'skip' | 'overwrite' | 'error';
+  readonly maxStates?: number;
+}
+```
+
+#### ImportPrivateStatesResult
+
+```typescript
+interface ImportPrivateStatesResult {
+  readonly imported: number;
+  readonly skipped: number;
+  readonly overwritten: number;
+}
+```
+
+#### ExportSigningKeysOptions
+
+```typescript
+interface ExportSigningKeysOptions {
+  readonly password?: string;
+  readonly maxKeys?: number;
+}
+```
+
+#### ImportSigningKeysOptions
+
+```typescript
+interface ImportSigningKeysOptions {
+  readonly password?: string;
+  readonly conflictStrategy?: 'skip' | 'overwrite' | 'error';
+  readonly maxKeys?: number;
+}
+```
+
+#### ImportSigningKeysResult
+
+```typescript
+interface ImportSigningKeysResult {
+  readonly imported: number;
+  readonly skipped: number;
+  readonly overwritten: number;
+}
+```
+
+### New Error Classes
+
+#### PrivateStateExportError
+
+```typescript
+class PrivateStateExportError extends Error {
+  constructor(message: string);
+}
+```
+
+#### SigningKeyExportError
+
+```typescript
+class SigningKeyExportError extends Error {
+  constructor(message: string);
+}
+```
+
+#### PrivateStateImportError
+
+```typescript
+type PrivateStateImportErrorCause = 'decryption_failed' | 'invalid_format' | 'conflict' | 'unknown';
+
+class PrivateStateImportError extends Error {
+  readonly cause?: PrivateStateImportErrorCause;
+  constructor(message: string, cause?: PrivateStateImportErrorCause);
+}
+```
+
+#### ExportDecryptionError
+
+```typescript
+class ExportDecryptionError extends PrivateStateImportError {
+  constructor(); // Fixed message about wrong password or corrupted data
+}
+```
+
+#### InvalidExportFormatError
+
+```typescript
+class InvalidExportFormatError extends PrivateStateImportError {
+  constructor(message?: string);
+}
+```
+
+#### ImportConflictError
+
+```typescript
+class ImportConflictError extends PrivateStateImportError {
+  readonly conflictCount: number;
+  constructor(conflictCount: number, entityName?: string);
+}
+```
+
+### Constants
+
+```typescript
+const MAX_EXPORT_STATES = 10000;
+const MAX_EXPORT_SIGNING_KEYS = 10000;
+```
+
+---
+
+## Package: @midnight-ntwrk/midnight-js-contracts
+
+### New Error Classes (#555)
+
+#### ScopedTransactionIdentityMismatchError
+
+```typescript
+class ScopedTransactionIdentityMismatchError extends Error {
+  readonly cached: { contractAddress: string; privateStateId?: PrivateStateId };
+  readonly requested: { contractAddress: string; privateStateId?: PrivateStateId };
+
+  constructor(
+    cached: { contractAddress: string; privateStateId?: PrivateStateId },
+    requested: { contractAddress: string; privateStateId?: PrivateStateId }
+  );
+}
+```
+
+**Usage context:** Thrown when `withContractScopedTransaction` detects a mismatch between cached states and the requested contract identity.
+
+---
+
+## Package: @midnight-ntwrk/testkit
+
+### New Exports (#524)
+
+#### fromMnemonic
+
+```typescript
+function fromMnemonic(mnemonic: string): Wallet;
+```
+
+### FluentWalletBuilder New Methods (#524)
+
+```typescript
+class FluentWalletBuilder {
+  withMnemonic(mnemonic: string): FluentWalletBuilder;
+  withTestWallet(): FluentWalletBuilder;
+}
+```
+
+---
+
+## Package: @midnight-ntwrk/compact
+
+### Removed Parameters (#523)
+
+#### fetchCompact
+
+**v3.1.0:**
+```typescript
+interface FetchCompactOptions {
+  uri: string;
+  authToken?: string; // Supported
+}
+```
+
+**v3.2.0:**
+```typescript
+interface FetchCompactOptions {
+  uri: string;
+  // authToken REMOVED
+}
+```
+
+---
+
+## Complete API Diff by Package
+
+### @midnight-ntwrk/level-private-state-provider
+
+```diff
+  interface LevelPrivateStateProviderConfig {
+    readonly midnightDbName?: string;
+    readonly privateStateStoreName?: string;
+    readonly signingKeyStoreName?: string;
+-   readonly walletProvider?: WalletProvider;
+-   readonly privateStoragePasswordProvider?: PrivateStoragePasswordProvider;
++   readonly privateStoragePasswordProvider: PrivateStoragePasswordProvider;
++   readonly accountId: string;
+  }
+
++ function migrateToAccountScoped(options): Promise<MigrationResult>;
++ interface MigrationResult { ... }
++ interface PasswordRotationOptions { ... }
++ interface PasswordRotationResult { ... }
+
+  // New methods on provider instance
++ changePassword(...): Promise<PasswordRotationResult>;
++ changeSigningKeysPassword(...): Promise<PasswordRotationResult>;
++ invalidateEncryptionCache(): void;
++ exportPrivateStates(...): Promise<PrivateStateExport>;
++ importPrivateStates(...): Promise<ImportPrivateStatesResult>;
++ exportSigningKeys(...): Promise<SigningKeyExport>;
++ importSigningKeys(...): Promise<ImportSigningKeysResult>;
+```
+
+### @midnight-ntwrk/midnight-js-types
+
+```diff
++ interface PrivateStateExport { ... }
++ interface SigningKeyExport { ... }
++ interface ExportPrivateStatesOptions { ... }
++ interface ImportPrivateStatesOptions { ... }
++ interface ImportPrivateStatesResult { ... }
++ interface ExportSigningKeysOptions { ... }
++ interface ImportSigningKeysOptions { ... }
++ interface ImportSigningKeysResult { ... }
++ class PrivateStateExportError extends Error { ... }
++ class SigningKeyExportError extends Error { ... }
++ class PrivateStateImportError extends Error { ... }
++ class ExportDecryptionError extends PrivateStateImportError { ... }
++ class InvalidExportFormatError extends PrivateStateImportError { ... }
++ class ImportConflictError extends PrivateStateImportError { ... }
++ const MAX_EXPORT_STATES = 10000;
++ const MAX_EXPORT_SIGNING_KEYS = 10000;
+```
+
+### @midnight-ntwrk/midnight-js-contracts
+
+```diff
++ class ScopedTransactionIdentityMismatchError extends Error { ... }
+```
+
+### @midnight-ntwrk/testkit
+
+```diff
++ function fromMnemonic(mnemonic: string): Wallet;
++ FluentWalletBuilder.withMnemonic(mnemonic: string): FluentWalletBuilder;
++ FluentWalletBuilder.withTestWallet(): FluentWalletBuilder;
+```
+
+### @midnight-ntwrk/compact
+
+```diff
+  interface FetchCompactOptions {
+    uri: string;
+-   authToken?: string;
+  }
+```

--- a/docs/releases/v3.2.0/breaking-changes.md
+++ b/docs/releases/v3.2.0/breaking-changes.md
@@ -1,0 +1,158 @@
+# Breaking Changes v3.2.0
+
+## 1. LevelPrivateStateProvider: `walletProvider` Option Removed (#528)
+
+### Reason
+Simplified configuration by consolidating authentication to a single method. Using `privateStoragePasswordProvider` provides clearer separation of concerns and more predictable encryption behavior.
+
+### Impact
+All `levelPrivateStateProvider` instantiations using `walletProvider` must be migrated to use `privateStoragePasswordProvider`.
+
+### Before
+```typescript
+import { levelPrivateStateProvider } from '@midnight-ntwrk/level-private-state-provider';
+
+const provider = levelPrivateStateProvider({
+  walletProvider: myWalletProvider
+});
+```
+
+### After
+```typescript
+import { levelPrivateStateProvider } from '@midnight-ntwrk/level-private-state-provider';
+
+const provider = levelPrivateStateProvider({
+  privateStoragePasswordProvider: () => process.env.STORAGE_PASSWORD!,
+  accountId: walletAddress
+});
+```
+
+### Migration Steps
+1. Remove `walletProvider` from configuration
+2. Add `privateStoragePasswordProvider` function that returns the encryption password
+3. Add `accountId` (typically the wallet address) for account isolation
+4. Ensure password meets requirements (16+ chars, 3+ character types)
+
+---
+
+## 2. LevelPrivateStateProvider: `accountId` Now Required (#545)
+
+### Reason
+Account-scoped isolation ensures data separation between different wallet accounts. This prevents data leakage and provides a clear namespace for each user's private states and signing keys.
+
+### Impact
+The `accountId` configuration option is now mandatory. Storage paths are namespaced using a SHA-256 hash of the account ID.
+
+### Before
+```typescript
+const provider = levelPrivateStateProvider({
+  privateStoragePasswordProvider: () => 'password'
+  // accountId was optional
+});
+```
+
+### After
+```typescript
+const provider = levelPrivateStateProvider({
+  privateStoragePasswordProvider: () => 'password',
+  accountId: walletAddress // Required
+});
+```
+
+### Migration Steps
+1. Add `accountId` to all `levelPrivateStateProvider` configurations
+2. Use a stable identifier (wallet address recommended)
+3. For existing data, use `migrateToAccountScoped()` to transition:
+
+```typescript
+import { migrateToAccountScoped } from '@midnight-ntwrk/level-private-state-provider';
+
+const result = await migrateToAccountScoped({ accountId: walletAddress });
+console.log(`Migrated ${result.privateStatesMigrated} private states`);
+console.log(`Migrated ${result.signingKeysMigrated} signing keys`);
+```
+
+### Storage Structure Change
+
+**Before (v3.1.0):**
+```
+LevelDB (midnight-level-db)
+├── private-states
+│   └── {contractAddress}:{privateStateId}
+└── signing-keys
+    └── {contractAddress}
+```
+
+**After (v3.2.0):**
+```
+LevelDB (midnight-level-db)
+├── private-states:{hashedAccountId}
+│   ├── __midnight_encryption_metadata__
+│   └── {contractAddress}:{privateStateId}
+└── signing-keys:{hashedAccountId}
+    ├── __midnight_encryption_metadata__
+    └── {contractAddress}
+```
+
+---
+
+## 3. Auth Token Removed from Compact Fetch (#523)
+
+### Reason
+Authentication is no longer required for fetching compiled contracts, simplifying the integration process.
+
+### Impact
+The `authToken` parameter has been removed from compact fetch operations. Any code passing auth tokens will need to be updated.
+
+### Before
+```typescript
+// v3.1.0 - auth token was supported
+const compiled = await fetchCompact({
+  uri: 'https://...',
+  authToken: 'my-token' // This option existed
+});
+```
+
+### After
+```typescript
+// v3.2.0 - auth token removed
+const compiled = await fetchCompact({
+  uri: 'https://...'
+  // authToken no longer supported
+});
+```
+
+### Migration Steps
+1. Remove `authToken` from any `fetchCompact` calls
+2. If authentication is still required by your infrastructure, handle it at the network/proxy level
+
+---
+
+## Common Migration Issues
+
+### Issue: Password Requirements Not Met
+**Error:** `Password does not meet security requirements`
+**Solution:** Ensure password has:
+- Minimum 16 characters
+- At least 3 character types (uppercase, lowercase, digits, special)
+- No more than 3 consecutive identical characters
+- No sequential patterns (e.g., `1234`, `abcd`)
+
+### Issue: Account ID Not Provided
+**Error:** `accountId is required for LevelPrivateStateProvider`
+**Solution:** Add `accountId` to configuration, typically using the wallet address.
+
+### Issue: Existing Data Not Accessible
+**Solution:** Run `migrateToAccountScoped()` to move data to account-scoped storage:
+```typescript
+const result = await migrateToAccountScoped({ accountId: walletAddress });
+```
+
+### Issue: V1 Encrypted Data After Upgrade
+**Solution:** V1 data is automatically migrated to V2 on read. For explicit migration, use password rotation:
+```typescript
+await provider.changePassword(
+  () => 'current-password',
+  () => 'same-or-new-password'
+);
+```

--- a/docs/releases/v3.2.0/migration-guide.md
+++ b/docs/releases/v3.2.0/migration-guide.md
@@ -1,0 +1,277 @@
+# Migration Guide v3.1.0 to v3.2.0
+
+## Overview
+
+This guide covers migrating from midnight-js v3.1.0 to v3.2.0. The main changes involve:
+1. LevelPrivateStateProvider configuration changes
+2. Account-scoped storage migration
+3. Auth token removal from compact fetch
+
+## Step 1: Update Dependencies
+
+```bash
+yarn upgrade @midnight-ntwrk/level-private-state-provider@^3.2.0
+yarn upgrade @midnight-ntwrk/midnight-js-contracts@^3.2.0
+yarn upgrade @midnight-ntwrk/midnight-js-types@^3.2.0
+yarn upgrade @midnight-ntwrk/compact@^3.2.0
+```
+
+## Step 2: Update LevelPrivateStateProvider Configuration
+
+### 2.1 Replace walletProvider with privateStoragePasswordProvider
+
+**Before (v3.1.0):**
+```typescript
+import { levelPrivateStateProvider } from '@midnight-ntwrk/level-private-state-provider';
+
+const provider = levelPrivateStateProvider({
+  walletProvider: myWalletProvider
+});
+```
+
+**After (v3.2.0):**
+```typescript
+import { levelPrivateStateProvider } from '@midnight-ntwrk/level-private-state-provider';
+
+const provider = levelPrivateStateProvider({
+  privateStoragePasswordProvider: () => process.env.STORAGE_PASSWORD!,
+  accountId: walletAddress
+});
+```
+
+### 2.2 Password Requirements
+
+Ensure your password meets these requirements:
+- Minimum 16 characters
+- At least 3 character types (uppercase, lowercase, digits, special)
+- No more than 3 consecutive identical characters
+- No sequential patterns (e.g., `1234`, `abcd`)
+
+Example of a compliant password function:
+```typescript
+const privateStoragePasswordProvider = () => {
+  const password = process.env.STORAGE_PASSWORD;
+  if (!password || password.length < 16) {
+    throw new Error('Storage password must be at least 16 characters');
+  }
+  return password;
+};
+```
+
+### 2.3 Choose Account ID
+
+The `accountId` should be a stable, unique identifier for each user:
+```typescript
+// Recommended: Use wallet address
+const accountId = walletAddress;
+
+// Alternative: Use user ID from your auth system
+const accountId = user.id;
+```
+
+## Step 3: Migrate Existing Data to Account-Scoped Storage
+
+If you have existing data from v3.1.0, migrate it to account-scoped storage:
+
+```typescript
+import { migrateToAccountScoped } from '@midnight-ntwrk/level-private-state-provider';
+
+async function migrateExistingData(walletAddress: string) {
+  try {
+    const result = await migrateToAccountScoped({
+      accountId: walletAddress
+    });
+
+    console.log(`Migration complete:`);
+    console.log(`  Private states: ${result.privateStatesMigrated}`);
+    console.log(`  Signing keys: ${result.signingKeysMigrated}`);
+
+    return result;
+  } catch (error) {
+    console.error('Migration failed:', error);
+    throw error;
+  }
+}
+
+// Run migration before creating provider
+await migrateExistingData(walletAddress);
+
+const provider = levelPrivateStateProvider({
+  privateStoragePasswordProvider: () => password,
+  accountId: walletAddress
+});
+```
+
+### Migration Notes
+- Original data is preserved (not deleted) for rollback capability
+- Migration is idempotent - running it multiple times is safe
+- Migration handles both private states and signing keys
+
+## Step 4: Remove Auth Token from Compact Fetch
+
+If you're using `fetchCompact` with an auth token, remove it:
+
+**Before (v3.1.0):**
+```typescript
+const compiled = await fetchCompact({
+  uri: 'https://example.com/contract',
+  authToken: 'my-auth-token'
+});
+```
+
+**After (v3.2.0):**
+```typescript
+const compiled = await fetchCompact({
+  uri: 'https://example.com/contract'
+});
+```
+
+If authentication is still required, handle it at the infrastructure level (proxy, API gateway, etc.).
+
+## Step 5: Update Error Handling (Optional)
+
+Add handling for new error types if using export/import or scoped transactions:
+
+```typescript
+import {
+  ExportDecryptionError,
+  InvalidExportFormatError,
+  ImportConflictError,
+  ScopedTransactionIdentityMismatchError
+} from '@midnight-ntwrk/midnight-js-types';
+
+try {
+  await provider.importPrivateStates(exportData, { password });
+} catch (error) {
+  if (error instanceof ExportDecryptionError) {
+    console.error('Wrong password or corrupted data');
+  } else if (error instanceof InvalidExportFormatError) {
+    console.error('Invalid export format');
+  } else if (error instanceof ImportConflictError) {
+    console.error(`${error.conflictCount} conflicts detected`);
+  }
+}
+
+try {
+  await withContractScopedTransaction(providers, async (scope) => {
+    // ...
+  });
+} catch (error) {
+  if (error instanceof ScopedTransactionIdentityMismatchError) {
+    console.error(`Cannot batch calls to different contracts`);
+    console.error(`Cached: ${error.cached.contractAddress}`);
+    console.error(`Requested: ${error.requested.contractAddress}`);
+  }
+}
+```
+
+## Step 6: Leverage New Features (Optional)
+
+### 6.1 Export/Import for Backup
+
+```typescript
+// Export signing keys for backup
+const keysBackup = await provider.exportSigningKeys({
+  password: 'backup-password'
+});
+fs.writeFileSync('keys-backup.json', JSON.stringify(keysBackup));
+
+// Later, restore from backup
+const backup = JSON.parse(fs.readFileSync('keys-backup.json', 'utf-8'));
+await provider.importSigningKeys(backup, {
+  password: 'backup-password',
+  conflictStrategy: 'skip'
+});
+```
+
+### 6.2 Password Rotation
+
+```typescript
+// Rotate password periodically for security
+await provider.changePassword(
+  () => currentPassword,
+  () => newPassword
+);
+```
+
+### 6.3 Encryption Cache Management
+
+```typescript
+// Invalidate cache if password changes externally
+provider.invalidateEncryptionCache();
+```
+
+## Step 7: Testing
+
+Run your test suite to verify the migration:
+
+```bash
+yarn test
+```
+
+### Test Checklist
+
+- [ ] Provider initialization works with new config
+- [ ] Private states can be read/written
+- [ ] Signing keys can be read/written
+- [ ] Contract deployment works
+- [ ] Contract calls work
+- [ ] Scoped transactions work
+- [ ] (If applicable) Data migrated successfully
+
+## Troubleshooting
+
+### Error: "accountId is required"
+
+Add `accountId` to your provider configuration:
+```typescript
+levelPrivateStateProvider({
+  privateStoragePasswordProvider: () => password,
+  accountId: walletAddress // Add this
+});
+```
+
+### Error: "Password does not meet security requirements"
+
+Ensure your password has:
+- 16+ characters
+- At least 3 types: uppercase, lowercase, digits, special characters
+
+### Error: "Failed to decrypt"
+
+This can happen if:
+1. Wrong password provided
+2. Data was encrypted with a different password
+3. Data is corrupted
+
+If migrating from v3.1.0, ensure you're using the same password as before.
+
+### Existing data not accessible after upgrade
+
+Run the migration utility:
+```typescript
+await migrateToAccountScoped({ accountId: walletAddress });
+```
+
+### Performance degradation after upgrade
+
+V2 encryption uses 600,000 PBKDF2 iterations vs 100,000 in V1. This is intentional for security. The encryption cache mitigates repeated operations:
+- First operation: ~1-2 seconds for key derivation
+- Subsequent operations: Instant (cached)
+
+If cache is being invalidated unexpectedly, check for:
+- Password provider returning different values
+- Explicit `invalidateEncryptionCache()` calls
+
+## Rollback Plan
+
+If you need to rollback to v3.1.0:
+
+1. The migration preserves original data, so v3.1.0 can still access it
+2. Downgrade packages:
+   ```bash
+   yarn add @midnight-ntwrk/level-private-state-provider@3.1.0
+   ```
+3. Revert configuration to use `walletProvider` if previously used
+
+Note: Data written with v3.2.0 (V2 encryption) cannot be read by v3.1.0.

--- a/docs/releases/v3.2.0/new-features.md
+++ b/docs/releases/v3.2.0/new-features.md
@@ -1,0 +1,265 @@
+# New Features v3.2.0
+
+## 1. Multi-Version Encryption (#530)
+
+Enhanced encryption with versioned format and increased security.
+
+### V2 Encryption Specifications
+
+| Parameter          | V1 (Legacy)    | V2 (Current)   |
+| ------------------ | -------------- | -------------- |
+| Algorithm          | AES-256-GCM    | AES-256-GCM    |
+| Key Derivation     | PBKDF2-SHA256  | PBKDF2-SHA256  |
+| Iterations         | 100,000        | **600,000**    |
+| Salt Length        | 32 bytes       | 32 bytes       |
+| IV Length          | 12 bytes       | 12 bytes       |
+| Auth Tag Length    | 16 bytes       | 16 bytes       |
+
+### Automatic Migration
+V1-encrypted data is automatically migrated to V2 when read or during password rotation.
+
+---
+
+## 2. Signing Key Export/Import (#526)
+
+Export and import signing keys with AES-256-GCM encryption.
+
+### Export Signing Keys
+```typescript
+const keysExport = await provider.exportSigningKeys({
+  password: 'export-password' // Optional, uses storage password if not provided
+});
+
+// Save to file
+fs.writeFileSync('keys-backup.json', JSON.stringify(keysExport));
+```
+
+### Import Signing Keys
+```typescript
+const keysExport = JSON.parse(fs.readFileSync('keys-backup.json', 'utf-8'));
+
+const result = await provider.importSigningKeys(keysExport, {
+  password: 'export-password',
+  conflictStrategy: 'skip' // 'skip' | 'overwrite' | 'error'
+});
+
+console.log(`Imported: ${result.imported}`);
+console.log(`Skipped: ${result.skipped}`);
+console.log(`Overwritten: ${result.overwritten}`);
+```
+
+### Export Format
+```typescript
+interface SigningKeyExport {
+  format: 'midnight-signing-key-export';
+  encryptedPayload: string; // Base64 AES-256-GCM encrypted JSON
+  salt: string; // Hex-encoded 32 bytes
+}
+```
+
+---
+
+## 3. Private State Export/Import (#526)
+
+Export and import private states with the same security features.
+
+### Export Private States
+```typescript
+provider.setContractAddress(contractAddress);
+
+const statesExport = await provider.exportPrivateStates({
+  password: 'export-password',
+  maxStates: 1000 // Optional limit, defaults to 10000
+});
+```
+
+### Import Private States
+```typescript
+const result = await provider.importPrivateStates(statesExport, {
+  password: 'export-password',
+  conflictStrategy: 'overwrite',
+  maxStates: 1000
+});
+```
+
+### Export Format
+```typescript
+interface PrivateStateExport {
+  format: 'midnight-private-state-export';
+  encryptedPayload: string;
+  salt: string;
+}
+```
+
+---
+
+## 4. Secure Password Rotation (#542)
+
+Rotate encryption passwords with atomic batch writes and automatic V1 to V2 migration.
+
+### Rotate Private State Password
+```typescript
+provider.setContractAddress(contractAddress);
+
+const result = await provider.changePassword(
+  () => 'old-password',
+  () => 'new-password',
+  { maxEntries: 1000 } // Optional limit
+);
+
+console.log(`Re-encrypted: ${result.entriesProcessed}`);
+console.log(`Migrated V1→V2: ${result.entriesMigrated}`);
+```
+
+### Rotate Signing Keys Password
+```typescript
+const result = await provider.changeSigningKeysPassword(
+  () => 'old-password',
+  () => 'new-password'
+);
+```
+
+### Password Rotation Options
+```typescript
+interface PasswordRotationOptions {
+  maxEntries?: number;   // Limit entries to process (default: unlimited)
+  timeout?: number;      // Lock timeout in ms (default: 5 minutes)
+}
+
+interface PasswordRotationResult {
+  entriesProcessed: number;
+  entriesMigrated: number; // V1→V2 migrations
+}
+```
+
+### Concurrency Safety
+- Rotation locks prevent concurrent read/write during password change
+- Lock timeout defaults to 5 minutes
+- Operations wait for rotation to complete before proceeding
+
+---
+
+## 5. Account-Scoped Storage Isolation (#545)
+
+Each account gets isolated storage namespaces for enhanced security and data separation.
+
+### Configuration
+```typescript
+const provider = levelPrivateStateProvider({
+  privateStoragePasswordProvider: () => 'password',
+  accountId: walletAddress // SHA-256 hashed for storage paths
+});
+```
+
+### Storage Structure
+```
+LevelDB (midnight-level-db)
+├── private-states:{hashedAccountId}
+│   ├── __midnight_encryption_metadata__
+│   └── {contractAddress}:{privateStateId}
+└── signing-keys:{hashedAccountId}
+    ├── __midnight_encryption_metadata__
+    └── {contractAddress}
+```
+
+### Migration from Unscoped Storage
+```typescript
+import { migrateToAccountScoped } from '@midnight-ntwrk/level-private-state-provider';
+
+const result = await migrateToAccountScoped({
+  accountId: walletAddress,
+  // Optional: custom database name
+  midnightDbName: 'midnight-level-db'
+});
+
+console.log(`Private states migrated: ${result.privateStatesMigrated}`);
+console.log(`Signing keys migrated: ${result.signingKeysMigrated}`);
+```
+
+---
+
+## 6. Encryption Cache Management (#538)
+
+Encryption keys are cached to avoid repeated PBKDF2 derivation (600,000 iterations).
+
+### Manual Cache Invalidation
+```typescript
+provider.invalidateEncryptionCache();
+```
+
+### Automatic Invalidation
+Cache is automatically invalidated:
+- After `changePassword()` completes
+- After `changeSigningKeysPassword()` completes
+
+---
+
+## 7. Scoped Transaction Identity Validation (#555)
+
+Prevents silent state mismatches when batching contract calls.
+
+### New Error Type
+```typescript
+class ScopedTransactionIdentityMismatchError extends Error {
+  readonly cached: { contractAddress: string; privateStateId?: string };
+  readonly requested: { contractAddress: string; privateStateId?: string };
+}
+```
+
+### How It Works
+When using `withContractScopedTransaction`, the system tracks which contract and private state ID the cached states belong to. If a subsequent call attempts to use a different contract or state ID, an error is thrown.
+
+```typescript
+import { withContractScopedTransaction } from '@midnight-ntwrk/midnight-js-contracts';
+
+// This will throw ScopedTransactionIdentityMismatchError
+await withContractScopedTransaction(providers, async (scope) => {
+  await scope.call(contractA, 'circuit1', [args]); // Caches states for contractA
+  await scope.call(contractB, 'circuit2', [args]); // Error: different contract
+});
+```
+
+---
+
+## 8. Mnemonic-Based Wallet in Testkit (#524)
+
+New helpers for creating wallets from mnemonics in test environments.
+
+### Using Custom Mnemonic
+```typescript
+import { FluentWalletBuilder } from '@midnight-ntwrk/testkit';
+
+const wallet = new FluentWalletBuilder()
+  .withMnemonic('abandon abandon abandon ... about')
+  .build();
+```
+
+### Using Predefined Test Wallet
+```typescript
+const testWallet = new FluentWalletBuilder()
+  .withTestWallet()
+  .build();
+```
+
+### Direct Helper Function
+```typescript
+import { fromMnemonic } from '@midnight-ntwrk/testkit';
+
+const wallet = fromMnemonic('your mnemonic phrase here');
+```
+
+---
+
+## 9. Browser Storage Warning (#526)
+
+Automatic console warning when using LevelDB in browser environments.
+
+### Warning Message
+```
+WARNING: Using LevelDB in browser environment.
+Data is stored in IndexedDB and may be lost if the user clears browser data.
+Consider implementing a backup/export strategy for important data.
+```
+
+### Environment Detection
+The warning triggers when both `window` and `document` are defined, indicating a browser environment.

--- a/docs/releases/v3.2.0/release-notes.md
+++ b/docs/releases/v3.2.0/release-notes.md
@@ -1,0 +1,202 @@
+# Release Notes v3.2.0
+
+**Release Date:** February 26, 2026
+**Previous Version:** v3.1.0
+**Node.js Requirement:** >=22
+
+## Breaking Changes
+
+### LevelPrivateStateProvider: `walletProvider` Option Removed (#528)
+The `walletProvider` configuration option has been removed. All instances must now use `privateStoragePasswordProvider`.
+
+- **Before:** `levelPrivateStateProvider({ walletProvider: myWallet })`
+- **After:** `levelPrivateStateProvider({ privateStoragePasswordProvider: () => 'password', accountId: 'wallet-address' })`
+
+```typescript
+import { levelPrivateStateProvider } from '@midnight-ntwrk/level-private-state-provider';
+
+// v3.2.0 - walletProvider no longer supported
+const provider = levelPrivateStateProvider({
+  privateStoragePasswordProvider: () => process.env.STORAGE_PASSWORD!,
+  accountId: walletAddress
+});
+```
+
+### LevelPrivateStateProvider: `accountId` Now Required (#545)
+The `accountId` configuration option is now mandatory for account-scoped data isolation.
+
+```typescript
+const provider = levelPrivateStateProvider({
+  privateStoragePasswordProvider: () => 'password',
+  accountId: walletAddress // Required - provides data isolation between accounts
+});
+```
+
+### Auth Token Removed from Compact Fetch (#523)
+The `authToken` parameter has been removed from compact fetch operations. Authentication is no longer required for fetching compiled contracts.
+
+## Security Enhancements
+
+### Multi-Version Encryption with Increased PBKDF2 Iterations (#530)
+- V2 encryption now uses **600,000 PBKDF2 iterations** (up from 100,000 in V1)
+- Automatic migration from V1 to V2 during password rotation
+- Enhanced password validation with character class and pattern checks
+
+### Consistent Salt Generation (#534)
+- New `getOrCreateSalt` utility prevents race conditions in private state operations
+- Salt consistency guaranteed across sequential operations
+- Prevents cryptographic issues from concurrent access
+
+### Encryption Caching and Invalidation (#538)
+- Encryption keys are cached to avoid repeated PBKDF2 derivation
+- New `invalidateEncryptionCache()` API for cache management
+- Automatic cache invalidation after password rotation
+
+### Secure Password Rotation (#542)
+- New `changePassword()` method for private states
+- New `changeSigningKeysPassword()` method for signing keys
+- Atomic batch writes ensure all-or-nothing re-encryption
+- Rotation locks for safe concurrent read/write operations
+- Automatic V1 to V2 migration during rotation
+
+### Account-Scoped Isolation (#545)
+- Each `accountId` creates isolated storage namespaces
+- Account ID is SHA-256 hashed (32 characters) before use in storage paths
+- New `migrateToAccountScoped()` function for transitioning from unscoped storage
+
+### Scoped Transaction Identity Validation (#555)
+- New `ScopedTransactionIdentityMismatchError` prevents silent state mismatches
+- Identity tracking with `CachedStateIdentity` interface
+- Validation ensures batched calls target the same contract and private state
+
+### CI/CD Security Hardening (#493)
+- 15 shell injection vulnerabilities fixed across workflow files
+- Proper permissions added to documentation workflows
+- Pinned workflow dependencies
+
+## Features
+
+### Signing Key Export/Import (#526)
+Export and import signing keys with password protection and conflict resolution.
+
+```typescript
+// Export
+const keysExport = await provider.exportSigningKeys({ password: 'export-pw' });
+
+// Import with conflict handling
+await provider.importSigningKeys(keysExport, {
+  password: 'export-pw',
+  conflictStrategy: 'skip' // 'skip' | 'overwrite' | 'error'
+});
+```
+
+### Private State Export/Import (#526)
+Export and import private states with the same security features.
+
+```typescript
+// Export
+provider.setContractAddress(contractAddress);
+const statesExport = await provider.exportPrivateStates({ password: 'export-pw' });
+
+// Import
+await provider.importPrivateStates(statesExport, {
+  password: 'export-pw',
+  conflictStrategy: 'overwrite'
+});
+```
+
+### Password Rotation APIs (#542)
+
+```typescript
+// Rotate private state password
+provider.setContractAddress(contractAddress);
+await provider.changePassword(
+  () => 'old-password',
+  () => 'new-password'
+);
+
+// Rotate signing keys password
+await provider.changeSigningKeysPassword(
+  () => 'old-password',
+  () => 'new-password'
+);
+```
+
+### Account Migration Support (#545)
+
+```typescript
+import { migrateToAccountScoped } from '@midnight-ntwrk/level-private-state-provider';
+
+const result = await migrateToAccountScoped({ accountId: walletAddress });
+// Original data preserved for rollback
+```
+
+### Mnemonic-Based Wallet in Testkit (#524)
+New testkit helpers for mnemonic-based wallet generation.
+
+```typescript
+import { FluentWalletBuilder } from '@midnight-ntwrk/testkit';
+
+const wallet = new FluentWalletBuilder()
+  .withMnemonic('your mnemonic phrase...')
+  .build();
+
+// Or use predefined test wallet
+const testWallet = new FluentWalletBuilder()
+  .withTestWallet()
+  .build();
+```
+
+### Browser Storage Warning (#526)
+Automatic warning when using LevelDB storage in browser environments, alerting users to data persistence risks.
+
+## Bug Fixes
+
+### Zswap Chain State Handling (#543)
+Fixed an issue where the initial Zswap chain state was incorrectly merged instead of being reused, potentially causing state inconsistencies.
+
+### Lodash Dependency Removed (#556)
+Removed lodash dependency and replaced usage with native object spread, reducing bundle size and eliminating a dependency.
+
+### Direnv Installation Auth (#562)
+Fixed direnv installation to use `GITHUB_TOKEN` for authentication, resolving CI failures.
+
+### Dependabot NPM Registry Auth (#505)
+Added npm registry authentication for Dependabot to access private packages.
+
+## Refactoring
+
+### Wallet State Provider Types (#529)
+Updated wallet state provider to use `ShieldedWalletAPI` and `UnshieldedWalletAPI` types for improved type specificity.
+
+## Dependencies
+
+### Runtime Dependencies Updated
+- `@midnight-ntwrk/wallet-sdk-facade`: 2.0.0-rc.2
+- `@midnight-ntwrk/compactc`: 0.29.0
+
+### Development Dependencies Updated
+- `@rollup/plugin-commonjs`: 29.0.0
+- `testcontainers`: 11.12.0
+- `glob`: 13.0.4
+- `typedoc-plugin-markdown`: 4.10.0
+- `eslint-plugin-unused-imports`: 4.4.1
+- `axios`: Updated for security fixes
+- `tar`: Updated for security fixes
+- `lodash`: 4.17.23 (then removed in #556)
+- `actions/cache`: 5.0.3
+
+## Documentation
+
+- Comprehensive README update for `levelPrivateStateProvider` (#563)
+- API documentation updates (#504, #531, #544, #557, #559)
+- Storage architecture and data flow diagrams
+- Password requirements and security specifications
+
+## Links
+
+- [Breaking Changes Details](./breaking-changes.md)
+- [New Features Guide](./new-features.md)
+- [Migration Guide](./migration-guide.md)
+- [API Changes Reference](./api-changes.md)
+- [GitHub Repository](https://github.com/midnightntwrk/midnight-js)


### PR DESCRIPTION
## Summary

Comprehensive release notes documentation for v3.2.0, covering all changes since v3.1.0.

### Breaking Changes (2)
- `walletProvider` option removed from LevelPrivateStateProvider (#528)
- `accountId` now required for LevelPrivateStateProvider (#545)

### Security Enhancements (7)
- Multi-version encryption with 600k PBKDF2 iterations (#530)
- Consistent salt generation for race condition prevention (#534)
- Encryption caching with invalidation API (#538)
- Secure password rotation with atomic writes (#542)
- Account-scoped storage isolation (#545)
- Scoped transaction identity validation (#555)
- CI/CD shell injection fixes (#493)

### New Features (5)
- Signing key export/import with encryption (#526)
- Private state export/import with conflict resolution (#526)
- Password rotation APIs (#542)
- Account migration support (#545)
- Mnemonic-based wallet in testkit (#524)

### Bug Fixes (4)
- Zswap chain state handling (#543)
- Lodash dependency removed (#556)
- Direnv installation auth fix (#562)
- Dependabot NPM registry auth (#505)

### Files Added
- `docs/releases/v3.2.0/README.md` - Quick links and overview
- `docs/releases/v3.2.0/release-notes.md` - High-level changelog
- `docs/releases/v3.2.0/breaking-changes.md` - Detailed breaking changes
- `docs/releases/v3.2.0/new-features.md` - Complete feature documentation
- `docs/releases/v3.2.0/api-changes.md` - API reference changes
- `docs/releases/v3.2.0/migration-guide.md` - Step-by-step upgrade guide

## Test plan

- [x] Verified all 39 commits since v3.1.0
- [x] Followed existing format from v3.0.0 release notes
- [x] Cross-referenced PR numbers and commit hashes
- [ ] Review documentation for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)