### PR TITLE
chore: use add calls to build transaction

### DIFF
--- a/packages/contracts/src/test/utils/ledger-utils.test.ts
+++ b/packages/contracts/src/test/utils/ledger-utils.test.ts
@@ -17,6 +17,7 @@ import {
   type AlignedValue,
   ContractOperation,
   ContractState as CompactContractState,
+  type Op,
   QueryContext
 } from '@midnight-ntwrk/compact-runtime';
 import {
@@ -124,6 +125,89 @@ describe('ledger-utils', () => {
       dummyCPK
     );
     expect(tx).toBeInstanceOf(Transaction);
+  });
+
+  it('createUnprovenLedgerCallTx with non-empty publicTranscript produces a valid Transaction', () => {
+    const circuitId = 'nonEmptyTranscriptTx';
+    const contractState = new CompactContractState();
+    const contractOperation = new ContractOperation();
+
+    contractState.setOperation(circuitId, contractOperation);
+
+    const alignedValue: AlignedValue = {
+      value: [new Uint8Array()],
+      alignment: [
+        {
+          tag: 'atom',
+          value: { tag: 'field' }
+        }
+      ]
+    };
+
+    const publicTranscript: Op<AlignedValue>[] = [{ noop: { n: 5 } }];
+
+    const contractAddress = sampleContractAddress();
+    const zswapChainState = new ZswapChainState();
+    const privateTranscriptOutputs: AlignedValue[] = [];
+    const nextZswapLocalState = {
+      outputs: [],
+      inputs: [],
+      coinPublicKey: sampleCoinPublicKey(),
+      currentIndex: 0n
+    };
+
+    const tx = createUnprovenLedgerCallTx(
+      circuitId,
+      contractAddress,
+      contractState,
+      zswapChainState,
+      publicTranscript,
+      privateTranscriptOutputs,
+      alignedValue,
+      alignedValue,
+      nextZswapLocalState,
+      dummyEncPublicKey,
+      LedgerParameters.initialParameters(),
+      dummyCPK
+    );
+    expect(tx).toBeInstanceOf(Transaction);
+  });
+
+  it('createUnprovenLedgerCallTx throws when circuitId has no registered operation', () => {
+    const unregisteredCircuitId = 'unregisteredCircuit';
+    const contractState = new CompactContractState();
+
+    const alignedValue: AlignedValue = {
+      value: [new Uint8Array()],
+      alignment: [
+        {
+          tag: 'atom',
+          value: { tag: 'field' }
+        }
+      ]
+    };
+
+    expect(() =>
+      createUnprovenLedgerCallTx(
+        unregisteredCircuitId,
+        sampleContractAddress(),
+        contractState,
+        new ZswapChainState(),
+        [],
+        [],
+        alignedValue,
+        alignedValue,
+        {
+          outputs: [],
+          inputs: [],
+          coinPublicKey: sampleCoinPublicKey(),
+          currentIndex: 0n
+        },
+        dummyEncPublicKey,
+        LedgerParameters.initialParameters(),
+        dummyCPK
+      )
+    ).toThrow(`Operation '${unregisteredCircuitId}' is undefined`);
   });
 
   it('createUnprovenReplaceAuthorityTx returns an UnprovenTransaction', async () => {

--- a/packages/contracts/src/test/utils/ledger-utils.test.ts
+++ b/packages/contracts/src/test/utils/ledger-utils.test.ts
@@ -20,32 +20,22 @@ import {
   QueryContext
 } from '@midnight-ntwrk/compact-runtime';
 import {
-  feeToken,
+  LedgerParameters,
   MaintenanceUpdate,
-  type PartitionedTranscript,
-  type PublicAddress,
   sampleCoinPublicKey,
   sampleContractAddress,
   sampleEncryptionPublicKey,
   sampleSigningKey,
-  sampleUserAddress,
-  shieldedToken,
-  type TokenType,
   Transaction,
-  type Transcript,
-  unshieldedToken,
   ZswapChainState
 } from '@midnight-ntwrk/ledger-v8';
 import { setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
-import { toHex } from '@midnight-ntwrk/midnight-js-utils';
-import { randomBytes } from 'crypto';
 import { beforeAll } from 'vitest';
 
 import {
   createUnprovenLedgerCallTx,
   createUnprovenRemoveVerifierKeyTx,
   createUnprovenReplaceAuthorityTx,
-  extractUserAddressedOutputs,
   fromLedgerContractState,
   toLedgerContractState,
   toLedgerQueryContext,
@@ -94,33 +84,10 @@ describe('ledger-utils', () => {
 
   it('createUnprovenLedgerCallTx returns an UnprovenTransaction', () => {
     const circuitId = 'unProvenLedgerTx';
-    const tokenType = unshieldedToken();
     const contractState = dummyContractState;
     const contractOperation = new ContractOperation();
-    const address = { tag: 'contract', address: sampleContractAddress() } as PublicAddress;
 
     contractState.setOperation(circuitId, contractOperation);
-
-    const transcript: Transcript<AlignedValue> = {
-      gas: {
-        readTime: 1n,
-        computeTime: 2n,
-        bytesWritten: 4n,
-        bytesDeleted: 8n,
-      },
-      effects: {
-        claimedNullifiers: [toHex(randomBytes(32))],
-        claimedShieldedReceives: [toHex(randomBytes(32))],
-        claimedShieldedSpends: [toHex(randomBytes(32))],
-        claimedContractCalls: new Array([5n, sampleContractAddress(), toHex(randomBytes(32)), new Uint8Array([0])]),
-        shieldedMints: new Map([[toHex(randomBytes(32)), 1n]]),
-        unshieldedInputs: new Map([[tokenType, 1n]]),
-        unshieldedOutputs: new Map([[tokenType, 1n]]),
-        unshieldedMints: new Map([[toHex(randomBytes(32)), 1n]]),
-        claimedUnshieldedSpends: new Map([[[tokenType, address], 1n]])
-      },
-      program: ['new', { noop: { n: 5 } }]
-    };
 
     const alignedValue: AlignedValue = {
       value: [new Uint8Array()],
@@ -134,7 +101,6 @@ describe('ledger-utils', () => {
 
     const contractAddress = sampleContractAddress();
     const zswapChainState = new ZswapChainState();
-    const partitionedTranscript: PartitionedTranscript = [transcript, transcript];
     const privateTranscriptOutputs: AlignedValue[] = [];
     const nextZswapLocalState = {
       outputs: [],
@@ -148,12 +114,13 @@ describe('ledger-utils', () => {
       contractAddress,
       contractState,
       zswapChainState,
-      partitionedTranscript,
+      [],
       privateTranscriptOutputs,
       alignedValue,
       alignedValue,
       nextZswapLocalState,
-      dummyEncPublicKey
+      dummyEncPublicKey,
+      LedgerParameters.initialParameters()
     );
     expect(tx).toBeInstanceOf(Transaction);
   });
@@ -182,258 +149,5 @@ describe('ledger-utils', () => {
       dummyCPK
     );
     expect(tx).toBeInstanceOf(Transaction);
-  });
-
-  const makeTranscript = (
-    claimedUnshieldedSpends: Map<[TokenType, PublicAddress], bigint>
-  ): Transcript<AlignedValue> => ({
-    gas: { readTime: 0n, computeTime: 0n, bytesWritten: 0n, bytesDeleted: 0n },
-    effects: {
-      claimedNullifiers: [toHex(randomBytes(32))],
-      claimedShieldedReceives: [toHex(randomBytes(32))],
-      claimedShieldedSpends: [toHex(randomBytes(32))],
-      claimedContractCalls: [],
-      shieldedMints: new Map(),
-      unshieldedInputs: new Map(),
-      unshieldedOutputs: new Map(),
-      unshieldedMints: new Map(),
-      claimedUnshieldedSpends
-    },
-    program: ['new', { noop: { n: 5 } }]
-  });
-
-  describe('extractUserAddressedOutputs', () => {
-    it('returns empty array when transcript is undefined', () => {
-      const result = extractUserAddressedOutputs(undefined);
-
-      expect(result).toEqual([]);
-    });
-
-    it('returns empty array when claimedUnshieldedSpends is empty', () => {
-      const transcript = makeTranscript(new Map());
-
-      const result = extractUserAddressedOutputs(transcript);
-
-      expect(result).toEqual([]);
-    });
-
-    it('returns output for user-addressed unshielded token spend', () => {
-      const userAddress = sampleUserAddress();
-      const tokenType = unshieldedToken();
-      const amount = 100n;
-      const transcript = makeTranscript(
-        new Map([[[tokenType, { tag: 'user', address: userAddress } as PublicAddress], amount]])
-      );
-
-      const result = extractUserAddressedOutputs(transcript);
-
-      expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({
-        value: amount,
-        owner: userAddress,
-        type: tokenType.raw
-      });
-    });
-
-    it('returns output for user-addressed shielded token spend', () => {
-      const userAddress = sampleUserAddress();
-      const tokenType = shieldedToken();
-      const amount = 50n;
-      const transcript = makeTranscript(
-        new Map([[[tokenType, { tag: 'user', address: userAddress } as PublicAddress], amount]])
-      );
-
-      const result = extractUserAddressedOutputs(transcript);
-
-      expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({
-        value: amount,
-        owner: userAddress,
-        type: tokenType.raw
-      });
-    });
-
-    it('filters out contract-addressed spends', () => {
-      const contractAddr = sampleContractAddress();
-      const tokenType = unshieldedToken();
-      const transcript = makeTranscript(
-        new Map([[[tokenType, { tag: 'contract', address: contractAddr } as PublicAddress], 100n]])
-      );
-
-      const result = extractUserAddressedOutputs(transcript);
-
-      expect(result).toEqual([]);
-    });
-
-    it('filters out dust token spends even for user addresses', () => {
-      const userAddress = sampleUserAddress();
-      const dustTokenType = feeToken();
-      const transcript = makeTranscript(
-        new Map([[[dustTokenType, { tag: 'user', address: userAddress } as PublicAddress], 100n]])
-      );
-
-      const result = extractUserAddressedOutputs(transcript);
-
-      expect(result).toEqual([]);
-    });
-
-    it('returns only user-addressed non-dust outputs from mixed spends', () => {
-      const userAddress1 = sampleUserAddress();
-      const userAddress2 = sampleUserAddress();
-      const contractAddr = sampleContractAddress();
-      const unshieldedTok = unshieldedToken();
-      const shieldedTok = shieldedToken();
-      const dustTok = feeToken();
-
-      const transcript = makeTranscript(
-        new Map([
-          [[unshieldedTok, { tag: 'user', address: userAddress1 } as PublicAddress], 100n],
-          [[shieldedTok, { tag: 'user', address: userAddress2 } as PublicAddress], 200n],
-          [[unshieldedTok, { tag: 'contract', address: contractAddr } as PublicAddress], 300n],
-          [[dustTok, { tag: 'user', address: userAddress1 } as PublicAddress], 400n]
-        ])
-      );
-
-      const result = extractUserAddressedOutputs(transcript);
-
-      expect(result).toHaveLength(2);
-      expect(result).toEqual(
-        expect.arrayContaining([
-          { value: 100n, owner: userAddress1, type: unshieldedTok.raw },
-          { value: 200n, owner: userAddress2, type: shieldedTok.raw }
-        ])
-      );
-    });
-  });
-
-  describe('createUnprovenLedgerCallTx unshielded offers', () => {
-    const circuitId = 'unshieldedOfferTx';
-    const alignedValue: AlignedValue = {
-      value: [new Uint8Array()],
-      alignment: [{ tag: 'atom', value: { tag: 'field' } }]
-    };
-    const privateTranscriptOutputs: AlignedValue[] = [];
-    const nextZswapLocalState = {
-      outputs: [],
-      inputs: [],
-      coinPublicKey: sampleCoinPublicKey(),
-      currentIndex: 0n
-    };
-
-    const callTxWithTranscripts = (
-      guaranteed: Transcript<AlignedValue> | undefined,
-      fallible: Transcript<AlignedValue> | undefined
-    ) => {
-      const contractState = new CompactContractState();
-      contractState.setOperation(circuitId, new ContractOperation());
-      const contractAddress = sampleContractAddress();
-
-      return createUnprovenLedgerCallTx(
-        circuitId,
-        contractAddress,
-        contractState,
-        new ZswapChainState(),
-        [guaranteed, fallible] as PartitionedTranscript,
-        privateTranscriptOutputs,
-        alignedValue,
-        alignedValue,
-        nextZswapLocalState,
-        dummyEncPublicKey
-      );
-    };
-
-    it('does not attach unshielded offers when transcripts are undefined', () => {
-      const tx = callTxWithTranscripts(undefined, undefined);
-
-      expect(tx).toBeInstanceOf(Transaction);
-      const intent = tx.intents?.values().next().value;
-      expect(intent).toBeDefined();
-      expect(intent!.guaranteedUnshieldedOffer).toBeUndefined();
-      expect(intent!.fallibleUnshieldedOffer).toBeUndefined();
-    });
-
-    it('attaches guaranteedUnshieldedOffer when guaranteed transcript has user-addressed spends', () => {
-      const userAddress = sampleUserAddress();
-      const tokenType = unshieldedToken();
-      const amount = 500n;
-      const guaranteed = makeTranscript(
-        new Map([[[tokenType, { tag: 'user', address: userAddress } as PublicAddress], amount]])
-      );
-      const fallible = makeTranscript(new Map());
-
-      const tx = callTxWithTranscripts(guaranteed, fallible);
-
-      expect(tx).toBeInstanceOf(Transaction);
-      const intent = tx.intents?.values().next().value;
-      expect(intent).toBeDefined();
-      expect(intent!.guaranteedUnshieldedOffer).toBeDefined();
-      expect(intent!.guaranteedUnshieldedOffer!.outputs).toHaveLength(1);
-      expect(intent!.guaranteedUnshieldedOffer!.outputs[0]).toEqual({
-        value: amount,
-        owner: userAddress,
-        type: tokenType.raw
-      });
-    });
-
-    it('attaches fallibleUnshieldedOffer when fallible transcript has user-addressed spends', () => {
-      const userAddress = sampleUserAddress();
-      const tokenType = unshieldedToken();
-      const amount = 750n;
-      const guaranteed = makeTranscript(new Map());
-      const fallible = makeTranscript(
-        new Map([[[tokenType, { tag: 'user', address: userAddress } as PublicAddress], amount]])
-      );
-
-      const tx = callTxWithTranscripts(guaranteed, fallible);
-
-      expect(tx).toBeInstanceOf(Transaction);
-      const intent = tx.intents?.values().next().value;
-      expect(intent).toBeDefined();
-      expect(intent!.fallibleUnshieldedOffer).toBeDefined();
-      expect(intent!.fallibleUnshieldedOffer!.outputs).toHaveLength(1);
-      expect(intent!.fallibleUnshieldedOffer!.outputs[0]).toEqual({
-        value: amount,
-        owner: userAddress,
-        type: tokenType.raw
-      });
-    });
-
-    it('does not attach unshielded offers when only contract-addressed spends exist', () => {
-      const contractAddr = sampleContractAddress();
-      const tokenType = unshieldedToken();
-      const transcript = makeTranscript(
-        new Map([[[tokenType, { tag: 'contract', address: contractAddr } as PublicAddress], 100n]])
-      );
-
-      const tx = callTxWithTranscripts(transcript, transcript);
-
-      expect(tx).toBeInstanceOf(Transaction);
-      const intent = tx.intents?.values().next().value;
-      expect(intent).toBeDefined();
-      expect(intent!.guaranteedUnshieldedOffer).toBeUndefined();
-      expect(intent!.fallibleUnshieldedOffer).toBeUndefined();
-    });
-
-    it('attaches offers to both guaranteed and fallible when both have user-addressed spends', () => {
-      const userAddress1 = sampleUserAddress();
-      const userAddress2 = sampleUserAddress();
-      const tokenType = unshieldedToken();
-      const guaranteed = makeTranscript(
-        new Map([[[tokenType, { tag: 'user', address: userAddress1 } as PublicAddress], 100n]])
-      );
-      const fallible = makeTranscript(
-        new Map([[[tokenType, { tag: 'user', address: userAddress2 } as PublicAddress], 200n]])
-      );
-
-      const tx = callTxWithTranscripts(guaranteed, fallible);
-
-      const intent = tx.intents?.values().next().value;
-      expect(intent!.guaranteedUnshieldedOffer).toBeDefined();
-      expect(intent!.guaranteedUnshieldedOffer!.outputs).toHaveLength(1);
-      expect(intent!.guaranteedUnshieldedOffer!.outputs[0].value).toBe(100n);
-      expect(intent!.fallibleUnshieldedOffer).toBeDefined();
-      expect(intent!.fallibleUnshieldedOffer!.outputs).toHaveLength(1);
-      expect(intent!.fallibleUnshieldedOffer!.outputs[0].value).toBe(200n);
-    });
   });
 });

--- a/packages/contracts/src/test/utils/ledger-utils.test.ts
+++ b/packages/contracts/src/test/utils/ledger-utils.test.ts
@@ -120,7 +120,8 @@ describe('ledger-utils', () => {
       alignedValue,
       nextZswapLocalState,
       dummyEncPublicKey,
-      LedgerParameters.initialParameters()
+      LedgerParameters.initialParameters(),
+      dummyCPK
     );
     expect(tx).toBeInstanceOf(Transaction);
   });

--- a/packages/contracts/src/unproven-call-tx.ts
+++ b/packages/contracts/src/unproven-call-tx.ts
@@ -15,7 +15,7 @@
 
 import { ContractExecutable } from '@midnight-ntwrk/compact-js';
 import { type Contract, ProvableCircuitId } from '@midnight-ntwrk/compact-js/effect/Contract';
-import type { CoinPublicKey, ContractState } from '@midnight-ntwrk/compact-runtime';
+import { type CoinPublicKey, type ContractState } from '@midnight-ntwrk/compact-runtime';
 import { type EncPublicKey, type LedgerParameters, type ZswapChainState } from '@midnight-ntwrk/ledger-v8';
 import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 import { exitResultOrError, makeContractExecutableRuntime, type PrivateStateId, type ZKConfigProvider } from '@midnight-ntwrk/midnight-js-types';
@@ -52,9 +52,9 @@ export function createUnprovenCallTxFromInitialStates<C extends Contract.Any, PC
  * Calls a circuit using the provided initial `states` and creates an unbalanced,
  * unproven, unsubmitted, call transaction.
  *
+ * @param zkConfigProvider
  * @param options Configuration.
  *
- * @param walletCoinPublicKey
  * @param walletEncryptionPublicKey
  * @returns Data produced by the circuit call and an unproven transaction assembled from the call result.
  */
@@ -133,7 +133,8 @@ export async function createUnprovenCallTxFromInitialStates<C extends Contract.A
             options.coinPublicKey,
             walletEncryptionPublicKey
           ),
-          ledgerParameters
+          ledgerParameters,
+          coinPublicKey
         ),
         newCoins: zswapStateToNewCoins(
           parseCoinPublicKeyToHex(coinPublicKey, getNetworkId()),

--- a/packages/contracts/src/unproven-call-tx.ts
+++ b/packages/contracts/src/unproven-call-tx.ts
@@ -123,7 +123,7 @@ export async function createUnprovenCallTxFromInitialStates<C extends Contract.A
           contractAddress,
           initialContractState,
           initialZswapChainState,
-          partitionedTranscript,
+          publicTranscript,
           privateTranscriptOutputs,
           input,
           output,
@@ -132,7 +132,8 @@ export async function createUnprovenCallTxFromInitialStates<C extends Contract.A
             zswapLocalState,
             options.coinPublicKey,
             walletEncryptionPublicKey
-          )
+          ),
+          ledgerParameters
         ),
         newCoins: zswapStateToNewCoins(
           parseCoinPublicKeyToHex(coinPublicKey, getNetworkId()),

--- a/packages/contracts/src/utils/ledger-utils.ts
+++ b/packages/contracts/src/utils/ledger-utils.ts
@@ -20,25 +20,25 @@ import {
   type CoinPublicKey,
   type ContractAddress,
   ContractState,
+  type Op,
+  QueryContext as CompactQueryContext,
   type QueryContext,
   type SigningKey,
   type ZswapLocalState} from '@midnight-ntwrk/compact-runtime';
 import {
   ChargedState,
   communicationCommitmentRandomness,
-  ContractCallPrototype,
   ContractDeploy,
   ContractState as LedgerContractState,
   type EncPublicKey,
   Intent,
+  type LedgerParameters,
   type MaintenanceUpdate,
-  type PartitionedTranscript,
+  PrePartitionContractCall,
+  PreTranscript,
   QueryContext as LedgerQueryContext,
   StateValue as LedgerStateValue,
-  type Transcript,
   type UnprovenTransaction,
-  UnshieldedOffer,
-  type UtxoOutput,
   type ZswapChainState
 } from '@midnight-ntwrk/ledger-v8';
 import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
@@ -54,32 +54,6 @@ import {
 import { assertDefined, ttlOneHour } from '@midnight-ntwrk/midnight-js-utils';
 
 import { zswapStateToOffer } from './zswap-utils';
-
-/**
- * Extracts user-addressed {@link UtxoOutput} entries from a transcript's
- * {@link Effects.claimedUnshieldedSpends claimedUnshieldedSpends}. These outputs
- * must be included in the Intent's {@link UnshieldedOffer} so that the ledger
- * validator's `real_unshielded_spends` subset check passes for user-addressed
- * `sendUnshielded` operations.
- *
- * Contract-addressed spends are satisfied by the transcript's `unshielded_inputs`
- * effects and do not need offer outputs.
- */
-export const extractUserAddressedOutputs = (transcript: Transcript<AlignedValue> | undefined): UtxoOutput[] => {
-  if (!transcript) return [];
-
-  const outputs: UtxoOutput[] = [];
-  for (const [[tokenType, publicAddress], value] of transcript.effects.claimedUnshieldedSpends) {
-    if (publicAddress.tag === 'user' && tokenType.tag !== 'dust') {
-      outputs.push({
-        value,
-        owner: publicAddress.address,
-        type: tokenType.raw
-      });
-    }
-  }
-  return outputs;
-};
 
 export const toLedgerContractState = (contractState: ContractState): LedgerContractState =>
   LedgerContractState.deserialize(contractState.serialize());
@@ -119,44 +93,33 @@ export const createUnprovenLedgerCallTx = (
   contractAddress: ContractAddress,
   initialContractState: ContractState,
   zswapChainState: ZswapChainState,
-  partitionedTranscript: PartitionedTranscript,
+  publicTranscript: Op<AlignedValue>[],
   privateTranscriptOutputs: AlignedValue[],
   input: AlignedValue,
   output: AlignedValue,
   nextZswapLocalState: ZswapLocalState,
-  encryptionPublicKey: EncPublicKey
+  encryptionPublicKey: EncPublicKey,
+  ledgerParameters: LedgerParameters
 ): UnprovenTransaction => {
-  const op = toLedgerContractState(initialContractState).operation(circuitId);
+  const ledgerContractState = toLedgerContractState(initialContractState);
+  const op = ledgerContractState.operation(circuitId);
   assertDefined(op, `Operation '${circuitId}' is undefined for contract state ${initialContractState.toString(false)}`);
 
-  const intent = Intent.new(ttlOneHour()).addCall(
-    new ContractCallPrototype(
-      contractAddress,
-      circuitId,
-      op,
-      partitionedTranscript[0],
-      partitionedTranscript[1],
-      privateTranscriptOutputs,
-      input,
-      output,
-      communicationCommitmentRandomness(),
-      circuitId
-    )
+  const compactQueryContext = new CompactQueryContext(initialContractState.data, contractAddress);
+  const queryContext = toLedgerQueryContext(compactQueryContext);
+  const preTranscript = new PreTranscript(queryContext, publicTranscript);
+
+  const call = new PrePartitionContractCall(
+    contractAddress,
+    circuitId,
+    op,
+    preTranscript,
+    privateTranscriptOutputs,
+    input,
+    output,
+    communicationCommitmentRandomness(),
+    circuitId
   );
-
-  // Attach UnshieldedOffers for user-addressed claimedUnshieldedSpends.
-  // When a Compact circuit calls sendUnshielded to a user address, the ledger
-  // validator requires matching UtxoOutput entries in the Intent's UnshieldedOffer.
-  // Without these, the real_unshielded_spends subset check fails (error 139).
-  const guaranteedOutputs = extractUserAddressedOutputs(partitionedTranscript[0]);
-  if (guaranteedOutputs.length > 0) {
-    intent.guaranteedUnshieldedOffer = UnshieldedOffer.new([], guaranteedOutputs, []);
-  }
-
-  const fallibleOutputs = extractUserAddressedOutputs(partitionedTranscript[1]);
-  if (fallibleOutputs.length > 0) {
-    intent.fallibleUnshieldedOffer = UnshieldedOffer.new([], fallibleOutputs, []);
-  }
 
   return Transaction.fromPartsRandomized(
     getNetworkId(),
@@ -164,8 +127,12 @@ export const createUnprovenLedgerCallTx = (
       contractAddress,
       zswapChainState
     }),
-    undefined,
-    intent
+    undefined
+  ).addCalls(
+    { tag: 'random' },
+    [call],
+    ledgerParameters,
+    ttlOneHour()
   );
 };
 

--- a/packages/contracts/src/utils/ledger-utils.ts
+++ b/packages/contracts/src/utils/ledger-utils.ts
@@ -20,8 +20,8 @@ import {
   type CoinPublicKey,
   type ContractAddress,
   ContractState,
+  createCircuitContext,
   type Op,
-  QueryContext as CompactQueryContext,
   type QueryContext,
   type SigningKey,
   type ZswapLocalState} from '@midnight-ntwrk/compact-runtime';
@@ -99,14 +99,14 @@ export const createUnprovenLedgerCallTx = (
   output: AlignedValue,
   nextZswapLocalState: ZswapLocalState,
   encryptionPublicKey: EncPublicKey,
-  ledgerParameters: LedgerParameters
+  ledgerParameters: LedgerParameters,
+  coinPublicKey: CoinPublicKey
 ): UnprovenTransaction => {
-  const ledgerContractState = toLedgerContractState(initialContractState);
-  const op = ledgerContractState.operation(circuitId);
+  const op = toLedgerContractState(initialContractState).operation(circuitId);
   assertDefined(op, `Operation '${circuitId}' is undefined for contract state ${initialContractState.toString(false)}`);
 
-  const compactQueryContext = new CompactQueryContext(initialContractState.data, contractAddress);
-  const queryContext = toLedgerQueryContext(compactQueryContext);
+  const initialQueryContext = createCircuitContext(contractAddress, coinPublicKey, initialContractState, undefined).currentQueryContext;
+  const queryContext = toLedgerQueryContext(initialQueryContext);
   const preTranscript = new PreTranscript(queryContext, publicTranscript);
 
   const call = new PrePartitionContractCall(


### PR DESCRIPTION
Use Transaction add calls to construct Transaction

https://shielded.atlassian.net/browse/PM-21556?search_id=dd39553b-e248-4533-af64-54448a777c73

The change is in how createUnprovenLedgerCallTx assembles the transaction.                                                                                                                                                                                                                                                                                                                                   
                                                   
  Current (after reverts):                                                                                                                                                                                                                                                                                                                                                                                     
  - Uses ContractCallPrototype + Intent.addCall() — requires already-partitioned transcripts (PartitionedTranscript = [guaranteed, fallible])                                                                                                                                                                                                                                                                  
  - Manually creates UnshieldedOffer via extractUserAddressedOutputs for user-addressed spends                                                                                                                                                                                                                                                                                                                 
  - Signature: (circuitId, contractAddress, initialContractState, zswapChainState, partitionedTranscript, privateTranscriptOutputs, input, output, nextZswapLocalState, encryptionPublicKey)                                                                                                                                                                                                                   

  Target:
  - Uses PrePartitionContractCall + Transaction.addCalls() — takes pre-partition transcripts (Op<AlignedValue>[] = raw publicTranscript)
  - addCalls() internally handles transcript partitioning and UnshieldedOffer creation — no manual work needed
  - PreTranscript requires a LedgerQueryContext — created via createCircuitContext() from compact-runtime, which reproduces the exact same context used during circuit execution
  - Signature: (circuitId, contractAddress, initialContractState, zswapChainState, publicTranscript, privateTranscriptOutputs, input, output, nextZswapLocalState, encryptionPublicKey, ledgerParameters, coinPublicKey)

  What changes in the caller (unproven-call-tx.ts):
  - Passes raw publicTranscript instead of partitionedTranscript
  - Adds ledgerParameters and coinPublicKey as new parameters
  - Removes extractUserAddressedOutputs and manual offer construction

  Why:
  - addCalls() is the newer, correct API — it manages partitioning and offers internally
  - Eliminates bugs from manually building UnshieldedOffer (e.g., error 139 in e2e tests with NIGHT token transfers)
  - createCircuitContext guarantees the QueryContext in PreTranscript has the exact same state path encoding as the one used during circuit execution (solves the [-] vs [01] encoding mismatch)

