### PR TITLE
fix: ensure TransactionContext is not included in circuit call arguments

### DIFF
--- a/packages/contracts/src/test/transaction-identity.test.ts
+++ b/packages/contracts/src/test/transaction-identity.test.ts
@@ -236,6 +236,40 @@ describe('TransactionContextImpl identity validation', () => {
       expect(result.privateState).toBe(mockCallData2.private.nextPrivateState);
     });
 
+    it('should preserve the original zswapChainState without modification after merge', () => {
+      const contractAddress = createMockContractAddress();
+      const privateStateId = 'test-private-state-id' as PrivateStateId;
+      const identity: CachedStateIdentity = { contractAddress, privateStateId };
+      const mockStates = createMockStates();
+      const originalZswapChainState = mockStates.zswapChainState;
+      const mockCallData = createMockUnprovenCallTxData();
+
+      txCtx[CacheStates](mockStates, identity);
+      txCtx[MergeUnsubmittedCallTxData]('testCircuit', mockCallData, privateStateId);
+
+      const result = txCtx[GetCurrentStatesForIdentity](identity) as ContractStates<Contract.PrivateState<Contract.Any>>;
+
+      expect(result.zswapChainState).toBe(originalZswapChainState);
+    });
+
+    it('should preserve the original zswapChainState across multiple merges', () => {
+      const contractAddress = createMockContractAddress();
+      const privateStateId = 'test-private-state-id' as PrivateStateId;
+      const identity: CachedStateIdentity = { contractAddress, privateStateId };
+      const mockStates = createMockStates();
+      const originalZswapChainState = mockStates.zswapChainState;
+      const mockCallData1 = createMockUnprovenCallTxData();
+      const mockCallData2 = createMockUnprovenCallTxData();
+
+      txCtx[CacheStates](mockStates, identity);
+      txCtx[MergeUnsubmittedCallTxData]('testCircuit', mockCallData1, privateStateId);
+      txCtx[MergeUnsubmittedCallTxData]('testCircuit', mockCallData2, privateStateId);
+
+      const result = txCtx[GetCurrentStatesForIdentity](identity) as ContractStates<Contract.PrivateState<Contract.Any>>;
+
+      expect(result.zswapChainState).toBe(originalZswapChainState);
+    });
+
     it('should throw when requesting with different identity after merge', () => {
       const contractAddress1 = createMockContractAddress();
       const contractAddress2 = createMockContractAddress();

--- a/packages/contracts/src/test/tx-interfaces.test.ts
+++ b/packages/contracts/src/test/tx-interfaces.test.ts
@@ -135,6 +135,111 @@ describe('tx-interfaces', () => {
       expect(callInterface).toHaveProperty('testCircuit');
       expect(typeof callInterface.testCircuit).toBe('function');
     });
+
+    it('should call submitCallTx without args when no arguments provided', async () => {
+      const { submitCallTx } = await import('../submit-call-tx');
+      vi.mocked(submitCallTx).mockResolvedValue(mockFinalizedTxData as never);
+
+      const callInterface = createCircuitCallTxInterface(
+        mockProviders,
+        mockCompiledContract,
+        mockContractAddress,
+        undefined
+      );
+
+      await (callInterface.testCircuit as (...args: unknown[]) => Promise<unknown>)();
+
+      expect(submitCallTx).toHaveBeenCalledWith(
+        mockProviders,
+        expect.objectContaining({
+          compiledContract: mockCompiledContract,
+          circuitId: 'testCircuit',
+          contractAddress: mockContractAddress
+        })
+      );
+      expect(submitCallTx).toHaveBeenCalledWith(
+        mockProviders,
+        expect.not.objectContaining({ args: expect.anything() })
+      );
+    });
+
+    it('should pass circuit arguments through to submitCallTx', async () => {
+      const { submitCallTx } = await import('../submit-call-tx');
+      vi.mocked(submitCallTx).mockResolvedValue(mockFinalizedTxData as never);
+
+      const callInterface = createCircuitCallTxInterface(
+        mockProviders,
+        mockCompiledContract,
+        mockContractAddress,
+        undefined
+      );
+
+      await (callInterface.testCircuit as (...args: unknown[]) => Promise<unknown>)('arg1', 'arg2');
+
+      expect(submitCallTx).toHaveBeenCalledWith(
+        mockProviders,
+        expect.objectContaining({
+          args: ['arg1', 'arg2']
+        })
+      );
+    });
+
+    it('should strip TransactionContext from circuit call arguments', async () => {
+      const { submitCallTx } = await import('../submit-call-tx');
+      const { TransactionContextImpl } = await import('../internal/transaction');
+      vi.mocked(submitCallTx).mockResolvedValue({ result: vi.fn() } as never);
+
+      const txCtx = new TransactionContextImpl(mockProviders);
+
+      const callInterface = createCircuitCallTxInterface(
+        mockProviders,
+        mockCompiledContract,
+        mockContractAddress,
+        mockPrivateStateId
+      );
+
+      await (callInterface.testCircuit as (...args: unknown[]) => Promise<unknown>)(txCtx, 'arg1', 'arg2');
+
+      expect(submitCallTx).toHaveBeenCalledWith(
+        mockProviders,
+        expect.objectContaining({
+          args: ['arg1', 'arg2']
+        }),
+        txCtx
+      );
+    });
+
+    it('should not include TransactionContext in args when it is the only argument', async () => {
+      const { submitCallTx } = await import('../submit-call-tx');
+      const { TransactionContextImpl } = await import('../internal/transaction');
+      vi.mocked(submitCallTx).mockResolvedValue({ result: vi.fn() } as never);
+
+      const txCtx = new TransactionContextImpl(mockProviders);
+
+      const callInterface = createCircuitCallTxInterface(
+        mockProviders,
+        mockCompiledContract,
+        mockContractAddress,
+        mockPrivateStateId
+      );
+
+      await (callInterface.testCircuit as (...args: unknown[]) => Promise<unknown>)(txCtx);
+
+      expect(submitCallTx).toHaveBeenCalledWith(
+        mockProviders,
+        expect.objectContaining({
+          compiledContract: mockCompiledContract,
+          circuitId: 'testCircuit',
+          contractAddress: mockContractAddress
+        }),
+        txCtx
+      );
+      expect(submitCallTx).toHaveBeenCalledWith(
+        mockProviders,
+        expect.not.objectContaining({ args: expect.anything() }),
+        txCtx
+      );
+    });
   });
 
   describe('createCircuitMaintenanceTxInterface', () => {


### PR DESCRIPTION
Adds tests for bug fixes:
https://shielded.atlassian.net/browse/PM-21974
https://shielded.atlassian.net/browse/PM-22251

Add tests to verify that TransactionContext is correctly stripped from circuit call arguments before they are forwarded  
 to submitCallTx. Covers four scenarios: no arguments, regular arguments, TransactionContext with arguments, and          
TransactionContext as the sole argument. Also adds tests for zswapChainState preservation after single and multiple      
merges in TransactionContextImpl.