### PR TITLE
chore: switch npm registry from GitHub Packages to npmjs.org

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,8 +9,8 @@ nodeLinker: node-modules
 
 npmScopes:
   midnight-ntwrk:
-    npmAlwaysAuth: true
-    npmPublishRegistry: "https://npm.pkg.github.com/"
-    npmRegistryServer: "https://npm.pkg.github.com/"
+    npmAlwaysAuth: false
+    npmPublishRegistry: 'https://npm.pkg.github.com/'
+    npmRegistryServer: 'https://registry.npmjs.org/'
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs


### PR DESCRIPTION
## Summary

Switch npm registry from GitHub Packages to npmjs.org for public package resolution.

## Changes

- Switch `npmRegistryServer` from `npm.pkg.github.com` to `registry.npmjs.org`
- Keep `npmPublishRegistry` on GitHub Packages for publishing
- Remove `npmAlwaysAuth` requirement