### PR TITLE
fix(midnight-js): copy WASM payload bytes before sending to proof server

### DIFF
--- a/packages/http-client-proof-provider/src/http-client-proving-provider.ts
+++ b/packages/http-client-proof-provider/src/http-client-proving-provider.ts
@@ -56,7 +56,7 @@ const getKeyMaterial = async <K extends string>(
 const makeHttpRequest = async (url: URL, payload: Uint8Array, timeout: number): Promise<Uint8Array> => {
   const response = await fetchRetry(url, {
     method: 'POST',
-    body: payload.buffer as ArrayBuffer,
+    body: new Uint8Array(payload),
     signal: AbortSignal.timeout(timeout)
   });
 

--- a/packages/http-client-proof-provider/src/test/http-client-proving-provider.test.ts
+++ b/packages/http-client-proof-provider/src/test/http-client-proving-provider.test.ts
@@ -169,7 +169,7 @@ describe('httpClientProvingProvider', () => {
         new URL('/check', mockUrl),
         expect.objectContaining({
           method: 'POST',
-          body: payload.buffer
+          body: new Uint8Array(payload)
         })
       );
     });
@@ -302,7 +302,7 @@ describe('httpClientProvingProvider', () => {
         new URL('/prove', mockUrl),
         expect.objectContaining({
           method: 'POST',
-          body: payload.buffer
+          body: new Uint8Array(payload)
         })
       );
     });


### PR DESCRIPTION
## Summary

- Replace `payload.buffer` with `new Uint8Array(payload)` in `makeHttpRequest` to avoid sending the entire WASM linear memory heap to the proof server
- Update test assertions to match the corrected behavior

## Problem

The `createCheckPayload` and `createProvingPayload` functions from `@midnight-ntwrk/ledger-v7` return `Uint8Array` views created via `.subarray()` over the WASM linear memory buffer. When `payload.buffer` is accessed, JavaScript returns the **entire underlying `ArrayBuffer`** (the full WASM heap — megabytes of unrelated memory), not the slice the view references.

This causes the proof server to receive a corrupted payload and fail with errors like:
- `BadInput("Unsupported ZKIR version")` — can't parse the ZKIR header
- `BadInput("Bit bound failed: ...")` — parses wrong bytes as field values

## Fix

`new Uint8Array(payload)` copies only the bytes referenced by the view into a correctly-sized buffer.

## Test plan

- [x] Updated test assertions in `http-client-proving-provider.test.ts`
- [ ] Verify `/check` and `/prove` requests succeed against a local proof server in browser (Vite dev)
- [ ] Verify no regression in Node.js environments


🤖 Generated with [Claude Code](https://claude.com/claude-code)