### PR TITLE
fix: prevent command injection in compact CLI tools

### DIFF
--- a/packages/compact/src/fetch-compact.mts
+++ b/packages/compact/src/fetch-compact.mts
@@ -133,8 +133,8 @@ const fetchCompact = async (): Promise<void> => {
   fs.rmSync(targetCompactDir, { force: true, recursive: true });
   fs.mkdirSync(targetCompactDir, { recursive: true });
 
-  childProcess.execSync(`unzip ${targetFile} -d ${targetCompactDir}`);
-  childProcess.execSync(`chmod -R +w ${targetCompactDir}`);
+  childProcess.spawnSync('unzip', [targetFile, '-d', targetCompactDir], { stdio: 'inherit' });
+  childProcess.spawnSync('chmod', ['-R', '+w', targetCompactDir], { stdio: 'inherit' });
   console.log(`Compact extracted to ${targetCompactDir}`);
 
   fs.rmSync(targetFile);
@@ -145,7 +145,7 @@ const fetchCompact = async (): Promise<void> => {
 const fetchDockerImage = () => {
   console.log('Fetching Compact docker image...');
   const dockerImage = `${compactDockerImage}:v${compactcVersion}`;
-  const child = childProcess.exec(`docker pull ${dockerImage}`);
+  const child = childProcess.spawn('docker', ['pull', dockerImage]);
   child.on('exit', (code, signal) => {
     console.log(`Child process exited with code ${code}`);
     if (code === 0) {

--- a/packages/compact/src/run-compactc.cjs
+++ b/packages/compact/src/run-compactc.cjs
@@ -3,7 +3,6 @@
 const childProcess = require('child_process');
 const path = require('path');
 const fs = require('fs');
-const { exec } = require("node:child_process");
 
 const [_node, _script, ...args] = process.argv;
 const COMPACT_HOME_ENV = process.env.COMPACT_HOME;
@@ -77,19 +76,15 @@ if (checkOs() === 'docker') {
   }
   const dockerImage = `ghcr.io/midnight-ntwrk/compactc:v${currentVersion}`;
 
-  const argsCompact = args
-    .map(arg => arg.startsWith('-') ? arg : `/compact/${arg}`)
-    .join(' ');
+  const argsCompact = args.map(arg => arg.startsWith('-') ? arg : `/compact/${arg}`);
 
   const containerName = 'compactc-docker';
 
   const argsDocker = [
-    'run', '--name', containerName, '--rm', '-v', `${currentDir}:/compact`, `${dockerImage}`, `"compactc ${argsCompact}"`
+    'run', '--name', containerName, '--rm', '-v', `${currentDir}:/compact`, dockerImage, 'compactc', ...argsCompact
   ];
 
-  const dockerCommand = `docker ${argsDocker.join(" ")}`;
-
-  child = exec(dockerCommand);
+  child = childProcess.spawn('docker', argsDocker);
 
   child.on('exit', (code, signal) => {
     console.log(`Child process exited with code ${code}`);


### PR DESCRIPTION
## Summary

- **`fetch-compact.mts`**: Replaced `execSync` / `exec` with template literal interpolation with `spawnSync` / `spawn` using argument arrays for `unzip`, `chmod`, and `docker pull` commands
- **`run-compactc.cjs`**: Replaced `exec()` with string-joined docker command with `childProcess.spawn()` using a proper argument array; removed unused `exec` import

## Problem

Both `fetch-compact.mts` and `run-compactc.cjs` construct shell commands by interpolating variables (version strings, file paths, CLI arguments) directly into template literals passed to `execSync` / `exec`. This is vulnerable to command injection if the interpolated values contain shell metacharacters (`;`, `|`, `&`, `` ` ``).

For example, a `COMPACTC_VERSION` value of `1.0; rm -rf /` would be executed as:
```
unzip /path/compactc-1.0; rm -rf /.zip -d /path/1.0; rm -rf /
```

While these are developer build tools (not runtime services), they pose a risk in CI/CD pipelines where version strings may originate from external inputs (PR metadata, config files, etc.).

## Fix

Replace all `execSync`/`exec` with template literal arguments with `spawnSync`/`spawn` using argument arrays. `spawn`/`spawnSync` bypass the shell entirely, passing arguments directly to the target process, which eliminates command injection.

Notably, the non-docker path in `run-compactc.cjs` already used the safe `spawn()` pattern — this PR aligns the docker path to match.

## Test plan

- [ ] Verify `fetch-compactc` still downloads and extracts compactc correctly
- [ ] Verify `run-compactc` docker path still executes compactc via docker
- [ ] Verify `run-compactc` native path still works (unchanged)
- [ ] `yarn lint` passes
- [ ] `yarn --cwd packages/compact build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)