### PR TITLE
chore: remove dead code from zswap-utils offer construction

### DIFF
--- a/packages/contracts/src/test/utils/zswap-utils.test.ts
+++ b/packages/contracts/src/test/utils/zswap-utils.test.ts
@@ -163,6 +163,18 @@ describe('Zswap utilities', () => {
       })
     ));
 
+  test('serializeCoinInfo produces plain string fields for type and nonce, not __uint8Array_val__ wrappers', () =>
+    fc.assert(
+      fc.property(arbitraryCoinInfo, (coinInfo) => {
+        const serialized = serializeCoinInfo(coinInfo);
+        const parsed = JSON.parse(serialized);
+        expect(typeof parsed.type).toBe('string');
+        expect(typeof parsed.nonce).toBe('string');
+        expect(parsed).not.toHaveProperty('color');
+        expect(parsed.value).toHaveProperty('__big_int_val__');
+      })
+    ));
+
   test("should produce the original value without 'mt_index' when serializing 'QualifiedShieldedCoinInfo' then deserializing 'CoinInfo'", () =>
     fc.assert(
       fc.property(arbitraryQualifiedShieldedCoinInfo, (qualifiedCoinInfo) => {

--- a/packages/contracts/src/utils/zswap-utils.ts
+++ b/packages/contracts/src/utils/zswap-utils.ts
@@ -33,7 +33,6 @@ import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 import {
   assertDefined,
   assertIsContractAddress,
-  fromHex,
   parseCoinPublicKeyToHex,
   parseEncPublicKeyToHex
 } from '@midnight-ntwrk/midnight-js-utils';
@@ -71,22 +70,9 @@ export const deserializeCoinInfo = (coinInfo: string): ShieldedCoinInfo => {
       value != null &&
       typeof value === 'object' &&
       '__big_int_val__' in value &&
-
       typeof value.__big_int_val__ === 'string'
     ) {
-
       return BigInt(value.__big_int_val__);
-    }
-    if (
-      (key === 'color' || key === 'nonce') &&
-      value != null &&
-      typeof value === 'object' &&
-      '__uint8Array_val__' in value &&
-
-      typeof value.__uint8Array_val__ === 'string'
-    ) {
-
-      return fromHex(value.__uint8Array_val__);
     }
     return value;
   });

--- a/packages/contracts/src/utils/zswap-utils.ts
+++ b/packages/contracts/src/utils/zswap-utils.ts
@@ -112,11 +112,7 @@ export const unprovenOfferFromMap = <U extends UnprovenInput | UnprovenOutput | 
     return undefined;
   }
 
-  const offers = Array.from(map, (entry) => unprovenOfferFromCoinInfo(entry, f)).filter((offer) => offer != null);
-
-  if (offers.length === 0) {
-    return undefined;
-  }
+  const offers = Array.from(map, (entry) => unprovenOfferFromCoinInfo(entry, f));
 
   return offers.reduce((acc, curr) => acc.merge(curr));
 };


### PR DESCRIPTION
## Summary

Removes two pieces of dead code from `packages/contracts/src/utils/zswap-utils.ts` that were identified during a thorough analysis of the guaranteed offer flow.

### 1. Dead `__uint8Array_val__` reviver in `deserializeCoinInfo`

The JSON reviver in `deserializeCoinInfo` contained a branch handling `color` and `nonce` keys with `__uint8Array_val__` wrapping format:

```typescript
if (
  (key === 'color' || key === 'nonce') &&
  value != null &&
  typeof value === 'object' &&
  '__uint8Array_val__' in value &&
  typeof value.__uint8Array_val__ === 'string'
) {
  return fromHex(value.__uint8Array_val__);
}
```

**Why this was dead code:**
- `ShieldedCoinInfo` has fields `{ type: RawTokenType, nonce: Nonce, value: bigint }` where both `RawTokenType` and `Nonce` are `string` types (hex-encoded), confirmed in `ledger-v8.d.ts`
- `serializeCoinInfo` spreads these string fields directly via `JSON.stringify` — they are never wrapped in `__uint8Array_val__` format
- `checkKeys()` (called after parsing) only allows `value`, `type`, and `nonce` — any object with a `color` key would be rejected regardless
- This code has been unreachable since the initial commit (`e4f78f8c`), likely carried over from a prototype where coin info fields used `Uint8Array` instead of hex strings

The now-unused `fromHex` import is also removed.

### 2. Dead null filter in `unprovenOfferFromMap`

```typescript
const offers = Array.from(map, (entry) => unprovenOfferFromCoinInfo(entry, f))
  .filter((offer) => offer != null);

if (offers.length === 0) {
  return undefined;
}
```

**Why this was dead code:**
- `ZswapOffer.fromInput`, `ZswapOffer.fromOutput`, and `ZswapOffer.fromTransient` all return `ZswapOffer<P>` (non-nullable), confirmed in `ledger-v8.d.ts`
- `unprovenOfferFromCoinInfo` has explicit return type `UnprovenOffer` (non-nullable)
- The `.filter((offer) => offer != null)` can never remove any elements
- The `if (offers.length === 0)` guard is redundant because `if (map.size === 0)` at the top of the function already ensures the array is non-empty
- Added defensively during a refactor in commit `07c77b62` when the return type changed to `UnprovenOffer | undefined`

### Validation

Both dead code claims were validated by:
- Checking the actual type definitions in `@midnight-ntwrk/ledger-v8` (`Nonce = string`, `RawTokenType = string`, `ZswapOffer.fromX` returns non-nullable)
- Tracing all callers of `deserializeCoinInfo` (only called with output from `serializeCoinInfo`)
- Confirming existing property-based tests cover the roundtrip behavior
- Adding a regression test that locks in the serialization format before removing code

## Test plan

- [x] Added property-based regression test confirming `serializeCoinInfo` produces plain string fields (not `__uint8Array_val__` wrappers)
- [x] All 23 existing `zswap-utils` tests pass after both removals
- [x] Linter passes with no new errors
- [x] Existing deserialization error test (line 147-157) still passes — `checkKeys` rejects invalid keys regardless of the reviver

🤖 Generated with [Claude Code](https://claude.com/claude-code)