### PR TITLE
feat: http-client-proof-provider - add custom headers for 3rd party proof servers

### DIFF
--- a/packages/http-client-proof-provider/src/http-client-proving-provider.ts
+++ b/packages/http-client-proof-provider/src/http-client-proving-provider.ts
@@ -53,10 +53,11 @@ const getKeyMaterial = async <K extends string>(
   }
 };
 
-const makeHttpRequest = async (url: URL, payload: Uint8Array, timeout: number): Promise<Uint8Array> => {
+const makeHttpRequest = async (url: URL, payload: Uint8Array, timeout: number, headers: Record<string, string> = {}): Promise<Uint8Array> => {
   const response = await fetchRetry(url, {
     method: 'POST',
     body: new Uint8Array(payload),
+    headers: { 'Content-Type': 'application/octet-stream', ...headers },
     signal: AbortSignal.timeout(timeout)
   });
 
@@ -71,6 +72,8 @@ const makeHttpRequest = async (url: URL, payload: Uint8Array, timeout: number): 
 
 export interface ProvingProviderConfig {
   readonly timeout?: number;
+  /** Custom headers to include in every proof server request (e.g., API keys for 3rd party proof services). */
+  readonly headers?: Record<string, string>;
 }
 
 export const httpClientProvingProvider = <K extends string>(
@@ -90,12 +93,13 @@ export const httpClientProvingProvider = <K extends string>(
   }
 
   const timeout = config?.timeout ?? DEFAULT_TIMEOUT;
+  const headers = config?.headers ?? {};
 
   return  {
     async check(serializedPreimage: Uint8Array, keyLocation: string): Promise<(bigint | undefined)[]> {
       const keyMaterial = await getKeyMaterial(zkConfigProvider, keyLocation as K);
       const payload = createCheckPayload(serializedPreimage, keyMaterial?.ir);
-      const result = await makeHttpRequest(checkUrl, payload, timeout);
+      const result = await makeHttpRequest(checkUrl, payload, timeout, headers);
       return parseCheckResult(result);
     },
 
@@ -106,7 +110,7 @@ export const httpClientProvingProvider = <K extends string>(
     ): Promise<Uint8Array> {
       const keyMaterial = await getKeyMaterial(zkConfigProvider, keyLocation as K);
       const payload = createProvingPayload(serializedPreimage, overwriteBindingInput, keyMaterial);
-      return makeHttpRequest(proveUrl, payload, timeout);
+      return makeHttpRequest(proveUrl, payload, timeout, headers);
     }
   };
 };


### PR DESCRIPTION
## Summary

Adds an optional `headers` field to `ProvingProviderConfig` in the HTTP client proof provider, enabling the Midnight SDK to work with authenticated 3rd party proof servers.

## Motivation

The current `httpClientProvingProvider` does not support custom HTTP headers. This makes it impossible to use the Midnight SDK with proof services that require API key authentication (e.g., `X-API-Key` header).

As the Midnight ecosystem grows, multiple proof-as-a-service providers are emerging (such as [Proof Station](https://proofstation.io)). These services require authentication headers to identify callers, enforce rate limits, and track usage. Without SDK-level header support, developers must create wrapper packages or intercept fetch calls to add authentication.

## Changes

**1 file changed, 7 insertions(+), 3 deletions(-)**

- Add `headers?: Record<string, string>` to `ProvingProviderConfig` interface
- Pass custom headers to `makeHttpRequest` via `fetchRetry`
- Set `Content-Type: application/octet-stream` as default header
- Fully backwards compatible — `headers` defaults to `{}`

## Usage

```typescript
// Before (no auth support)
const provider = httpClientProvingProvider(url, zkConfigProvider, {
  timeout: 300000,
});

// After (with API key auth)
const provider = httpClientProvingProvider(url, zkConfigProvider, {
  timeout: 300000,
  headers: {
    'X-API-Key': 'pk_live_...',
  },
});
```

## Backwards Compatibility

- No breaking changes
- Existing code continues to work without modification
- `headers` is optional and defaults to empty object
- No new dependencies

## Test Plan

- [ ] Existing tests pass (no behavioral change when `headers` is omitted)
- [ ] Headers are correctly forwarded to `/prove` and `/check` endpoints
- [ ] `Content-Type: application/octet-stream` is set by default
- [ ] Custom headers merge with defaults without overwriting

---

*Submitted by [Utkarsh Varma](https://github.com/UvRoxx) at [Webisoft](https://webisoft.com)*