### PR TITLE
docs: add release notes for v4.0.2

### DIFF
--- a/docs/releases/v4.0.2/README.md
+++ b/docs/releases/v4.0.2/README.md
@@ -1,0 +1,44 @@
+# midnight-js v4.0.2 Release Documentation
+
+**Release Date:** March 24, 2026
+**Previous Version:** v4.0.1
+**Migration Complexity:** Low
+
+## Quick Links
+
+- [Release Notes](./release-notes.md) - High-level changelog
+- [Breaking Changes](./breaking-changes.md) - v4.0.1 breaking change #4 reverted
+- [New Features](./new-features.md) - Headers support in proof provider
+- [Migration Guide](./migration-guide.md) - Step-by-step upgrade from v4.0.1
+- [API Changes](./api-changes.md) - Restored APIs from v3.2.0
+
+## Overview
+
+v4.0.2 is a patch release that reverts the `addCalls` API refactor introduced in v4.0.1 (#648), which caused failures for contracts using shielded operations. The `createUnprovenLedgerCallTx` signature and `extractUserAddressedOutputs` export are restored to match v3.2.0 (with ledger-v8 types).
+
+## Key Changes
+
+1. **Revert `addCalls` API refactor** - Restores `ContractCallPrototype` approach for shielded contract compatibility (#695)
+2. **Security: command injection prevention** - Replace shell string interpolation with safe argument arrays in compact CLI (#711)
+3. **Fallible offer error reporting** - Fix Map serialization and scopeName in error messages (#705)
+4. **Type safety** - Replace `as any` casts with `isEffectContractError` type guard (#712)
+
+## Requirements
+
+- **Node.js:** 22+
+- **TypeScript:** 5.8+
+
+## Testing Checklist
+
+- [ ] Revert any v4.0.1 `addCalls` API call site adaptations
+- [ ] Restore `extractUserAddressedOutputs` usages if previously removed
+- [ ] Restore `partitionedTranscript` parameter in `createUnprovenLedgerCallTx` calls
+- [ ] Contracts using `receiveShielded`/`sendShielded` work correctly
+- [ ] Unit tests pass
+- [ ] Integration tests pass
+- [ ] E2E tests pass
+
+---
+
+**Last Updated:** March 24, 2026
+**License:** Apache-2.0

--- a/docs/releases/v4.0.2/api-changes.md
+++ b/docs/releases/v4.0.2/api-changes.md
@@ -1,0 +1,115 @@
+# API Changes Reference v4.0.2
+
+## Package: @midnight-ntwrk/midnight-js-contracts
+
+### Restored Exports
+
+#### `extractUserAddressedOutputs`
+
+Removed in v4.0.1 (#648), restored in v4.0.2 (#695).
+
+```typescript
+export const extractUserAddressedOutputs = (
+  transcript: Transcript<AlignedValue> | undefined
+): UtxoOutput[]
+```
+
+#### `createUnprovenLedgerCallTx` — signature restored
+
+**v4.0.1:**
+```typescript
+export const createUnprovenLedgerCallTx = (
+  circuitId: AnyProvableCircuitId,
+  contractAddress: ContractAddress,
+  initialContractState: ContractState,
+  zswapChainState: ZswapChainState,
+  publicTranscript: Op<AlignedValue>[],
+  privateTranscriptOutputs: AlignedValue[],
+  input: AlignedValue,
+  output: AlignedValue,
+  nextZswapLocalState: ZswapLocalState,
+  encryptionPublicKey: EncPublicKey,
+  ledgerParameters: LedgerParameters
+): UnprovenTransaction
+```
+
+**v4.0.2:**
+```typescript
+export const createUnprovenLedgerCallTx = (
+  circuitId: AnyProvableCircuitId,
+  contractAddress: ContractAddress,
+  initialContractState: ContractState,
+  zswapChainState: ZswapChainState,
+  partitionedTranscript: PartitionedTranscript,
+  privateTranscriptOutputs: AlignedValue[],
+  input: AlignedValue,
+  output: AlignedValue,
+  nextZswapLocalState: ZswapLocalState,
+  encryptionPublicKey: EncPublicKey
+): UnprovenTransaction
+```
+
+**Changes:** `publicTranscript` reverted to `partitionedTranscript`, `ledgerParameters` parameter removed.
+
+### New Exports
+
+#### `isEffectContractError`
+
+```typescript
+export const isEffectContractError = (
+  error: unknown
+): error is EffectContractError
+```
+
+Type guard for safely narrowing Effect-ts contract errors. Checks for `_tag` and `cause` properties.
+
+## Package: @midnight-ntwrk/http-client-proof-provider
+
+### Modified Exports
+
+#### `ProvingProviderConfig`
+
+**v4.0.1:**
+```typescript
+export interface ProvingProviderConfig {
+  readonly timeout?: number;
+}
+```
+
+**v4.0.2:**
+```typescript
+export interface ProvingProviderConfig {
+  readonly timeout?: number;
+  readonly headers?: Record<string, string>;
+}
+```
+
+**Non-breaking:** New optional field added.
+
+---
+
+## Complete API Diff by Package
+
+### @midnight-ntwrk/midnight-js-contracts
+
+```diff
++ export const isEffectContractError: (error: unknown) => error is EffectContractError
++ export const extractUserAddressedOutputs: (transcript: Transcript<AlignedValue> | undefined) => UtxoOutput[]
+  export const createUnprovenLedgerCallTx: (
+    circuitId, contractAddress, initialContractState, zswapChainState,
+-   publicTranscript: Op<AlignedValue>[],
++   partitionedTranscript: PartitionedTranscript,
+    privateTranscriptOutputs, input, output, nextZswapLocalState,
+-   encryptionPublicKey, ledgerParameters: LedgerParameters
++   encryptionPublicKey
+  ) => UnprovenTransaction
+```
+
+### @midnight-ntwrk/http-client-proof-provider
+
+```diff
+  export interface ProvingProviderConfig {
+    readonly timeout?: number;
++   readonly headers?: Record<string, string>;
+  }
+```

--- a/docs/releases/v4.0.2/breaking-changes.md
+++ b/docs/releases/v4.0.2/breaking-changes.md
@@ -1,0 +1,83 @@
+# Breaking Changes v4.0.2
+
+v4.0.2 introduces no new breaking changes. However, it **reverts** breaking change #4 from v4.0.1, which means users who already adapted to the v4.0.1 `addCalls` API must revert those adaptations.
+
+## 1. Revert of v4.0.1 Breaking Change #4: `addCalls` API (#695)
+
+### Reason
+
+The `PreTranscript + Transaction.addCalls()` approach introduced in v4.0.1 (#648) fails for contracts using shielded coin operations (`receiveShielded`, `sendShielded`, `writeCoin`). The `addCalls()` stack machine does not initialize its stack identically to compact-runtime, causing `"expected a cell, received null"` errors. This affected real-world contracts including Seabattle and Lunarswap.
+
+### Impact
+
+If you adapted your code to v4.0.1's `addCalls` API, you must revert those changes. If you are upgrading directly from v3.2.0 to v4.0.2, the `createUnprovenLedgerCallTx` signature matches v3.2.0 (with ledger-v8 types) and no action is needed for this change.
+
+### Restored APIs
+
+#### `createUnprovenLedgerCallTx` — original signature restored
+
+**v4.0.1 (removed):**
+```typescript
+createUnprovenLedgerCallTx(
+  circuitId: AnyProvableCircuitId,
+  contractAddress: ContractAddress,
+  initialContractState: ContractState,
+  zswapChainState: ZswapChainState,
+  publicTranscript: Op<AlignedValue>[],       // changed
+  privateTranscriptOutputs: AlignedValue[],
+  input: AlignedValue,
+  output: AlignedValue,
+  nextZswapLocalState: ZswapLocalState,
+  encryptionPublicKey: EncPublicKey,
+  ledgerParameters: LedgerParameters          // added
+): UnprovenTransaction
+```
+
+**v4.0.2 (restored):**
+```typescript
+createUnprovenLedgerCallTx(
+  circuitId: AnyProvableCircuitId,
+  contractAddress: ContractAddress,
+  initialContractState: ContractState,
+  zswapChainState: ZswapChainState,
+  partitionedTranscript: PartitionedTranscript, // restored
+  privateTranscriptOutputs: AlignedValue[],
+  input: AlignedValue,
+  output: AlignedValue,
+  nextZswapLocalState: ZswapLocalState,
+  encryptionPublicKey: EncPublicKey
+  // ledgerParameters removed
+): UnprovenTransaction
+```
+
+#### `extractUserAddressedOutputs` — restored
+
+This function was removed in v4.0.1 (#648) and is now re-exported from `@midnight-ntwrk/midnight-js-contracts`.
+
+```typescript
+extractUserAddressedOutputs(
+  transcript: Transcript<AlignedValue> | undefined
+): UtxoOutput[]
+```
+
+### Migration Steps
+
+1. Replace `publicTranscript` parameter with `partitionedTranscript: PartitionedTranscript` in `createUnprovenLedgerCallTx` calls
+2. Remove the `ledgerParameters` parameter from `createUnprovenLedgerCallTx` calls (note: `ledgerParameters` is still required in `CallOptionsProviderDataDependencies`)
+3. Restore any `extractUserAddressedOutputs` usages that were removed for v4.0.1
+
+---
+
+## Common Migration Issues
+
+### Error: "expected a cell, received null" on shielded operations
+
+**Cause:** Using v4.0.1's `addCalls` API with contracts that call `receiveShielded`, `sendShielded`, or `writeCoin`.
+
+**Solution:** Upgrade to v4.0.2. The `ContractCallPrototype` approach correctly handles shielded operations.
+
+### Error: "attempted to spend from a Merkle tree that was not rehashed"
+
+**Cause:** The chain state's Merkle tree was not rehashed before constructing coin inclusion proofs.
+
+**Solution:** Upgrade to v4.0.2. The `zswapStateToOffer` function now calls `postBlockUpdate()` automatically.

--- a/docs/releases/v4.0.2/migration-guide.md
+++ b/docs/releases/v4.0.2/migration-guide.md
@@ -1,0 +1,97 @@
+# Migration Guide v4.0.1 to v4.0.2
+
+## Overview
+
+This guide covers migrating from midnight-js v4.0.1 to v4.0.2. The primary change is the **revert of the `addCalls` API refactor** (#648) that was introduced in v4.0.1. If you are upgrading directly from v3.2.0, the `createUnprovenLedgerCallTx` signature in v4.0.2 matches v3.2.0 (with ledger-v8 types) — follow the [v4.0.1 migration guide](../v4.0.1/migration-guide.md) but skip breaking change #4.
+
+## Step 1: Update Dependencies
+
+```bash
+yarn upgrade @midnight-ntwrk/midnight-js-contracts@^4.0.2
+yarn upgrade @midnight-ntwrk/http-client-proof-provider@^4.0.2
+```
+
+## Step 2: Revert `createUnprovenLedgerCallTx` Call Sites
+
+If you adapted call sites to the v4.0.1 signature, revert them.
+
+**Before (v4.0.1):**
+```typescript
+const tx = createUnprovenLedgerCallTx(
+  circuitId,
+  contractAddress,
+  initialContractState,
+  zswapChainState,
+  publicTranscript,           // Op<AlignedValue>[]
+  privateTranscriptOutputs,
+  input,
+  output,
+  nextZswapLocalState,
+  encryptionPublicKey,
+  ledgerParameters             // LedgerParameters
+);
+```
+
+**After (v4.0.2):**
+```typescript
+const tx = createUnprovenLedgerCallTx(
+  circuitId,
+  contractAddress,
+  initialContractState,
+  zswapChainState,
+  partitionedTranscript,       // PartitionedTranscript
+  privateTranscriptOutputs,
+  input,
+  output,
+  nextZswapLocalState,
+  encryptionPublicKey
+  // ledgerParameters removed from this function
+);
+```
+
+## Step 3: Restore `extractUserAddressedOutputs` Usages
+
+If you removed calls to `extractUserAddressedOutputs` when upgrading to v4.0.1, restore them. The function is once again exported from `@midnight-ntwrk/midnight-js-contracts`.
+
+```typescript
+import { extractUserAddressedOutputs } from '@midnight-ntwrk/midnight-js-contracts';
+
+const outputs = extractUserAddressedOutputs(transcript);
+```
+
+## Step 4: (Optional) Add Proof Server Headers
+
+If your proof server requires authentication, you can now pass headers:
+
+```typescript
+const provider = httpClientProvingProvider(zkConfigProvider, proofServerUrl, {
+  headers: { 'Authorization': 'Bearer <token>' }
+});
+```
+
+## Troubleshooting
+
+### Error: "expected a cell, received null"
+
+**Cause:** Still using v4.0.1's `addCalls` approach with shielded contracts.
+
+**Solution:** Ensure you are on v4.0.2 and using `partitionedTranscript` (not `publicTranscript`). If using `createUnprovenCallTx` (the high-level API), simply updating the dependency is sufficient — the fix is internal.
+
+### Error: "attempted to spend from a Merkle tree that was not rehashed"
+
+**Cause:** Chain state Merkle tree not rehashed before coin spending.
+
+**Solution:** Upgrade to v4.0.2. Fixed internally in `zswapStateToOffer` — no code changes needed.
+
+### Error: `CompactError` not propagated from deploy transactions
+
+**Cause:** `createUnprovenDeployTxFromVerifierKeys` only caught `ContractRuntimeError`, not `ContractConfigurationError`.
+
+**Solution:** Upgrade to v4.0.2. Fixed internally — no code changes needed.
+
+## Rollback Plan
+
+If rollback is needed:
+1. Downgrade to v4.0.1: `yarn upgrade @midnight-ntwrk/midnight-js-contracts@^4.0.1`
+2. Re-apply v4.0.1 breaking change #4 adaptations (see [v4.0.1 migration guide](../v4.0.1/migration-guide.md))
+3. Note: shielded contract operations will not work on v4.0.1

--- a/docs/releases/v4.0.2/new-features.md
+++ b/docs/releases/v4.0.2/new-features.md
@@ -1,0 +1,51 @@
+# New Features v4.0.2
+
+## 1. Headers Support in `httpClientProvingProvider` (#685)
+
+The HTTP client proving provider now supports custom headers for all requests to the proof server. This enables authentication tokens, API keys, or other custom headers to be forwarded with proof generation and verification requests.
+
+### Usage
+
+```typescript
+import { httpClientProvingProvider } from '@midnight-ntwrk/http-client-proof-provider';
+
+const provider = httpClientProvingProvider(zkConfigProvider, proofServerUrl, {
+  timeout: 60_000,
+  headers: {
+    'Authorization': 'Bearer <token>',
+    'X-Custom-Header': 'value'
+  }
+});
+```
+
+### API
+
+```typescript
+export interface ProvingProviderConfig {
+  readonly timeout?: number;
+  readonly headers?: Record<string, string>;  // NEW
+}
+```
+
+Headers are merged with `{ 'Content-Type': 'application/octet-stream' }` as the base, so custom headers take precedence over defaults.
+
+---
+
+## 2. `isEffectContractError` Type Guard (#712)
+
+A new type guard for safely narrowing Effect-ts contract errors without `as any` casts. Used internally in `unproven-call-tx.ts` and `unproven-deploy-tx.ts`, and exported from `@midnight-ntwrk/midnight-js-contracts` for use in custom error handling.
+
+### Usage
+
+```typescript
+import { isEffectContractError } from '@midnight-ntwrk/midnight-js-contracts';
+
+try {
+  await executeCircuit();
+} catch (error) {
+  if (isEffectContractError(error) && error._tag === 'ContractRuntimeError') {
+    // Safely access error.cause without any casts
+    console.error(error.cause.message);
+  }
+}
+```

--- a/docs/releases/v4.0.2/release-notes.md
+++ b/docs/releases/v4.0.2/release-notes.md
@@ -1,40 +1,93 @@
 # Release Notes v4.0.2
 
-**Release Date:** March 2026
+**Release Date:** March 24, 2026
 **Previous Version:** v4.0.1
 **Node.js Requirement:** >=22
 
 ## Bug Fixes
 
-### Revert `createUnprovenLedgerCallTx` to `ContractCallPrototype` approach (#686)
+### Revert `createUnprovenLedgerCallTx` to `ContractCallPrototype` approach (#695)
 
-The `PreTranscript + Transaction.addCalls()` approach introduced in v4.0.0 (#648) fails for contracts using shielded coin operations (`receiveShielded`, `sendShielded`, `writeCoin`). The `addCalls()` stack machine does not initialize its stack identically to compact-runtime's `queryLedgerState` during circuit execution, causing `"expected a cell, received null"` errors when shielded operations produce `dup` ops expecting items on the initial stack.
+The `PreTranscript + Transaction.addCalls()` approach introduced in v4.0.1 (#648) fails for contracts using shielded coin operations (`receiveShielded`, `sendShielded`, `writeCoin`). The `addCalls()` stack machine does not initialize its stack identically to compact-runtime's `queryLedgerState` during circuit execution, causing `"expected a cell, received null"` errors when shielded operations produce `dup` ops expecting items on the initial stack.
 
 Reverted `createUnprovenLedgerCallTx` to use `ContractCallPrototype + Intent.addCall()` with `PartitionedTranscript`, which correctly handles shielded coin operations.
 
 **Affected contracts:** Any contract using `receiveShielded`, `sendShielded`, or `writeCoin` (e.g., Seabattle `join_p1`/`join_p2`, Lunarswap `addLiquidity`).
 
-#### Corrections to v4.0.0 release documentation
+#### Corrections to v4.0.1 release documentation
 
-The v4.0.0 release notes described breaking change #4 ("Transaction building refactored to `addCalls` API", #648). That change has been reverted. The following statements from v4.0.0 docs are no longer accurate:
+The v4.0.1 release notes described breaking change #4 ("Transaction building refactored to `addCalls` API", #648). That change has been reverted. The following statements from v4.0.1 docs are no longer accurate:
 
 - ~~`createUnprovenLedgerCallTx` signature now requires `ledgerParameters` and `coinPublicKey` parameters~~ -- Reverted. The function takes `partitionedTranscript: PartitionedTranscript` and does not require `ledgerParameters` or `coinPublicKey`.
 - ~~`extractUserAddressedOutputs` has been removed~~ -- Restored. This function is exported from `@midnight-ntwrk/midnight-js-contracts`.
 - ~~`partitionedTranscript` parameter replaced with `publicTranscript` (`Op<AlignedValue>[]`)~~ -- Reverted. The parameter is `partitionedTranscript: PartitionedTranscript`.
 
-The `createUnprovenLedgerCallTx` signature in v4.0.2 matches the v3.2.0 signature (with ledger-v8 types). Users who adapted call sites to the v4.0.0 signature must revert those changes.
+The `createUnprovenLedgerCallTx` signature in v4.0.2 matches the v3.2.0 signature (with ledger-v8 types). Users who adapted call sites to the v4.0.1 signature must revert those changes.
 
-All other v4.0.0 breaking changes remain valid: ledger v7-to-v8 migration (#607), `queryZSwapAndContractState` 3-tuple (#633), and `CallOptionsProviderDataDependencies` requiring `ledgerParameters` (#633).
+All other v4.0.1 breaking changes remain valid: ledger v7-to-v8 migration (#607), `queryZSwapAndContractState` 3-tuple (#633), and `CallOptionsProviderDataDependencies` requiring `ledgerParameters` (#633).
 
-### Rehash `ZswapChainState` before spending from Merkle tree
+### Rehash `ZswapChainState` before spending from Merkle tree (#695)
 
 `ZswapInput.newContractOwned` in ledger-v8 requires the chain state's Merkle tree to be rehashed before validating coin inclusion proofs. The `zswapStateToOffer` function now calls `postBlockUpdate()` on the chain state before constructing inputs. Without this, contracts that spend coins deposited in a prior transaction (e.g., Seabattle `join_p2` calling `mergeCoinImmediate` on a coin from `join_p1`) fail with `"attempted to spend from a Merkle tree that was not rehashed"`.
 
-### Fix `CompactError` propagation in `createUnprovenDeployTxFromVerifierKeys`
+### Fix `CompactError` propagation in `createUnprovenDeployTxFromVerifierKeys` (#695)
 
 The error handler in `createUnprovenDeployTxFromVerifierKeys` only checked for `ContractRuntimeError` when unwrapping errors from the contract runtime. The `compact-js` dependency now wraps `initialState` errors as `ContractConfigurationError`. Updated the handler to recognize both `ContractRuntimeError` and `ContractConfigurationError`, so `CompactError` messages propagate correctly to callers.
 
+### Fix fallible offer error reporting (#705)
+
+Two bugs in fallible transaction error reporting:
+
+1. **Map serialization in `TxFailedError`:** `segmentStatusMap` was silently lost during `JSON.stringify` because `Map` is not natively serializable. The replacer now converts `Map` instances to plain objects via `Object.fromEntries`.
+
+2. **Incorrect `scopeName` in scoped transaction errors:** Error messages referenced the `options` parameter (only set for nested transactions) instead of the resolved `txOptions`. Root transactions always displayed `<unnamed>` even when a `scopeName` was provided.
+
+### Fix fallible error handling (#704)
+
+Fixed error construction in fallible transaction handling where the error object was incorrectly built.
+
+### Replace error `as any` casts with type guard (#712)
+
+Introduced `isEffectContractError` type guard in `errors.ts` to safely narrow Effect-ts errors instead of using fragile `(error as any)` introspection. Removed all `as-any` casts and `eslint-disable` comments from catch blocks in `unproven-call-tx.ts` and `unproven-deploy-tx.ts`.
+
+## Security
+
+### Command injection prevention in compact CLI tools (#711)
+
+`execSync`/`exec` with template literals in `fetch-compact.mts` and `run-compactc.cjs` were vulnerable to command injection when version strings or CLI arguments contained shell metacharacters. Replaced with `spawnSync`/`spawn` using argument arrays, which bypass the shell entirely.
+
+### Pin `upload-sarif-github-action` to latest SHA
+
+Pinned the SARIF upload GitHub Action to a specific commit SHA to prevent supply chain attacks from compromised tags.
+
+## Enhancements
+
+### Headers support in `httpClientProvingProvider` (#685)
+
+The `ProvingProviderConfig` interface now accepts an optional `headers` field (`Record<string, string>`), which is forwarded to all HTTP requests made by the proving provider. This enables authentication and custom header injection for proof server communication.
+
+```typescript
+const provider = httpClientProvingProvider(zkConfigProvider, proofServerUrl, {
+  timeout: 60_000,
+  headers: { 'Authorization': 'Bearer <token>' }
+});
+```
+
+## Chore
+
+- Remove dead code from zswap-utils offer construction (#710) — removed unused `__uint8Array_val__` reviver from `deserializeCoinInfo` and dead null filter from `unprovenOfferFromMap`
+- Update `scan.yaml` CI workflow (#708)
+
+## Documentation
+
+- API documentation update (#703)
+- Release notes for v4.0.1 (#698, #696)
+
 ## Links
 
-- [v4.0.0 Release Notes](../v4.0.0/release-notes.md)
+- [Breaking Changes Details](./breaking-changes.md)
+- [New Features Guide](./new-features.md)
+- [Migration Guide](./migration-guide.md)
+- [API Changes Reference](./api-changes.md)
+- [v4.0.1 Release Notes](../v4.0.1/release-notes.md)
 - [GitHub Issue #686](https://github.com/midnightntwrk/midnight-js/issues/686)


### PR DESCRIPTION
## Summary

- Expand existing `release-notes.md` from 3 items to full changelog covering all 14 commits between v4.0.1 and v4.0.2
- Add `README.md` with overview, quick links, and testing checklist
- Add `breaking-changes.md` documenting the revert of v4.0.1 breaking change #4 (addCalls API)
- Add `new-features.md` covering headers support in proof provider and `isEffectContractError` type guard
- Add `api-changes.md` with restored/modified exports and diff view
- Add `migration-guide.md` with step-by-step v4.0.1 → v4.0.2 upgrade instructions

## Test plan

- [ ] Verify all internal links between release doc files resolve correctly
- [ ] Verify links to v4.0.1 release docs resolve correctly
- [ ] Confirm API signatures in docs match actual code in v4.0.2
- [ ] Review breaking-changes.md before/after code examples for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)