### PR TITLE
docs: update release and API docs from v4.0.0 to v4.0.1

### DIFF
--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/README.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/README.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/CallTxFailedError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/CallTxFailedError.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -28,9 +28,9 @@ The finalization data of the call transaction that failed.
 
 ##### circuitId
 
-`string` \| `string`[]
-
 The name of the circuit that was called to build the transaction.
+
+`string` | `string`[]
 
 #### Returns
 
@@ -44,7 +44,7 @@ The name of the circuit that was called to build the transaction.
 
 ### circuitId?
 
-> `readonly` `optional` **circuitId?**: `string` \| `string`[]
+> `readonly` `optional` **circuitId**: `string` \| `string`[]
 
 The name of the circuit that was called to create the call
                  transaction that failed. Only defined if a call transaction

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/ContractTypeError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/ContractTypeError.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/DeployTxFailedError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/DeployTxFailedError.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -38,7 +38,7 @@ The finalization data of the deployment transaction that failed.
 
 ### circuitId?
 
-> `readonly` `optional` **circuitId?**: `string` \| `string`[]
+> `readonly` `optional` **circuitId**: `string` \| `string`[]
 
 The name of the circuit that was called to create the call
                  transaction that failed. Only defined if a call transaction

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/IncompleteCallTxPrivateStateConfig.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/IncompleteCallTxPrivateStateConfig.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/IncompleteFindContractPrivateStateConfig.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/IncompleteFindContractPrivateStateConfig.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/InsertVerifierKeyTxFailedError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/InsertVerifierKeyTxFailedError.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -36,7 +36,7 @@ An error indicating that a verifier key insertion transaction failed.
 
 ### circuitId?
 
-> `readonly` `optional` **circuitId?**: `string` \| `string`[]
+> `readonly` `optional` **circuitId**: `string` \| `string`[]
 
 The name of the circuit that was called to create the call
                  transaction that failed. Only defined if a call transaction

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/RemoveVerifierKeyTxFailedError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/RemoveVerifierKeyTxFailedError.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -36,7 +36,7 @@ An error indicating that a verifier key removal transaction failed.
 
 ### circuitId?
 
-> `readonly` `optional` **circuitId?**: `string` \| `string`[]
+> `readonly` `optional` **circuitId**: `string` \| `string`[]
 
 The name of the circuit that was called to create the call
                  transaction that failed. Only defined if a call transaction

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/ReplaceMaintenanceAuthorityTxFailedError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/ReplaceMaintenanceAuthorityTxFailedError.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -36,7 +36,7 @@ An error indicating that a contract maintenance authority replacement transactio
 
 ### circuitId?
 
-> `readonly` `optional` **circuitId?**: `string` \| `string`[]
+> `readonly` `optional` **circuitId**: `string` \| `string`[]
 
 The name of the circuit that was called to create the call
                  transaction that failed. Only defined if a call transaction

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/TxFailedError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/classes/TxFailedError.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -36,11 +36,11 @@ The finalization data of the transaction that failed.
 
 ##### circuitId?
 
-`string` \| `string`[]
-
 The name of the circuit that was called to create the call
                  transaction that failed. Only defined if a call transaction
                  failed.
+
+`string` | `string`[]
 
 #### Returns
 
@@ -54,7 +54,7 @@ The name of the circuit that was called to create the call
 
 ### circuitId?
 
-> `readonly` `optional` **circuitId?**: `string` \| `string`[]
+> `readonly` `optional` **circuitId**: `string` \| `string`[]
 
 The name of the circuit that was called to create the call
                  transaction that failed. Only defined if a call transaction

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createCallTxOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createCallTxOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -36,7 +36,7 @@ Creates a [CallTxOptions](../type-aliases/CallTxOptions.md) object from various 
 
 ### privateStateId
 
-`string` \| `undefined`
+`string` | `undefined`
 
 ### args
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createCircuitCallTxInterface.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createCircuitCallTxInterface.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -38,9 +38,9 @@ The ledger address of the contract.
 
 ### privateStateId
 
-`string` \| `undefined`
-
 The identifier of the state of the witnesses of the contract.
+
+`string` | `undefined`
 
 ## Returns
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createCircuitMaintenanceTxInterface.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createCircuitMaintenanceTxInterface.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createCircuitMaintenanceTxInterfaces.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createCircuitMaintenanceTxInterfaces.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createCircuitMaintenanceTxInterfaces.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createCircuitMaintenanceTxInterfaces.md
@@ -28,6 +28,8 @@ The providers to use to build transactions.
 
 `CompiledContract`\<`C`, `any`\>
 
+The contract to use to execute circuits.
+
 ### contractAddress
 
 `string`

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createContractMaintenanceTxInterface.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createContractMaintenanceTxInterface.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createUnprovenCallTx.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createUnprovenCallTx.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createUnprovenCallTxFromInitialStates.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createUnprovenCallTxFromInitialStates.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createUnprovenCallTxFromInitialStates.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createUnprovenCallTxFromInitialStates.md
@@ -35,7 +35,7 @@ Configuration.
 
 #### zkConfigProvider
 
-`ZKConfigProvider`\<`string`\>
+[`ZKConfigProvider`](#)\<`string`\>
 
 #### options
 
@@ -67,7 +67,7 @@ Configuration.
 
 #### zkConfigProvider
 
-`ZKConfigProvider`\<`string`\>
+[`ZKConfigProvider`](#)\<`string`\>
 
 #### options
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createUnprovenDeployTx.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createUnprovenDeployTx.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createUnprovenDeployTxFromVerifierKeys.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createUnprovenDeployTxFromVerifierKeys.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createUnprovenDeployTxFromVerifierKeys.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/createUnprovenDeployTxFromVerifierKeys.md
@@ -37,7 +37,7 @@ Configuration.
 
 #### zkConfigProvider
 
-`ZKConfigProvider`\<`string`\>
+[`ZKConfigProvider`](#)\<`string`\>
 
 #### coinPublicKey
 
@@ -69,7 +69,7 @@ Configuration.
 
 #### zkConfigProvider
 
-`ZKConfigProvider`\<`string`\>
+[`ZKConfigProvider`](#)\<`string`\>
 
 #### coinPublicKey
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/deployContract.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/deployContract.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/findDeployedContract.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/findDeployedContract.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/getPublicStates.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/getPublicStates.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/getPublicStates.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/getPublicStates.md
@@ -14,7 +14,7 @@ Fetches only the public visible (Zswap and ledger) states of a contract.
 
 ### publicDataProvider
 
-`PublicDataProvider`
+[`PublicDataProvider`](#)
 
 The provider to use to fetch the public states (Zswap and ledger)
                           from the blockchain.

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/getStates.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/getStates.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/getStates.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/getStates.md
@@ -21,14 +21,14 @@ to the given identifier using the given providers.
 
 ### publicDataProvider
 
-`PublicDataProvider`
+[`PublicDataProvider`](#)
 
 The provider to use to fetch the public states (Zswap and ledger)
                           from the blockchain.
 
 ### privateStateProvider
 
-`PrivateStateProvider`\<`string`, `PS`\>
+[`PrivateStateProvider`](#)\<`string`, `PS`\>
 
 The provider to use to fetch the private state.
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/getUnshieldedBalances.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/getUnshieldedBalances.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/getUnshieldedBalances.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/getUnshieldedBalances.md
@@ -14,7 +14,7 @@ Fetches the unshielded balances associated with a specific contract address.
 
 ### publicDataProvider
 
-`PublicDataProvider`
+[`PublicDataProvider`](#)
 
 The provider to use to fetch the unshielded balances from the blockchain.
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitCallTx.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitCallTx.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitCallTxAsync.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitCallTxAsync.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitDeployTx.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitDeployTx.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitInsertVerifierKeyTx.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitInsertVerifierKeyTx.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitRemoveVerifierKeyTx.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitRemoveVerifierKeyTx.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitReplaceAuthorityTx.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitReplaceAuthorityTx.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitTx.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitTx.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitTxAsync.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/submitTxAsync.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/verifierKeysEqual.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/verifierKeysEqual.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/verifyContractState.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/functions/verifyContractState.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/interfaces/ContractMaintenanceTxInterface.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/interfaces/ContractMaintenanceTxInterface.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/interfaces/TransactionContext.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/interfaces/TransactionContext.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -20,7 +20,7 @@ Encapsulates the context for managing a scoped contract transaction.
 
 ## Properties
 
-### \[CacheStates\]
+### \[CacheStates\]()
 
 > `readonly` **\[CacheStates\]**: (`states`, `identity`) => `void`
 
@@ -28,7 +28,7 @@ Encapsulates the context for managing a scoped contract transaction.
 
 ##### states
 
-[`PublicContractStates`](../type-aliases/PublicContractStates.md) \| [`ContractStates`](../type-aliases/ContractStates.md)\<`PrivateState`\<`C`\>\>
+[`PublicContractStates`](../type-aliases/PublicContractStates.md) | [`ContractStates`](../type-aliases/ContractStates.md)\<`PrivateState`\<`C`\>\>
 
 ##### identity
 
@@ -40,7 +40,7 @@ Encapsulates the context for managing a scoped contract transaction.
 
 ***
 
-### \[GetCurrentStatesForIdentity\]
+### \[GetCurrentStatesForIdentity\]()
 
 > `readonly` **\[GetCurrentStatesForIdentity\]**: (`identity`) => [`PublicContractStates`](../type-aliases/PublicContractStates.md) \| [`ContractStates`](../type-aliases/ContractStates.md)\<`PrivateState`\<`C`\>\> \| `undefined`
 
@@ -56,7 +56,7 @@ Encapsulates the context for managing a scoped contract transaction.
 
 ***
 
-### \[MergeUnsubmittedCallTxData\]
+### \[MergeUnsubmittedCallTxData\]()
 
 > `readonly` **\[MergeUnsubmittedCallTxData\]**: (`circuitId`, `callData`, `privateStateId?`) => `void`
 
@@ -80,7 +80,7 @@ Encapsulates the context for managing a scoped contract transaction.
 
 ***
 
-### \[Submit\]
+### \[Submit\]()
 
 > `readonly` **\[Submit\]**: () => `Promise`\<[`FinalizedCallTxData`](../type-aliases/FinalizedCallTxData.md)\<`C`, `PCK`\>\>
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallOptionsBase.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallOptionsBase.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallOptionsBase.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallOptionsBase.md
@@ -40,6 +40,6 @@ The contract defining the circuit to call.
 
 ### contractAddress
 
-> `readonly` **contractAddress**: `ContractAddress`
+> `readonly` **contractAddress**: [`ContractAddress`](#)
 
 The address of the contract being executed.

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallOptionsProviderDataDependencies.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallOptionsProviderDataDependencies.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallOptionsWithArguments.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallOptionsWithArguments.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallOptionsWithPrivateState.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallOptionsWithPrivateState.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallOptionsWithProviderDataDependencies.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallOptionsWithProviderDataDependencies.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallResult.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallResult.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallResultPrivate.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallResultPrivate.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallResultPublic.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallResultPublic.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallTxOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallTxOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallTxOptionsBase.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallTxOptionsBase.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallTxOptionsWithPrivateStateId.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CallTxOptionsWithPrivateStateId.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CircuitCallTxInterface.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CircuitCallTxInterface.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CircuitMaintenanceTxInterface.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CircuitMaintenanceTxInterface.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CircuitMaintenanceTxInterfaces.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/CircuitMaintenanceTxInterfaces.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractConstructorOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractConstructorOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractConstructorOptionsBase.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractConstructorOptionsBase.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractConstructorOptionsProviderDataDependencies.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractConstructorOptionsProviderDataDependencies.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractConstructorOptionsWithArguments.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractConstructorOptionsWithArguments.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractConstructorOptionsWithPrivateState.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractConstructorOptionsWithPrivateState.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractConstructorOptionsWithProviderDataDependencies.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractConstructorOptionsWithProviderDataDependencies.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractConstructorResult.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractConstructorResult.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractProviders.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractProviders.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractStates.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ContractStates.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployContractOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployContractOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployContractOptionsBase.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployContractOptionsBase.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -17,7 +17,7 @@ in the event that `signingKey` is undefined.
 
 ### signingKey?
 
-> `readonly` `optional` **signingKey?**: `SigningKey`
+> `readonly` `optional` **signingKey**: `SigningKey`
 
 The signing key to add as the to-be-deployed contract's maintenance authority.
 If undefined, a new signing key is sampled and used as the CMA then stored

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployContractOptionsWithPrivateState.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployContractOptionsWithPrivateState.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployTxOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployTxOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployTxOptionsBase.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployTxOptionsBase.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployTxOptionsWithPrivateState.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployTxOptionsWithPrivateState.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployTxOptionsWithPrivateStateId.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployTxOptionsWithPrivateStateId.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployedContract.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/DeployedContract.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FinalizedCallTxData.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FinalizedCallTxData.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FinalizedDeployTxData.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FinalizedDeployTxData.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FinalizedDeployTxDataBase.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FinalizedDeployTxDataBase.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FindDeployedContractOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FindDeployedContractOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FindDeployedContractOptionsBase.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FindDeployedContractOptionsBase.md
@@ -28,7 +28,7 @@ The compiled contract to use to execute circuits.
 
 ### contractAddress
 
-> `readonly` **contractAddress**: `ContractAddress`
+> `readonly` **contractAddress**: [`ContractAddress`](#)
 
 The address of a previously deployed contract.
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FindDeployedContractOptionsBase.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FindDeployedContractOptionsBase.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -36,7 +36,7 @@ The address of a previously deployed contract.
 
 ### signingKey?
 
-> `readonly` `optional` **signingKey?**: `SigningKey`
+> `readonly` `optional` **signingKey**: `SigningKey`
 
 The signing key to use to perform contract maintenance updates. If defined, the given signing
 key is stored for this contract address. This is useful when someone has already added the given signing

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FindDeployedContractOptionsExistingPrivateState.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FindDeployedContractOptionsExistingPrivateState.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FindDeployedContractOptionsStorePrivateState.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FindDeployedContractOptionsStorePrivateState.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FoundContract.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/FoundContract.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/PublicContractStates.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/PublicContractStates.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ScopedTransactionOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/ScopedTransactionOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -14,6 +14,6 @@ Options for use when creating scoped transactions.
 
 ### scopeName?
 
-> `readonly` `optional` **scopeName?**: `string`
+> `readonly` `optional` **scopeName**: `string`
 
 An optional name for the transaction scope.

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/SubmitTxOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/SubmitTxOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -20,7 +20,7 @@ Configuration for [submitTx](../functions/submitTx.md).
 
 ### circuitId?
 
-> `readonly` `optional` **circuitId?**: `PCK` \| `PCK`[]
+> `readonly` `optional` **circuitId**: `PCK` \| `PCK`[]
 
 A circuit identifier to use to fetch the ZK artifacts needed to prove the
 transaction. Only defined if a call transaction is being submitted.

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/SubmitTxProviders.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/SubmitTxProviders.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/SubmittedCallTx.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/SubmittedCallTx.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnprovenCallTxProvidersBase.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnprovenCallTxProvidersBase.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnprovenCallTxProvidersWithPrivateState.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnprovenCallTxProvidersWithPrivateState.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnprovenDeployTxOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnprovenDeployTxOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnprovenDeployTxProviders.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnprovenDeployTxProviders.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnsubmittedCallTxData.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnsubmittedCallTxData.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnsubmittedDeployTxData.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnsubmittedDeployTxData.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnsubmittedDeployTxDataBase.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnsubmittedDeployTxDataBase.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnsubmittedDeployTxPrivateData.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnsubmittedDeployTxPrivateData.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnsubmittedDeployTxPublicData.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnsubmittedDeployTxPublicData.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnsubmittedDeployTxPublicData.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnsubmittedDeployTxPublicData.md
@@ -14,7 +14,7 @@ Base type for public data relevant to an unsubmitted deployment transaction.
 
 ### contractAddress
 
-> `readonly` **contractAddress**: `ContractAddress`
+> `readonly` **contractAddress**: [`ContractAddress`](#)
 
 The ledger address of the contract that was deployed.
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnsubmittedTxData.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/type-aliases/UnsubmittedTxData.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/variables/withContractScopedTransaction.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-contracts/variables/withContractScopedTransaction.md
@@ -1,10 +1,10 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
 [Midnight.js API Reference](../../../packages.md) / [@midnight-ntwrk/midnight-js-contracts](../README.md) / withContractScopedTransaction
 
-# Variable: withContractScopedTransaction
+# Variable: withContractScopedTransaction()
 
 > `const` **withContractScopedTransaction**: \<`C`, `PCK`\>(`providers`, `fn`, `options?`) => `Promise`\<[`FinalizedCallTxData`](../type-aliases/FinalizedCallTxData.md)\<`C`, `PCK`\>\>
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-fetch-zk-config-provider/README.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-fetch-zk-config-provider/README.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-fetch-zk-config-provider/classes/FetchZkConfigProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-fetch-zk-config-provider/classes/FetchZkConfigProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-fetch-zk-config-provider/classes/FetchZkConfigProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-fetch-zk-config-provider/classes/FetchZkConfigProvider.md
@@ -10,7 +10,7 @@ Retrieves ZK artifacts from a remote source.
 
 ## Extends
 
-- `ZKConfigProvider`\<`K`\>
+- [`ZKConfigProvider`](#)\<`K`\>
 
 ## Type Parameters
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/README.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/README.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/functions/httpClientProofProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/functions/httpClientProofProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/functions/httpClientProofProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/functions/httpClientProofProvider.md
@@ -6,10 +6,10 @@
 
 # Function: httpClientProofProvider()
 
-> **httpClientProofProvider**\<`K`\>(`url`, `zkConfigProvider`, `config?`): `ProofProvider`
+> **httpClientProofProvider**\<`K`\>(`url`, `zkConfigProvider`, `config?`): [`ProofProvider`](#)
 
-Creates a high-level ProofProvider that implements transaction-level proving
-using the low-level circuit-by-circuit ProvingProvider as its foundation.
+Creates a high-level [ProofProvider](#) that implements transaction-level proving
+using the low-level circuit-by-circuit [ProvingProvider](#) as its foundation.
 
 This adapter bridges the gap between:
 - High-level ProofProvider interface (works with complete transactions)
@@ -31,7 +31,7 @@ The URL of the proof server
 
 ### zkConfigProvider
 
-`ZKConfigProvider`\<`K`\>
+[`ZKConfigProvider`](#)\<`K`\>
 
 Provider for zero-knowledge configuration artifacts
 
@@ -43,7 +43,7 @@ Optional configuration for the underlying ProvingProvider
 
 ## Returns
 
-`ProofProvider`
+[`ProofProvider`](#)
 
 A ProofProvider instance that uses ProvingProvider internally
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/functions/httpClientProvingProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/functions/httpClientProvingProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/functions/httpClientProvingProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/functions/httpClientProvingProvider.md
@@ -6,7 +6,7 @@
 
 # Function: httpClientProvingProvider()
 
-> **httpClientProvingProvider**\<`K`\>(`url`, `zkConfigProvider`, `config?`): `ProvingProvider`
+> **httpClientProvingProvider**\<`K`\>(`url`, `zkConfigProvider`, `config?`): [`ProvingProvider`](#)
 
 ## Type Parameters
 
@@ -22,7 +22,7 @@
 
 ### zkConfigProvider
 
-`ZKConfigProvider`\<`K`\>
+[`ZKConfigProvider`](#)\<`K`\>
 
 ### config?
 
@@ -30,4 +30,4 @@
 
 ## Returns
 
-`ProvingProvider`
+[`ProvingProvider`](#)

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/interfaces/ProvingProviderConfig.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/interfaces/ProvingProviderConfig.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -10,4 +10,4 @@
 
 ### timeout?
 
-> `readonly` `optional` **timeout?**: `number`
+> `readonly` `optional` **timeout**: `number`

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/variables/DEFAULT_CONFIG.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/variables/DEFAULT_CONFIG.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/variables/DEFAULT_TIMEOUT.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-http-client-proof-provider/variables/DEFAULT_TIMEOUT.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-indexer-public-data-provider/README.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-indexer-public-data-provider/README.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-indexer-public-data-provider/classes/IndexerFormattedError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-indexer-public-data-provider/classes/IndexerFormattedError.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-indexer-public-data-provider/functions/indexerPublicDataProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-indexer-public-data-provider/functions/indexerPublicDataProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-indexer-public-data-provider/functions/indexerPublicDataProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-indexer-public-data-provider/functions/indexerPublicDataProvider.md
@@ -6,9 +6,9 @@
 
 # Function: indexerPublicDataProvider()
 
-> **indexerPublicDataProvider**(`queryURL`, `subscriptionURL`, `webSocketImpl?`): `PublicDataProvider`
+> **indexerPublicDataProvider**(`queryURL`, `subscriptionURL`, `webSocketImpl?`): [`PublicDataProvider`](#)
 
-Constructs a PublicDataProvider based on an ApolloClient.
+Constructs a [PublicDataProvider](#) based on an [ApolloClient](#).
 
 ## Parameters
 
@@ -34,4 +34,4 @@ TODO: Re-examine caching when 'ContractCall' and 'ContractDeploy' have transacti
 
 ## Returns
 
-`PublicDataProvider`
+[`PublicDataProvider`](#)

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-indexer-public-data-provider/functions/toUnshieldedBalances.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-indexer-public-data-provider/functions/toUnshieldedBalances.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-indexer-public-data-provider/functions/toUnshieldedUtxos.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-indexer-public-data-provider/functions/toUnshieldedUtxos.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-indexer-public-data-provider/type-aliases/IndexerUtxo.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-indexer-public-data-provider/type-aliases/IndexerUtxo.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/README.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/README.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/classes/StorageEncryption.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/classes/StorageEncryption.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/functions/decryptValue.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/functions/decryptValue.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/functions/levelPrivateStateProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/functions/levelPrivateStateProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/functions/levelPrivateStateProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/functions/levelPrivateStateProvider.md
@@ -6,9 +6,9 @@
 
 # Function: levelPrivateStateProvider()
 
-> **levelPrivateStateProvider**\<`PSI`, `PS`\>(`config`): `PrivateStateProvider`\<`PSI`, `PS`\> & `object`
+> **levelPrivateStateProvider**\<`PSI`, `PS`\>(`config`): [`PrivateStateProvider`](#)\<`PSI`, `PS`\> & `object`
 
-Constructs an instance of PrivateStateProvider based on Level database.
+Constructs an instance of [PrivateStateProvider](#) based on [Level](#) database.
 
 ⚠️ WARNING
 
@@ -37,4 +37,4 @@ Database configuration options.
 
 ## Returns
 
-`PrivateStateProvider`\<`PSI`, `PS`\> & `object`
+[`PrivateStateProvider`](#)\<`PSI`, `PS`\> & `object`

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/functions/migrateToAccountScoped.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/functions/migrateToAccountScoped.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/interfaces/LevelPrivateStateProviderConfig.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/interfaces/LevelPrivateStateProviderConfig.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/interfaces/MigrationResult.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/interfaces/MigrationResult.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/interfaces/PasswordRotationOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/interfaces/PasswordRotationOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -10,4 +10,4 @@
 
 ### maxEntries?
 
-> `readonly` `optional` **maxEntries?**: `number`
+> `readonly` `optional` **maxEntries**: `number`

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/interfaces/PasswordRotationResult.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/interfaces/PasswordRotationResult.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/type-aliases/PrivateStoragePasswordProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/type-aliases/PrivateStoragePasswordProvider.md
@@ -1,10 +1,10 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
 [Midnight.js API Reference](../../../packages.md) / [@midnight-ntwrk/midnight-js-level-private-state-provider](../README.md) / PrivateStoragePasswordProvider
 
-# Type Alias: PrivateStoragePasswordProvider
+# Type Alias: PrivateStoragePasswordProvider()
 
 > **PrivateStoragePasswordProvider** = () => `string` \| `Promise`\<`string`\>
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/variables/DEFAULT_CONFIG.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-level-private-state-provider/variables/DEFAULT_CONFIG.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-logger-provider/README.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-logger-provider/README.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-logger-provider/classes/LoggerProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-logger-provider/classes/LoggerProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-logger-provider/classes/LoggerProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-logger-provider/classes/LoggerProvider.md
@@ -6,7 +6,7 @@
 
 # Class: LoggerProvider
 
-Implementation of LoggerProvider that returns a Logger instance.
+Implementation of LoggerProvider that returns a [Logger](#) instance.
 
 ## Constructors
 
@@ -18,7 +18,7 @@ Implementation of LoggerProvider that returns a Logger instance.
 
 ##### logger
 
-`Logger`
+[`Logger`](#)
 
 #### Returns
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-network-id/README.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-network-id/README.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-network-id/functions/getNetworkId.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-network-id/functions/getNetworkId.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-network-id/functions/setNetworkId.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-network-id/functions/setNetworkId.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-network-id/type-aliases/NetworkId.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-network-id/type-aliases/NetworkId.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-node-zk-config-provider/README.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-node-zk-config-provider/README.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-node-zk-config-provider/classes/NodeZkConfigProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-node-zk-config-provider/classes/NodeZkConfigProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-node-zk-config-provider/classes/NodeZkConfigProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-node-zk-config-provider/classes/NodeZkConfigProvider.md
@@ -6,11 +6,11 @@
 
 # Class: NodeZkConfigProvider\<K\>
 
-Implementation of ZKConfigProvider that reads the keys and zkIR from the local filesystem.
+Implementation of [ZKConfigProvider](#) that reads the keys and zkIR from the local filesystem.
 
 ## Extends
 
-- `ZKConfigProvider`\<`K`\>
+- [`ZKConfigProvider`](#)\<`K`\>
 
 ## Type Parameters
 
@@ -94,7 +94,7 @@ The circuit ID of the artifacts to retrieve.
 
 > **getProverKey**(`circuitId`): `Promise`\<`ProverKey`\>
 
-ZKConfigProvider.getProverKey
+[ZKConfigProvider.getProverKey](#)
 
 #### Parameters
 
@@ -116,7 +116,7 @@ ZKConfigProvider.getProverKey
 
 > **getVerifierKey**(`circuitId`): `Promise`\<`VerifierKey`\>
 
-ZKConfigProvider.getVerifierKey
+[ZKConfigProvider.getVerifierKey](#)
 
 #### Parameters
 
@@ -162,7 +162,7 @@ The circuit IDs of the verifier keys to retrieve.
 
 > **getZKIR**(`circuitId`): `Promise`\<`ZKIR`\>
 
-ZKConfigProvider.getZKIR
+[ZKConfigProvider.getZKIR](#)
 
 #### Parameters
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/README.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/README.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/ExportDecryptionError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/ExportDecryptionError.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -32,7 +32,7 @@ The specific cause is intentionally not disclosed to prevent oracle attacks.
 
 ### cause?
 
-> `readonly` `optional` **cause?**: [`PrivateStateImportErrorCause`](../type-aliases/PrivateStateImportErrorCause.md)
+> `readonly` `optional` **cause**: [`PrivateStateImportErrorCause`](../type-aliases/PrivateStateImportErrorCause.md)
 
 #### Inherited from
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/ImportConflictError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/ImportConflictError.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -40,7 +40,7 @@ Error thrown when import conflicts with existing data and conflictStrategy is 'e
 
 ### cause?
 
-> `readonly` `optional` **cause?**: [`PrivateStateImportErrorCause`](../type-aliases/PrivateStateImportErrorCause.md)
+> `readonly` `optional` **cause**: [`PrivateStateImportErrorCause`](../type-aliases/PrivateStateImportErrorCause.md)
 
 #### Inherited from
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/InvalidExportFormatError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/InvalidExportFormatError.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -36,7 +36,7 @@ Error thrown when the export data format is invalid.
 
 ### cause?
 
-> `readonly` `optional` **cause?**: [`PrivateStateImportErrorCause`](../type-aliases/PrivateStateImportErrorCause.md)
+> `readonly` `optional` **cause**: [`PrivateStateImportErrorCause`](../type-aliases/PrivateStateImportErrorCause.md)
 
 #### Inherited from
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/InvalidProtocolSchemeError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/InvalidProtocolSchemeError.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/PrivateStateExportError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/PrivateStateExportError.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/PrivateStateImportError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/PrivateStateImportError.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -46,7 +46,7 @@ Base error thrown when importing private states fails.
 
 ### cause?
 
-> `readonly` `optional` **cause?**: [`PrivateStateImportErrorCause`](../type-aliases/PrivateStateImportErrorCause.md)
+> `readonly` `optional` **cause**: [`PrivateStateImportErrorCause`](../type-aliases/PrivateStateImportErrorCause.md)
 
 #### Inherited from
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/SigningKeyExportError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/SigningKeyExportError.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/ZKConfigProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/classes/ZKConfigProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/enumerations/LogLevel.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/enumerations/LogLevel.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/asContractAddress.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/asContractAddress.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/asContractAddress.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/asContractAddress.md
@@ -6,7 +6,7 @@
 
 # Function: asContractAddress()
 
-> **asContractAddress**(`address`): `ContractAddress`
+> **asContractAddress**(`address`): [`ContractAddress`](#)
 
 Constructs a branded contract address from a given string value.
 
@@ -20,6 +20,6 @@ A string value representing a contract address.
 
 ## Returns
 
-`ContractAddress`
+[`ContractAddress`](#)
 
-A ContractAddress.ContractAddress \| ContractAddress constructed from `address`.
+A [ContractAddress](#) constructed from `address`.

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/asEffectOption.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/asEffectOption.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/createProofProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/createProofProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/createProofProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/createProofProvider.md
@@ -8,14 +8,14 @@
 
 > **createProofProvider**(`provingProvider`, `costModel?`): [`ProofProvider`](../interfaces/ProofProvider.md)
 
-Creates a [ProofProvider](../interfaces/ProofProvider.md) from a ProvingProvider.
+Creates a [ProofProvider](../interfaces/ProofProvider.md) from a [ProvingProvider](#).
 The returned provider proves transactions using the initial cost model.
 
 ## Parameters
 
 ### provingProvider
 
-`ProvingProvider`
+[`ProvingProvider`](#)
 
 The underlying proving provider used to generate proofs.
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/createProverKey.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/createProverKey.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/createVerifierKey.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/createVerifierKey.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/createZKIR.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/createZKIR.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/zkConfigToProvingKeyMaterial.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/functions/zkConfigToProvingKeyMaterial.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ExportPrivateStatesOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ExportPrivateStatesOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -12,7 +12,7 @@ Options for exporting private states.
 
 ### maxStates?
 
-> `readonly` `optional` **maxStates?**: `number`
+> `readonly` `optional` **maxStates**: `number`
 
 Maximum number of states to export.
 Defaults to MAX_EXPORT_STATES (10000).
@@ -22,7 +22,7 @@ Set to a lower value to limit memory usage.
 
 ### password?
 
-> `readonly` `optional` **password?**: `string`
+> `readonly` `optional` **password**: `string`
 
 Password used to encrypt the export.
 Must be at least 16 characters.

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ExportSigningKeysOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ExportSigningKeysOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -12,7 +12,7 @@ Options for exporting signing keys.
 
 ### maxKeys?
 
-> `readonly` `optional` **maxKeys?**: `number`
+> `readonly` `optional` **maxKeys**: `number`
 
 Maximum number of keys to export.
 Defaults to MAX_EXPORT_SIGNING_KEYS (10000).
@@ -22,7 +22,7 @@ Set to a lower value to limit memory usage.
 
 ### password?
 
-> `readonly` `optional` **password?**: `string`
+> `readonly` `optional` **password**: `string`
 
 Password used to encrypt the export.
 Must be at least 16 characters.

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/FinalizedTxData.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/FinalizedTxData.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ImportPrivateStatesOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ImportPrivateStatesOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -12,7 +12,7 @@ Options for importing private states.
 
 ### conflictStrategy?
 
-> `readonly` `optional` **conflictStrategy?**: `"error"` \| `"skip"` \| `"overwrite"`
+> `readonly` `optional` **conflictStrategy**: `"error"` \| `"skip"` \| `"overwrite"`
 
 How to handle conflicts when a private state ID already exists.
 - 'skip': Keep existing state, ignore imported state
@@ -24,7 +24,7 @@ Default: 'error'
 
 ### maxStates?
 
-> `readonly` `optional` **maxStates?**: `number`
+> `readonly` `optional` **maxStates**: `number`
 
 Maximum number of states to import.
 Defaults to MAX_EXPORT_STATES (10000).
@@ -34,7 +34,7 @@ Set to a lower value to limit memory usage.
 
 ### password?
 
-> `readonly` `optional` **password?**: `string`
+> `readonly` `optional` **password**: `string`
 
 Password used to decrypt the import.
 Must match the password used during export.

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ImportPrivateStatesResult.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ImportPrivateStatesResult.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ImportSigningKeysOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ImportSigningKeysOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -12,7 +12,7 @@ Options for importing signing keys.
 
 ### conflictStrategy?
 
-> `readonly` `optional` **conflictStrategy?**: `"error"` \| `"skip"` \| `"overwrite"`
+> `readonly` `optional` **conflictStrategy**: `"error"` \| `"skip"` \| `"overwrite"`
 
 How to handle conflicts when a signing key already exists for an address.
 - 'skip': Keep existing key, ignore imported key
@@ -24,7 +24,7 @@ Default: 'error'
 
 ### maxKeys?
 
-> `readonly` `optional` **maxKeys?**: `number`
+> `readonly` `optional` **maxKeys**: `number`
 
 Maximum number of keys to import.
 Defaults to MAX_EXPORT_SIGNING_KEYS (10000).
@@ -34,7 +34,7 @@ Set to a lower value to limit memory usage.
 
 ### password?
 
-> `readonly` `optional` **password?**: `string`
+> `readonly` `optional` **password**: `string`
 
 Password used to decrypt the import.
 Must match the password used during export.

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ImportSigningKeysResult.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ImportSigningKeysResult.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/LoggerProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/LoggerProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -12,31 +12,31 @@ A provider for logging functions.
 
 ### debug?
 
-> `optional` **debug?**: `LogFn`
+> `optional` **debug**: `LogFn`
 
 ***
 
 ### error?
 
-> `optional` **error?**: `LogFn`
+> `optional` **error**: `LogFn`
 
 ***
 
 ### fatal?
 
-> `optional` **fatal?**: `LogFn`
+> `optional` **fatal**: `LogFn`
 
 ***
 
 ### info?
 
-> `optional` **info?**: `LogFn`
+> `optional` **info**: `LogFn`
 
 ***
 
 ### warn?
 
-> `optional` **warn?**: `LogFn`
+> `optional` **warn**: `LogFn`
 
 ## Methods
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/MidnightProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/MidnightProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/MidnightProviders.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/MidnightProviders.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -32,7 +32,7 @@ Parameter indicating the private state type stored, sometimes a union of private
 
 ### loggerProvider?
 
-> `readonly` `optional` **loggerProvider?**: [`LoggerProvider`](LoggerProvider.md)
+> `readonly` `optional` **loggerProvider**: [`LoggerProvider`](LoggerProvider.md)
 
 An optional logger that provides utilities for logging at given levels.
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/PrivateStateExport.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/PrivateStateExport.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/PrivateStateProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/PrivateStateProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ProofProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ProofProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ProveTxConfig.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ProveTxConfig.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -12,6 +12,6 @@ The configuration for the proof request to the proof provider.
 
 ### timeout?
 
-> `readonly` `optional` **timeout?**: `number`
+> `readonly` `optional` **timeout**: `number`
 
 The timeout for the request.

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/PublicDataProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/PublicDataProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -57,10 +57,10 @@ The address of the contract of interest.
 
 ##### config?
 
-[`BlockHeightConfig`](../type-aliases/BlockHeightConfig.md) \| [`BlockHashConfig`](../type-aliases/BlockHashConfig.md)
-
 The configuration of the query.
               If `undefined` returns the latest states.
+
+[`BlockHeightConfig`](../type-aliases/BlockHeightConfig.md) | [`BlockHashConfig`](../type-aliases/BlockHashConfig.md)
 
 #### Returns
 
@@ -105,10 +105,10 @@ The address of the contract of interest.
 
 ##### config?
 
-[`BlockHeightConfig`](../type-aliases/BlockHeightConfig.md) \| [`BlockHashConfig`](../type-aliases/BlockHashConfig.md)
-
 The configuration of the query.
               If `undefined` returns the latest states.
+
+[`BlockHeightConfig`](../type-aliases/BlockHeightConfig.md) | [`BlockHashConfig`](../type-aliases/BlockHashConfig.md)
 
 #### Returns
 
@@ -135,10 +135,10 @@ The address of the contract of interest.
 
 ##### config?
 
-[`BlockHeightConfig`](../type-aliases/BlockHeightConfig.md) \| [`BlockHashConfig`](../type-aliases/BlockHashConfig.md)
-
 The configuration of the query.
               If `undefined` returns the latest states.
+
+[`BlockHeightConfig`](../type-aliases/BlockHeightConfig.md) | [`BlockHashConfig`](../type-aliases/BlockHashConfig.md)
 
 #### Returns
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/SigningKeyExport.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/SigningKeyExport.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/WalletProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/WalletProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ZKConfig.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/ZKConfig.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/All.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/All.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/AnyPrivateState.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/AnyPrivateState.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/AnyProvableCircuitId.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/AnyProvableCircuitId.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/BlockHash.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/BlockHash.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/BlockHashConfig.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/BlockHashConfig.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/BlockHeightConfig.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/BlockHeightConfig.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/ContractExecutableRuntimeOptions.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/ContractExecutableRuntimeOptions.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -22,6 +22,6 @@ The current user's ZSwap public key.
 
 ### signingKey?
 
-> `readonly` `optional` **signingKey?**: `string`
+> `readonly` `optional` **signingKey**: `string`
 
 The signing key to add as the to-be-deployed contract's maintenance authority.

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/ContractStateObservableConfig.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/ContractStateObservableConfig.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/Fees.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/Fees.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/KeyMaterialProvider.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/KeyMaterialProvider.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/Latest.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/Latest.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/PrivateStateId.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/PrivateStateId.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/PrivateStateImportErrorCause.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/PrivateStateImportErrorCause.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/ProverKey.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/ProverKey.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/SegmentStatus.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/SegmentStatus.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/TxIdConfig.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/TxIdConfig.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/TxStatus.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/TxStatus.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/UnboundTransaction.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/UnboundTransaction.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/UnshieldedBalance.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/UnshieldedBalance.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/UnshieldedBalances.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/UnshieldedBalances.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/UnshieldedUtxo.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/UnshieldedUtxo.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/UnshieldedUtxos.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/UnshieldedUtxos.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/VerifierKey.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/VerifierKey.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/ZKIR.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/type-aliases/ZKIR.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/FailEntirely.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/FailEntirely.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/FailFallible.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/FailFallible.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/MAX_EXPORT_SIGNING_KEYS.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/MAX_EXPORT_SIGNING_KEYS.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/MAX_EXPORT_STATES.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/MAX_EXPORT_STATES.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/SegmentFail.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/SegmentFail.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/SegmentSuccess.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/SegmentSuccess.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/SucceedEntirely.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/SucceedEntirely.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/exitResultOrError.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/exitResultOrError.md
@@ -1,10 +1,10 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
 [Midnight.js API Reference](../../../packages.md) / [@midnight-ntwrk/midnight-js-types](../README.md) / exitResultOrError
 
-# Variable: exitResultOrError
+# Variable: exitResultOrError()
 
 > `const` **exitResultOrError**: \<`A`, `E`\>(`exit`) => `A`
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/makeContractExecutableRuntime.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/makeContractExecutableRuntime.md
@@ -1,10 +1,10 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
 [Midnight.js API Reference](../../../packages.md) / [@midnight-ntwrk/midnight-js-types](../README.md) / makeContractExecutableRuntime
 
-# Variable: makeContractExecutableRuntime
+# Variable: makeContractExecutableRuntime()
 
 > `const` **makeContractExecutableRuntime**: (`zkConfigProvider`, `options`) => `ManagedRuntime`\<`ContractExecutable.ContractExecutable.Context`, `ConfigError.ConfigError`\>
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/makeContractExecutableRuntime.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-types/variables/makeContractExecutableRuntime.md
@@ -6,7 +6,7 @@
 
 # Variable: makeContractExecutableRuntime()
 
-> `const` **makeContractExecutableRuntime**: (`zkConfigProvider`, `options`) => `ManagedRuntime`\<`ContractExecutable.ContractExecutable.Context`, `ConfigError.ConfigError`\>
+> `const` **makeContractExecutableRuntime**: (`zkConfigProvider`, `options`) => [`ManagedRuntime`](#)\<`ContractExecutable.ContractExecutable.Context`, `ConfigError.ConfigError`\>
 
 Constructs an Effect managed runtime configured to execute contract executables.
 
@@ -26,6 +26,6 @@ Values that will be mapped into and made available within the constructed runtim
 
 ## Returns
 
-`ManagedRuntime`\<`ContractExecutable.ContractExecutable.Context`, `ConfigError.ConfigError`\>
+[`ManagedRuntime`](#)\<`ContractExecutable.ContractExecutable.Context`, `ConfigError.ConfigError`\>
 
-An Effect ManagedRuntime that can be used to execute ContractExecutable instances.
+An Effect [ManagedRuntime](#) that can be used to execute [ContractExecutable](#) instances.

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/README.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/README.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/assertDefined.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/assertDefined.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -20,9 +20,9 @@ Asserts that the given value is non-nullable.
 
 ### value
 
-`A` \| `null` \| `undefined`
-
 The value to test for nullability.
+
+`A` | `null` | `undefined`
 
 ### message?
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/assertIsContractAddress.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/assertIsContractAddress.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/assertIsContractAddress.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/assertIsContractAddress.md
@@ -27,4 +27,4 @@ The source string.
 ## Throws
 
 `TypeError`
-`contractAddress` is not a correctly formatted ContractAddress.
+`contractAddress` is not a correctly formatted [ContractAddress](#).

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/assertIsHex.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/assertIsHex.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/assertUndefined.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/assertUndefined.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 
@@ -20,9 +20,9 @@ Asserts that the given value is null or undefined.
 
 ### value
 
-`A` \| `null` \| `undefined`
-
 The value to test for nullability.
+
+`A` | `null` | `undefined`
 
 ### message?
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/fromHex.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/fromHex.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/isHex.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/isHex.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/parseCoinPublicKeyToHex.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/parseCoinPublicKeyToHex.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/parseEncPublicKeyToHex.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/parseEncPublicKeyToHex.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/parseHex.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/parseHex.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/toHex.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/toHex.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/ttlOneHour.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/functions/ttlOneHour.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/type-aliases/ParsedHexString.md
+++ b/docs/api/midnight-js/@midnight-ntwrk/midnight-js-utils/type-aliases/ParsedHexString.md
@@ -1,4 +1,4 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](../../../README.md)
+[**Midnight.js API Reference v4.0.1**](../../../README.md)
 
 ***
 

--- a/docs/api/midnight-js/README.md
+++ b/docs/api/midnight-js/README.md
@@ -1,4 +1,4 @@
-**Midnight.js API Reference v4.0.0-rc.2**
+**Midnight.js API Reference v4.0.1**
 
 ***
 

--- a/docs/api/midnight-js/packages.md
+++ b/docs/api/midnight-js/packages.md
@@ -1,18 +1,18 @@
-[**Midnight.js API Reference v4.0.0-rc.2**](README.md)
+[**Midnight.js API Reference v4.0.1**](README.md)
 
 ***
 
-# Midnight.js API Reference v4.0.0-rc.2
+# Midnight.js API Reference v4.0.1
 
 ## Packages
 
-- [@midnight-ntwrk/midnight-js-contracts - v4.0.0-rc.2](@midnight-ntwrk/midnight-js-contracts/README.md)
-- [@midnight-ntwrk/midnight-js-fetch-zk-config-provider - v4.0.0-rc.2](@midnight-ntwrk/midnight-js-fetch-zk-config-provider/README.md)
-- [@midnight-ntwrk/midnight-js-http-client-proof-provider - v4.0.0-rc.2](@midnight-ntwrk/midnight-js-http-client-proof-provider/README.md)
-- [@midnight-ntwrk/midnight-js-indexer-public-data-provider - v4.0.0-rc.2](@midnight-ntwrk/midnight-js-indexer-public-data-provider/README.md)
-- [@midnight-ntwrk/midnight-js-level-private-state-provider - v4.0.0-rc.2](@midnight-ntwrk/midnight-js-level-private-state-provider/README.md)
-- [@midnight-ntwrk/midnight-js-logger-provider - v4.0.0-rc.2](@midnight-ntwrk/midnight-js-logger-provider/README.md)
-- [@midnight-ntwrk/midnight-js-network-id - v4.0.0-rc.2](@midnight-ntwrk/midnight-js-network-id/README.md)
-- [@midnight-ntwrk/midnight-js-node-zk-config-provider - v4.0.0-rc.2](@midnight-ntwrk/midnight-js-node-zk-config-provider/README.md)
-- [@midnight-ntwrk/midnight-js-types - v4.0.0-rc.2](@midnight-ntwrk/midnight-js-types/README.md)
-- [@midnight-ntwrk/midnight-js-utils - v4.0.0-rc.2](@midnight-ntwrk/midnight-js-utils/README.md)
+- [@midnight-ntwrk/midnight-js-contracts - v4.0.1](@midnight-ntwrk/midnight-js-contracts/README.md)
+- [@midnight-ntwrk/midnight-js-fetch-zk-config-provider - v4.0.1](@midnight-ntwrk/midnight-js-fetch-zk-config-provider/README.md)
+- [@midnight-ntwrk/midnight-js-http-client-proof-provider - v4.0.1](@midnight-ntwrk/midnight-js-http-client-proof-provider/README.md)
+- [@midnight-ntwrk/midnight-js-indexer-public-data-provider - v4.0.1](@midnight-ntwrk/midnight-js-indexer-public-data-provider/README.md)
+- [@midnight-ntwrk/midnight-js-level-private-state-provider - v4.0.1](@midnight-ntwrk/midnight-js-level-private-state-provider/README.md)
+- [@midnight-ntwrk/midnight-js-logger-provider - v4.0.1](@midnight-ntwrk/midnight-js-logger-provider/README.md)
+- [@midnight-ntwrk/midnight-js-network-id - v4.0.1](@midnight-ntwrk/midnight-js-network-id/README.md)
+- [@midnight-ntwrk/midnight-js-node-zk-config-provider - v4.0.1](@midnight-ntwrk/midnight-js-node-zk-config-provider/README.md)
+- [@midnight-ntwrk/midnight-js-types - v4.0.1](@midnight-ntwrk/midnight-js-types/README.md)
+- [@midnight-ntwrk/midnight-js-utils - v4.0.1](@midnight-ntwrk/midnight-js-utils/README.md)

--- a/docs/releases/v4.0.1/README.md
+++ b/docs/releases/v4.0.1/README.md
@@ -1,4 +1,4 @@
-# midnight-js v4.0.0 Release Documentation
+# midnight-js v4.0.1 Release Documentation
 
 **Release Date:** March 17, 2026
 **Previous Version:** v3.2.0
@@ -38,7 +38,7 @@ type MyCircuit = Contract.ImpureCircuitId<MyContract>;
 const [zswapState, contractState] = await provider.queryZSwapAndContractState(address);
 ```
 
-### After (v4.0.0)
+### After (v4.0.1)
 ```typescript
 import { type ContractAddress } from '@midnight-ntwrk/ledger-v8';
 

--- a/docs/releases/v4.0.1/api-changes.md
+++ b/docs/releases/v4.0.1/api-changes.md
@@ -1,4 +1,4 @@
-# API Changes Reference v4.0.0
+# API Changes Reference v4.0.1
 
 ## Package: @midnight-ntwrk/midnight-js-types
 
@@ -15,7 +15,7 @@ export interface MidnightProviders<
 >
 ```
 
-**v4.0.0:**
+**v4.0.1:**
 ```typescript
 export interface MidnightProviders<
   PCK extends AnyProvableCircuitId = AnyProvableCircuitId,
@@ -36,7 +36,7 @@ queryZSwapAndContractState(
 ): Promise<[ZswapChainState, ContractState] | null>;
 ```
 
-**v4.0.0:**
+**v4.0.1:**
 ```typescript
 queryZSwapAndContractState(
   contractAddress: ContractAddress,
@@ -82,7 +82,7 @@ export const createProofProvider = (
 export type CallOptionsBase<C extends Contract.Any, ICK extends Contract.ImpureCircuitId<C>>
 ```
 
-**v4.0.0:**
+**v4.0.1:**
 ```typescript
 export type CallOptionsBase<C extends Contract.Any, PCK extends Contract.ProvableCircuitId<C>>
 ```
@@ -94,7 +94,7 @@ export type CallOptionsBase<C extends Contract.Any, PCK extends Contract.Provabl
 export type CallOptionsWithArguments<C extends Contract.Any, ICK extends Contract.ImpureCircuitId<C>>
 ```
 
-**v4.0.0:**
+**v4.0.1:**
 ```typescript
 export type CallOptionsWithArguments<C extends Contract.Any, PCK extends Contract.ProvableCircuitId<C>>
 ```
@@ -110,7 +110,7 @@ export type CallOptionsProviderDataDependencies = {
 };
 ```
 
-**v4.0.0:**
+**v4.0.1:**
 ```typescript
 export type CallOptionsProviderDataDependencies = {
   readonly coinPublicKey: string;
@@ -129,7 +129,7 @@ export type CallOptionsProviderDataDependencies = {
 export type CallOptionsWithProviderDataDependencies<C extends Contract.Any, ICK extends Contract.ImpureCircuitId<C>>
 ```
 
-**v4.0.0:**
+**v4.0.1:**
 ```typescript
 export type CallOptionsWithProviderDataDependencies<C extends Contract.Any, PCK extends Contract.ProvableCircuitId<C>>
 ```
@@ -141,7 +141,7 @@ export type CallOptionsWithProviderDataDependencies<C extends Contract.Any, PCK 
 export type CallOptionsWithPrivateState<C extends Contract.Any, ICK extends Contract.ImpureCircuitId<C>>
 ```
 
-**v4.0.0:**
+**v4.0.1:**
 ```typescript
 export type CallOptionsWithPrivateState<C extends Contract.Any, PCK extends Contract.ProvableCircuitId<C>>
 ```
@@ -153,7 +153,7 @@ export type CallOptionsWithPrivateState<C extends Contract.Any, PCK extends Cont
 export type CallOptions<C extends Contract.Any, ICK extends Contract.ImpureCircuitId<C>>
 ```
 
-**v4.0.0:**
+**v4.0.1:**
 ```typescript
 export type CallOptions<C extends Contract.Any, PCK extends Contract.ProvableCircuitId<C>>
 ```
@@ -166,7 +166,7 @@ export type CallResult<C extends Contract.Any, ICK extends Contract.ImpureCircui
 export type CallResultPrivate<C extends Contract.Any, ICK extends Contract.ImpureCircuitId<C>>
 ```
 
-**v4.0.0:**
+**v4.0.1:**
 ```typescript
 export type CallResult<C extends Contract.Any, PCK extends Contract.ProvableCircuitId<C>>
 export type CallResultPrivate<C extends Contract.Any, PCK extends Contract.ProvableCircuitId<C>>
@@ -181,7 +181,7 @@ export type CircuitCallTxInterface<C extends Contract.Any> = {
 };
 ```
 
-**v4.0.0:**
+**v4.0.1:**
 ```typescript
 export type CircuitCallTxInterface<C extends Contract.Any> = {
   [PCK in Contract.ProvableCircuitId<C>]: { ... };
@@ -195,7 +195,7 @@ export type CircuitCallTxInterface<C extends Contract.Any> = {
 export type CircuitMaintenanceTxInterfaces<C extends Contract.Any> = Record<Contract.ImpureCircuitId<C>, CircuitMaintenanceTxInterface>;
 ```
 
-**v4.0.0:**
+**v4.0.1:**
 ```typescript
 export type CircuitMaintenanceTxInterfaces<C extends Contract.Any> = Record<Contract.ProvableCircuitId<C>, CircuitMaintenanceTxInterface>;
 ```
@@ -210,7 +210,7 @@ export type PublicContractStates = {
 };
 ```
 
-**v4.0.0:**
+**v4.0.1:**
 ```typescript
 export type PublicContractStates = {
   readonly zswapChainState: ZswapChainState;

--- a/docs/releases/v4.0.1/breaking-changes.md
+++ b/docs/releases/v4.0.1/breaking-changes.md
@@ -1,4 +1,4 @@
-# Breaking Changes v4.0.0
+# Breaking Changes v4.0.1
 
 ## 1. Ledger v7 to v8: `ImpureCircuitId` Renamed to `ProvableCircuitId` (#607)
 

--- a/docs/releases/v4.0.1/migration-guide.md
+++ b/docs/releases/v4.0.1/migration-guide.md
@@ -1,15 +1,15 @@
-# Migration Guide v3.2.0 to v4.0.0
+# Migration Guide v3.2.0 to v4.0.1
 
 ## Overview
 
-This guide covers migrating from midnight-js v3.2.0 to v4.0.0. The major change is the upgrade from ledger v7 to ledger v8, which renames "impure circuits" to "provable circuits" and introduces `LedgerParameters` flow through circuit execution.
+This guide covers migrating from midnight-js v3.2.0 to v4.0.1. The major change is the upgrade from ledger v7 to ledger v8, which renames "impure circuits" to "provable circuits" and introduces `LedgerParameters` flow through circuit execution.
 
 ## Step 1: Update Dependencies
 
 ```bash
-yarn upgrade @midnight-ntwrk/midnight-js-types@^4.0.0
-yarn upgrade @midnight-ntwrk/midnight-js-contracts@^4.0.0
-yarn upgrade @midnight-ntwrk/indexer-public-data-provider@^4.0.0
+yarn upgrade @midnight-ntwrk/midnight-js-types@^4.0.1
+yarn upgrade @midnight-ntwrk/midnight-js-contracts@^4.0.1
+yarn upgrade @midnight-ntwrk/indexer-public-data-provider@^4.0.1
 ```
 
 Replace `@midnight-ntwrk/ledger-v7` with `@midnight-ntwrk/ledger-v8` in your `package.json`:
@@ -31,7 +31,7 @@ Replace all imports from `ledger-v7` with `ledger-v8`.
 import { type ContractAddress, type ZswapChainState } from '@midnight-ntwrk/ledger-v7';
 ```
 
-**After (v4.0.0):**
+**After (v4.0.1):**
 ```typescript
 import { type ContractAddress, type LedgerParameters, type ZswapChainState } from '@midnight-ntwrk/ledger-v8';
 ```
@@ -47,7 +47,7 @@ import { type Contract } from '@midnight-ntwrk/compact-js';
 type MyCircuitId = Contract.ImpureCircuitId<MyContract>;
 ```
 
-**After (v4.0.0):**
+**After (v4.0.1):**
 ```typescript
 import { type Contract } from '@midnight-ntwrk/compact-js';
 
@@ -61,7 +61,7 @@ type MyCircuitId = Contract.ProvableCircuitId<MyContract>;
 const ids = ContractExecutable.make(compiledContract).getImpureCircuitIds();
 ```
 
-**After (v4.0.0):**
+**After (v4.0.1):**
 ```typescript
 const ids = ContractExecutable.make(compiledContract).getProvableCircuitIds();
 ```
@@ -90,7 +90,7 @@ if (result) {
 }
 ```
 
-**After (v4.0.0):**
+**After (v4.0.1):**
 ```typescript
 const result = await publicDataProvider.queryZSwapAndContractState(address);
 if (result) {
@@ -114,7 +114,7 @@ const result = await createUnprovenCallTxFromInitialStates(zkConfigProvider, {
 }, walletEncryptionPublicKey);
 ```
 
-**After (v4.0.0):**
+**After (v4.0.1):**
 ```typescript
 const result = await createUnprovenCallTxFromInitialStates(zkConfigProvider, {
   compiledContract,
@@ -151,7 +151,7 @@ const tx = createUnprovenLedgerCallTx(
 );
 ```
 
-**After (v4.0.0):**
+**After (v4.0.1):**
 ```typescript
 import { createUnprovenLedgerCallTx } from '@midnight-ntwrk/midnight-js-contracts';
 

--- a/docs/releases/v4.0.1/new-features.md
+++ b/docs/releases/v4.0.1/new-features.md
@@ -1,4 +1,4 @@
-# New Features v4.0.0
+# New Features v4.0.1
 
 ## 1. LedgerParameters Flow Through Circuit Execution (#633)
 

--- a/docs/releases/v4.0.1/release-notes.md
+++ b/docs/releases/v4.0.1/release-notes.md
@@ -1,4 +1,4 @@
-# Release Notes v4.0.0
+# Release Notes v4.0.1
 
 **Release Date:** March 17, 2026
 **Previous Version:** v3.2.0
@@ -17,7 +17,7 @@ All ledger imports have been upgraded from `@midnight-ntwrk/ledger-v7` to `@midn
 import { type ContractAddress } from '@midnight-ntwrk/ledger-v7';
 type CircuitId = Contract.ImpureCircuitId<MyContract>;
 
-// v4.0.0
+// v4.0.1
 import { type ContractAddress } from '@midnight-ntwrk/ledger-v8';
 type CircuitId = Contract.ProvableCircuitId<MyContract>;
 ```
@@ -33,7 +33,7 @@ The return type now includes `LedgerParameters` as a third tuple element.
 const result = await provider.queryZSwapAndContractState(address);
 const [zswapState, contractState] = result;
 
-// v4.0.0
+// v4.0.1
 const result = await provider.queryZSwapAndContractState(address);
 const [zswapState, contractState, ledgerParameters] = result;
 ```
@@ -42,7 +42,7 @@ const [zswapState, contractState, ledgerParameters] = result;
 The `ledgerParameters` field is now required when constructing call options for circuit execution.
 
 ```typescript
-// v4.0.0
+// v4.0.1
 const callOptions: CallOptionsProviderDataDependencies = {
   coinPublicKey,
   initialContractState,

--- a/packages/contracts/src/tx-interfaces.ts
+++ b/packages/contracts/src/tx-interfaces.ts
@@ -156,7 +156,7 @@ export type CircuitMaintenanceTxInterfaces<C extends Contract.Any> = Record<Cont
  * Creates a {@link CircuitMaintenanceTxInterfaces}.
  *
  * @param providers The providers to use to build transactions.
- * @param contract The contract to use to execute circuits.
+ * @param compiledContract The contract to use to execute circuits.
  * @param contractAddress The ledger address of the contract.
  */
 export const createCircuitMaintenanceTxInterfaces = <C extends Contract.Any>(

--- a/packages/contracts/typedoc.json
+++ b/packages/contracts/typedoc.json
@@ -1,5 +1,10 @@
 {
   "extends": ["../../typedoc.base.json"],
   "readme": "none",
-  "entryPoints": ["src/index.ts"]
+  "entryPoints": ["src/index.ts"],
+  "intentionallyNotExported": [
+    "TypeId",
+    "SubmitCallTxProviders",
+    "CachedStateIdentity"
+  ]
 }

--- a/packages/indexer-public-data-provider/typedoc.json
+++ b/packages/indexer-public-data-provider/typedoc.json
@@ -1,5 +1,8 @@
 {
   "extends": ["../../typedoc.base.json"],
   "readme": "none",
-  "entryPoints": ["src/index.ts"]
+  "entryPoints": ["src/index.ts"],
+  "intentionallyNotExported": [
+    "ContractBalance"
+  ]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -7,5 +7,40 @@
   "excludePrivate": true,
   "entryPoints": ["packages/*"],
   "entryPointStrategy": "packages",
-  "exclude": ["packages/compact"]
+  "exclude": ["packages/compact"],
+  "externalSymbolLinkMappings": {
+    "@midnight-ntwrk/midnight-js-types": {
+      "ProofProvider": "#",
+      "PublicDataProvider": "#",
+      "PrivateStateProvider": "#",
+      "ZKConfigProvider": "#",
+      "ZKConfigProvider.getProverKey": "#",
+      "ZKConfigProvider.getVerifierKey": "#",
+      "ZKConfigProvider.getZKIR": "#"
+    },
+    "@midnight-ntwrk/ledger-v8": {
+      "ProvingProvider": "#"
+    },
+    "@midnight-ntwrk/compact-js": {
+      "": "#"
+    },
+    "@midnight-ntwrk/platform-js": {
+      "ContractAddress": "#"
+    },
+    "@midnight-ntwrk/onchain-runtime-v3": {
+      "ContractAddress": "#"
+    },
+    "@apollo/client": {
+      "ApolloClient": "#"
+    },
+    "level": {
+      "Level": "#"
+    },
+    "pino": {
+      "pino.Logger": "#"
+    },
+    "effect": {
+      "ManagedRuntime": "#"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Rename `docs/releases/v4.0.0/` to `docs/releases/v4.0.1/` and update all version references within
- Regenerate API docs (`yarn build:markdown-docs`) to reflect current `4.0.1` package versions
- Fix all 21 typedoc warnings: add `externalSymbolLinkMappings` for cross-package links, `intentionallyNotExported` for internal symbols, and fix `@param` mismatch in `createCircuitMaintenanceTxInterfaces`

The 4.0.0 release shipped as 4.0.1 but the documentation still referenced 4.0.0.

## Test plan

- [ ] Verify no remaining `v4.0.0` references in `docs/releases/v4.0.1/`
- [ ] Verify API docs show `v4.0.1` in `docs/api/midnight-js/packages.md`
- [ ] Verify `yarn build:markdown-docs` produces 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)