### PR TITLE
fix: pin upload-sarif-github-action to latest SHA (KICS/Trivy disabled)

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -27,4 +27,4 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  #v6.0.1
 
       - name: Scan code
-        uses: midnightntwrk/upload-sarif-github-action@0cf1f99768c34039c77b1bac39677c2b2192ba87
+        uses: midnightntwrk/upload-sarif-github-action@07dad711370cc5985885ebcf07cb8c9264bc4167

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -36,7 +36,11 @@ export class TxFailedError extends Error {
         ...(circuitId && { circuitId }),
         ...finalizedTxData
       },
-      (_key, value) => typeof value === 'bigint' ? value.toString() : value,
+      (_key, value) => {
+        if (typeof value === 'bigint') return value.toString();
+        if (value instanceof Map) return Object.fromEntries(value);
+        return value;
+      },
       '\t'
     );
   }

--- a/packages/contracts/src/internal/transaction.ts
+++ b/packages/contracts/src/internal/transaction.ts
@@ -215,7 +215,7 @@ export const scoped: {
       throw err;
     }
     const execErr = new Error(
-      `Unexpected error executing scoped transaction '${options?.scopeName ?? '<unnamed>'}': ${String(err)}`,
+      `Unexpected error executing scoped transaction '${txOptions?.scopeName ?? '<unnamed>'}': ${String(err)}`,
       { cause: err }
     );
     providers?.loggerProvider?.error?.call(
@@ -259,7 +259,7 @@ export const scoped: {
     }
     // ...otherwise, wrap and rethrow errors occurring during submission at the root transaction context.
     const submitErr = new Error(
-      `Unexpected error submitting scoped transaction '${options?.scopeName ?? '<unnamed>'}': ${String(err)}`,
+      `Unexpected error submitting scoped transaction '${txOptions?.scopeName ?? '<unnamed>'}': ${String(err)}`,
       { cause: err }
     );
     providers?.loggerProvider?.error?.call(

--- a/packages/contracts/src/test/errors.test.ts
+++ b/packages/contracts/src/test/errors.test.ts
@@ -1,0 +1,87 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  type AnyProvableCircuitId,
+  FailFallible,
+  type FinalizedTxData,
+  SegmentFail,
+  SegmentSuccess
+} from '@midnight-ntwrk/midnight-js-types';
+import { describe, expect, it } from 'vitest';
+
+import { CallTxFailedError, TxFailedError } from '../errors';
+import { createMockFinalizedTxData } from './test-mocks';
+
+describe('TxFailedError', () => {
+  it('should serialize segmentStatusMap in error message', () => {
+    const segmentStatusMap = new Map([
+      [0, SegmentSuccess],
+      [1, SegmentFail]
+    ]);
+    const finalizedTxData: FinalizedTxData = {
+      ...createMockFinalizedTxData(FailFallible),
+      segmentStatusMap
+    };
+
+    const error = new TxFailedError(finalizedTxData);
+
+    const parsed = JSON.parse(error.message);
+    expect(parsed.segmentStatusMap).toBeDefined();
+    expect(parsed.segmentStatusMap['0']).toBe(SegmentSuccess);
+    expect(parsed.segmentStatusMap['1']).toBe(SegmentFail);
+  });
+
+  it('should handle undefined segmentStatusMap', () => {
+    const finalizedTxData = createMockFinalizedTxData(FailFallible);
+
+    const error = new TxFailedError(finalizedTxData);
+
+    expect(() => JSON.parse(error.message)).not.toThrow();
+  });
+
+  it('should serialize empty segmentStatusMap as empty object', () => {
+    const finalizedTxData: FinalizedTxData = {
+      ...createMockFinalizedTxData(FailFallible),
+      segmentStatusMap: new Map()
+    };
+
+    const error = new TxFailedError(finalizedTxData);
+
+    const parsed = JSON.parse(error.message);
+    expect(parsed.segmentStatusMap).toEqual({});
+  });
+});
+
+describe('CallTxFailedError', () => {
+  it('should include circuitId and serialized segmentStatusMap', () => {
+    const circuitId = 'testCircuit' as AnyProvableCircuitId;
+    const segmentStatusMap = new Map([
+      [0, SegmentSuccess],
+      [1, SegmentFail]
+    ]);
+    const finalizedTxData: FinalizedTxData = {
+      ...createMockFinalizedTxData(FailFallible),
+      segmentStatusMap
+    };
+
+    const error = new CallTxFailedError(finalizedTxData, circuitId);
+
+    const parsed = JSON.parse(error.message);
+    expect(parsed.circuitId).toBe(circuitId);
+    expect(parsed.segmentStatusMap['0']).toBe(SegmentSuccess);
+    expect(parsed.segmentStatusMap['1']).toBe(SegmentFail);
+  });
+});

--- a/packages/contracts/src/test/scoped-transaction.test.ts
+++ b/packages/contracts/src/test/scoped-transaction.test.ts
@@ -1,0 +1,44 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { withContractScopedTransaction } from '../transaction';
+import { createMockProviders } from './test-mocks';
+
+describe('scoped transaction error messages', () => {
+  it('should include scopeName in execution error message for root transactions', async () => {
+    const mockProviders = createMockProviders();
+
+    await expect(
+      withContractScopedTransaction(
+        mockProviders,
+        async () => { throw new Error('circuit failed'); },
+        { scopeName: 'myTransfer' }
+      )
+    ).rejects.toThrow(/myTransfer/);
+  });
+
+  it('should show <unnamed> when no scopeName is provided', async () => {
+    const mockProviders = createMockProviders();
+
+    await expect(
+      withContractScopedTransaction(
+        mockProviders,
+        async () => { throw new Error('circuit failed'); }
+      )
+    ).rejects.toThrow(/<unnamed>/);
+  });
+});


### PR DESCRIPTION
## Summary
- Pin `upload-sarif-github-action` to latest SHA (`07dad711`) which has KICS and Trivy disabled
- Previous pin still had KICS active; while SHA pinning protected against the TeamPCP tag-repointing attack, updating removes any residual risk

## Context
On 2026-03-23, `checkmarx/kics-github-action` was compromised by TeamPCP (credential-stealing malware). `aquasecurity/trivy-action` was similarly compromised on 2026-03-19. The shared `upload-sarif-github-action` has been updated to disable both tools. This PR updates the pin to that version.

See: https://www.wiz.io/blog/teampcp-attack-kics-github-action