### PR TITLE
fix(testkit-js): fix 15 bugs covering missing assertions, swallowed errors, and stale env vars

### DIFF
--- a/testkit-js/testkit-js-e2e/vite.setup.mjs
+++ b/testkit-js/testkit-js-e2e/vite.setup.mjs
@@ -1,7 +1,7 @@
 import { beforeAll, vi } from 'vitest';
 import {
   createLogger,
-  deleteDirectory,
+  tryDeleteDirectory,
   defaultContainersConfiguration,
   setContainersConfiguration
 } from '@midnight-ntwrk/testkit-js';
@@ -28,7 +28,7 @@ beforeAll(async () => {
     'Setting up container configuration to use pinned component versions'
   );
   setContainersConfiguration(testKitContainersConfiguration);
-  await deleteDirectory('../midnight-level-db');
+  await tryDeleteDirectory('../midnight-level-db');
 });
 
 const MINUTE = 60 * 1000;

--- a/testkit-js/testkit-js/src/assertions.ts
+++ b/testkit-js/testkit-js/src/assertions.ts
@@ -112,7 +112,7 @@ export const expectSuccessfulDeployTx = async <C extends Contract.Any>(
   const deployedLedgerState = await providers.publicDataProvider.queryContractState(
     deployTxData.public.contractAddress
   );
-  expect(stateValueEqual(deployTxData.public.initialContractState.data.state, deployedLedgerState!.data.state));
+  expect(stateValueEqual(deployTxData.public.initialContractState.data.state, deployedLedgerState!.data.state)).toBeTruthy();
   expect(deployTxData.public.initialContractState).toBeTruthy();
 
   // Checks that the signing key and private state passed in the deploy configuration
@@ -143,7 +143,7 @@ export const expectSuccessfulCallTx = async <C extends Contract.Any, PCK extends
 ): Promise<void> => {
   expectSuccessfulTxData(callTxData.public);
   expect(callTxData.public.nextContractState).toBeTruthy();
-  expect(callTxData.private.nextZswapLocalState);
+  expect(callTxData.private.nextZswapLocalState).toBeTruthy();
   if (callTxOptions) {
     if ('privateStateId' in callTxOptions) {
       const storedPrivateState = await providers.privateStateProvider.get(callTxOptions.privateStateId);

--- a/testkit-js/testkit-js/src/client/faucet-client.ts
+++ b/testkit-js/testkit-js/src/client/faucet-client.ts
@@ -16,7 +16,7 @@
 import axios from 'axios';
 import type { Logger } from 'pino';
 
-import { extractHostnameAndPort } from '@/utils';
+import { buildUrlWithPath } from '@/utils';
 
 /**
  * Client for interacting with the Midnight faucet service.
@@ -42,16 +42,10 @@ export class FaucetClient {
    * @returns {Promise<AxiosResponse | void>} A promise that resolves to the response of the health check or logs an error if the request fails
    */
   async health() {
-    const url = `https://${extractHostnameAndPort(this.faucetUrl)}/api/health`;
-    return axios
-      .get(url, { timeout: 1000 })
-      .then((r) => {
-        this.logger.info(`Connected to faucet ${url}: ${JSON.stringify(r.data)}`);
-        return r;
-      })
-      .catch((error) => {
-        this.logger.warn(`Failed to connect to faucet service at '${url}'`, error);
-      });
+    const url = buildUrlWithPath(this.faucetUrl, '/api/health');
+    const response = await axios.get(url, { timeout: 1000 });
+    this.logger.info(`Connected to faucet ${url}: ${JSON.stringify(response.data)}`);
+    return response;
   }
 
   /**
@@ -63,27 +57,19 @@ export class FaucetClient {
    */
   async requestTokens(walletAddress: string): Promise<void> {
     this.logger.info(`Requesting tokens from '${this.faucetUrl}' for address: '${walletAddress}'`);
-    try {
-      const response = await axios.post(
-        this.faucetUrl,
-        {
-          address: walletAddress,
-          captchaToken: 'XXXX.DUMMY.TOKEN.XXXX'
-        },
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            'x-turnstile-token': process.env.TURNSTILE_HEADER ?? ''
-          }
+    const response = await axios.post(
+      this.faucetUrl,
+      {
+        address: walletAddress,
+        captchaToken: 'XXXX.DUMMY.TOKEN.XXXX'
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'x-turnstile-token': process.env.TURNSTILE_HEADER ?? ''
         }
-      );
-      this.logger.info(`Faucet response: ${response.statusText}`);
-    } catch (error) {
-      if (error instanceof Error) {
-        this.logger.error(`Error requesting tokens: ${error.message}`);
-      } else {
-        this.logger.error(`Error requesting tokens`);
       }
-    }
+    );
+    this.logger.info(`Faucet response: ${response.statusText}`);
   }
 }

--- a/testkit-js/testkit-js/src/client/indexer-client.ts
+++ b/testkit-js/testkit-js/src/client/indexer-client.ts
@@ -16,7 +16,7 @@
 import axios from 'axios';
 import type { Logger } from 'pino';
 
-import { extractHostnameAndPort } from '@/utils';
+import { buildUrlWithPath } from '@/utils';
 
 export class IndexerClient {
   readonly indexerUrl: string;
@@ -38,15 +38,9 @@ export class IndexerClient {
    * @returns {Promise<AxiosResponse | void>} A promise that resolves to the response of the health check or logs an error if the request fails.
    */
   async health() {
-    const url = `https://${extractHostnameAndPort(this.indexerUrl)}/ready`;
-    return axios
-      .get(url, { timeout: 1000 })
-      .then((r) => {
-        this.logger.info(`Connected to indexer ${url}: ${JSON.stringify(r.data)}`);
-        return r;
-      })
-      .catch((error) => {
-        this.logger.warn(`Failed to connect to indexer at '${url}'`, error);
-      });
+    const url = buildUrlWithPath(this.indexerUrl, '/ready');
+    const response = await axios.get(url, { timeout: 1000 });
+    this.logger.info(`Connected to indexer ${url}: ${JSON.stringify(response.data)}`);
+    return response;
   }
 }

--- a/testkit-js/testkit-js/src/client/node-client.ts
+++ b/testkit-js/testkit-js/src/client/node-client.ts
@@ -20,7 +20,7 @@ import type { BlockHash } from '@midnight-ntwrk/midnight-js-types';
 import axios, { type AxiosResponse } from 'axios';
 import type { Logger } from 'pino';
 
-import { extractHostnameAndPort } from '@/utils';
+import { buildUrlWithPath } from '@/utils';
 
 /**
  * Client for interacting with a Midnight node's JSON-RPC API
@@ -45,16 +45,10 @@ export class NodeClient {
    * @returns {Promise<AxiosResponse | void>} A promise that resolves to the response of the health check or logs an error if the request fails.
    */
   async health() {
-    const url = `https://${extractHostnameAndPort(this.nodeURL)}/health`;
-    return axios
-      .get(url, { timeout: 1000 })
-      .then((r) => {
-        this.logger.info(`Connected to node ${url}: ${JSON.stringify(r.data)}`);
-        return r;
-      })
-      .catch((error) => {
-        this.logger.warn(`Failed to connect to node at '${url}'`, error);
-      });
+    const url = buildUrlWithPath(this.nodeURL, '/health');
+    const response = await axios.get(url, { timeout: 1000 });
+    this.logger.info(`Connected to node ${url}: ${JSON.stringify(response.data)}`);
+    return response;
   }
 
   /**
@@ -129,7 +123,7 @@ export class NodeClient {
    */
   async ledgerStateBlob(blockHash: BlockHash): Promise<Uint8Array> {
     this.logger.info(`Fetching ledger state at block hash '${blockHash}'`);
-    const result = await this.jsonRPC('midnight_getLedgerState', []);
+    const result = await this.jsonRPC('midnight_getLedgerState', [blockHash]);
     if (result === '') {
       throw new Error(`No ledger state found at block hash '${blockHash}'`);
     }
@@ -144,7 +138,7 @@ export class NodeClient {
    */
   async ledgerVersion(blockHash: BlockHash): Promise<string> {
     this.logger.info(`Fetching ledger version at block hash '${blockHash}'`);
-    const result = await this.jsonRPC('midnight_ledgerVersion', []);
+    const result = await this.jsonRPC('midnight_ledgerVersion', [blockHash]);
     if (result === '') {
       throw new Error(`No ledger version found at block hash '${blockHash}'`);
     }

--- a/testkit-js/testkit-js/src/client/proof-server-client.ts
+++ b/testkit-js/testkit-js/src/client/proof-server-client.ts
@@ -16,7 +16,7 @@
 import axios, { type AxiosRequestConfig } from 'axios';
 import type { Logger } from 'pino';
 
-import { extractHostnameAndPort } from '@/utils';
+import { buildUrlWithPath } from '@/utils';
 
 export class ProofServerClient {
   readonly proofServer: string;
@@ -38,16 +38,10 @@ export class ProofServerClient {
    * @returns {Promise<AxiosResponse | void>} A promise that resolves to the response of the health check or logs an error if the request fails.
    */
   async health() {
-    const url = `http://${extractHostnameAndPort(this.proofServer)}/health`;
-    return axios
-      .get(url, { timeout: 1000 })
-      .then((r) => {
-        this.logger.info(`Connected to proof server ${url}: ${JSON.stringify(r.data)}`);
-        return r;
-      })
-      .catch((error) => {
-        this.logger.warn(`Failed to connect to proof server at '${url}'`, error);
-      });
+    const url = buildUrlWithPath(this.proofServer, '/health');
+    const response = await axios.get(url, { timeout: 1000 });
+    this.logger.info(`Connected to proof server ${url}: ${JSON.stringify(response.data)}`);
+    return response;
   }
 
   /**
@@ -61,15 +55,9 @@ export class ProofServerClient {
       timeout: 3 * 60_000
     }
   ) {
-    const url = `http://${extractHostnameAndPort(this.proofServer)}/prove-tx`;
-    return axios
-      .post(url, data, config)
-      .then((r) => {
-        this.logger.info(`Received data from proof server ${url}`);
-        return r;
-      })
-      .catch((error) => {
-        this.logger.error(`Error in proof server at '${url}' ${error.toString()}`);
-      });
+    const url = buildUrlWithPath(this.proofServer, '/prove-tx');
+    const response = await axios.post(url, data, config);
+    this.logger.info(`Received data from proof server ${url}`);
+    return response;
   }
 }

--- a/testkit-js/testkit-js/src/env-vars.ts
+++ b/testkit-js/testkit-js/src/env-vars.ts
@@ -23,10 +23,10 @@ export const getEnvVarWalletSeeds = () => {
   const envSeeds = process.env.MN_TEST_WALLET_SEED || process.env.TEST_WALLET_SEED;
   return envSeeds ? envSeeds.split(',') : undefined;
 };
-export const MN_TEST_INDEXER = process.env.MN_TEST_INDEXER;
-export const MN_TEST_INDEXER_WS = process.env.MN_TEST_INDEXER_WS;
-export const MN_TEST_NODE = process.env.MN_TEST_NODE;
-export const MN_TEST_NODE_WS = process.env.MN_TEST_NODE_WS;
-export const MN_TEST_FAUCET = process.env.MN_TEST_FAUCET;
-export const MN_TEST_NETWORK_ID = process.env.MN_TEST_NETWORK_ID;
-export const MN_TEST_WALLET_NETWORK_ID = process.env.MN_TEST_WALLET_NETWORK_ID;
+export const getMnTestIndexer = () => process.env.MN_TEST_INDEXER;
+export const getMnTestIndexerWs = () => process.env.MN_TEST_INDEXER_WS;
+export const getMnTestNode = () => process.env.MN_TEST_NODE;
+export const getMnTestNodeWs = () => process.env.MN_TEST_NODE_WS;
+export const getMnTestFaucet = () => process.env.MN_TEST_FAUCET;
+export const getMnTestNetworkId = () => process.env.MN_TEST_NETWORK_ID;
+export const getMnTestWalletNetworkId = () => process.env.MN_TEST_WALLET_NETWORK_ID;

--- a/testkit-js/testkit-js/src/test-environment/test-environments/env-var-remote-test-environment.ts
+++ b/testkit-js/testkit-js/src/test-environment/test-environments/env-var-remote-test-environment.ts
@@ -16,13 +16,13 @@
 import { type NetworkId } from '@midnight-ntwrk/wallet-sdk-abstractions';
 
 import {
-  MN_TEST_FAUCET,
-  MN_TEST_INDEXER,
-  MN_TEST_INDEXER_WS,
-  MN_TEST_NETWORK_ID,
-  MN_TEST_NODE,
-  MN_TEST_NODE_WS,
-  MN_TEST_WALLET_NETWORK_ID
+  getMnTestFaucet,
+  getMnTestIndexer,
+  getMnTestIndexerWs,
+  getMnTestNetworkId,
+  getMnTestNode,
+  getMnTestNodeWs,
+  getMnTestWalletNetworkId
 } from '@/env-vars';
 import { MissingEnvironmentVariable } from '@/errors';
 import type { EnvironmentConfiguration } from '@/test-environment';
@@ -59,13 +59,13 @@ export class EnvVarRemoteTestEnvironment extends RemoteTestEnvironment {
       }
     });
     return {
-      walletNetworkId: MN_TEST_WALLET_NETWORK_ID as NetworkId.NetworkId,
-      networkId: MN_TEST_NETWORK_ID as string,
-      indexer: MN_TEST_INDEXER as string,
-      indexerWS: MN_TEST_INDEXER_WS as string,
-      node: MN_TEST_NODE as string,
-      nodeWS: MN_TEST_NODE_WS as string,
-      faucet: MN_TEST_FAUCET,
+      walletNetworkId: getMnTestWalletNetworkId() as NetworkId.NetworkId,
+      networkId: getMnTestNetworkId() as string,
+      indexer: getMnTestIndexer() as string,
+      indexerWS: getMnTestIndexerWs() as string,
+      node: getMnTestNode() as string,
+      nodeWS: getMnTestNodeWs() as string,
+      faucet: getMnTestFaucet(),
       proofServer: this.proofServerContainer?.getUrl()
     };
   }

--- a/testkit-js/testkit-js/src/test-environment/test-environments/test-environment.ts
+++ b/testkit-js/testkit-js/src/test-environment/test-environments/test-environment.ts
@@ -30,7 +30,6 @@ export abstract class TestEnvironment {
   /** Unique identifier for this test environment instance */
   protected readonly uid: string;
 
-  protected readonly envConfiguration: EnvironmentConfiguration;
   /**
    * Creates a new TestEnvironment instance.
    * @param {Logger} logger - Logger instance for recording operations

--- a/testkit-js/testkit-js/src/utils.ts
+++ b/testkit-js/testkit-js/src/utils.ts
@@ -41,7 +41,7 @@ export const delay = (ms: number) => {
  * @returns {Promise<void>} A promise that resolves when the directory is deleted
  * @private
  */
-export const deleteDirectory = async (dirPath: string) => {
+export const tryDeleteDirectory = async (dirPath: string) => {
   try {
     const resolvedPath = path.resolve(dirPath);
     await rm(resolvedPath, { recursive: true, force: true });
@@ -55,10 +55,7 @@ export const deleteDirectory = async (dirPath: string) => {
   }
 };
 
-export const extractHostnameAndPort = (url: string): string => {
-  const { hostname, port } = new URL(url);
-  if (port !== '') {
-    return `${hostname}:${port}`;
-  }
-  return hostname;
+export const buildUrlWithPath = (baseUrl: string, urlPath: string): string => {
+  const url = new URL(baseUrl);
+  return `${url.protocol}//${url.host}${urlPath}`;
 };

--- a/testkit-js/testkit-js/src/wallet/fluent-wallet-builder.ts
+++ b/testkit-js/testkit-js/src/wallet/fluent-wallet-builder.ts
@@ -81,30 +81,27 @@ export class FluentWalletBuilder {
   }
 
   async build(): Promise<WalletFacade> {
-    if (!this.seeds) {
+    const seeds = this.seeds ?? (() => {
       logger.info('No seed provided, generating random seed');
-      this.seeds = WalletSeeds.generateRandom();
-      logger.info(`Generated random wallet seed: ${this.seeds.masterSeed}`);
-    }
+      return WalletSeeds.generateRandom();
+    })();
 
-    logger.info(`Building wallet with configuration: ${JSON.stringify(this.config)}`);
+    const unshieldedKeystore = createKeystore(seeds.unshielded, this.networkId);
 
-    const unshieldedKeystore = createKeystore(this.seeds.unshielded, this.networkId);
-
-    const shieldedWallet = WalletFactory.createShieldedWallet(this.config, this.seeds.shielded);
+    const shieldedWallet = WalletFactory.createShieldedWallet(this.config, seeds.shielded);
     const unshieldedWallet = WalletFactory.createUnshieldedWallet(
       this.config,
       unshieldedKeystore
     );
     const dustWallet = WalletFactory.createDustWallet(
       this.config,
-      this.seeds.dust,
+      seeds.dust,
       this.dustOptions
     );
 
     const walletFacade = await WalletFactory.createWalletFacade(this.config, shieldedWallet, unshieldedWallet, dustWallet);
 
-    return WalletFactory.startWalletFacade(walletFacade, this.seeds.shielded, this.seeds.dust);
+    return WalletFactory.startWalletFacade(walletFacade, seeds.shielded, seeds.dust);
   }
 
   async buildWithoutStarting(): Promise<{
@@ -112,24 +109,21 @@ export class FluentWalletBuilder {
     seeds: WalletSeeds;
     keystore: UnshieldedKeystore;
   }> {
-    if (!this.seeds) {
+    const seeds = this.seeds ?? (() => {
       logger.info('No seed provided, generating random seed');
-      this.seeds = WalletSeeds.generateRandom();
-      logger.info(`Generated random wallet seed: ${this.seeds.masterSeed}`);
-    }
+      return WalletSeeds.generateRandom();
+    })();
 
-    logger.info(`Building wallet without starting with configuration: ${JSON.stringify(this.config)}`);
+    const unshieldedKeystore = createKeystore(seeds.unshielded, this.networkId);
 
-    const unshieldedKeystore = createKeystore(this.seeds.unshielded, this.networkId);
-
-    const shieldedWallet = WalletFactory.createShieldedWallet(this.config, this.seeds.shielded);
+    const shieldedWallet = WalletFactory.createShieldedWallet(this.config, seeds.shielded);
     const unshieldedWallet = WalletFactory.createUnshieldedWallet(
       this.config,
       unshieldedKeystore
     );
     const dustWallet = WalletFactory.createDustWallet(
       this.config,
-      this.seeds.dust,
+      seeds.dust,
       this.dustOptions
     );
 
@@ -137,7 +131,7 @@ export class FluentWalletBuilder {
 
     return {
       wallet: walletFacade,
-      seeds: this.seeds,
+      seeds,
       keystore: unshieldedKeystore
     };
   }

--- a/testkit-js/testkit-js/src/wallet/midnight-wallet-provider.ts
+++ b/testkit-js/testkit-js/src/wallet/midnight-wallet-provider.ts
@@ -87,7 +87,7 @@ export class MidnightWalletProvider implements MidnightProvider, WalletProvider 
     await this.wallet.start(this.zswapSecretKeys, this.dustSecretKey);
     if (waitForFundsInWallet) {
       const balance = await waitForFunds(this.wallet, this.env, tokenType, true);
-      this.logger.info(`Your wallet balance is: ${JSON.stringify(balance)}`);
+      this.logger.info(`Your wallet balance is: ${balance}`);
     }
   }
 

--- a/testkit-js/testkit-js/src/wallet/wallet-state-provider.ts
+++ b/testkit-js/testkit-js/src/wallet/wallet-state-provider.ts
@@ -79,22 +79,14 @@ export class WalletSaveStateProvider {
    */
   async save(wallet: ShieldedWalletAPI | UnshieldedWalletAPI): Promise<void> {
     this.logger.info(`Saving state in ${this.filePath}`);
-    try {
-      fs.mkdirSync(this.directoryPath, { recursive: true });
-      const serializedState = await wallet.serializeState();
-      try {
-        const tempFile = `${this.filePath.replaceAll('.gz', '')}`;
-        fs.writeFileSync(tempFile, serializedState);
-        this.logger.info(`File '${tempFile}' written successfully.`);
-        await new GzipFile(tempFile, `${this.filePath.replaceAll('.gz', '')}.gz`).compress();
-        fs.rmSync(tempFile);
-        this.logger.info(`File '${this.filePath}' written successfully.`);
-      } catch (err) {
-        this.logger.error(`Error writing file '${this.filePath}': ${err instanceof Error ? err.message : String(err)}`);
-      }
-    } catch (e) {
-      this.logger.warn(e instanceof Error ? e.message : String(e));
-    }
+    fs.mkdirSync(this.directoryPath, { recursive: true });
+    const serializedState = await wallet.serializeState();
+    const tempFile = this.filePath.endsWith('.gz') ? this.filePath.slice(0, -3) : this.filePath;
+    fs.writeFileSync(tempFile, serializedState);
+    this.logger.info(`File '${tempFile}' written successfully.`);
+    await new GzipFile(tempFile, `${tempFile}.gz`).compress();
+    fs.rmSync(tempFile);
+    this.logger.info(`File '${this.filePath}' written successfully.`);
   }
 
   /**

--- a/testkit-js/testkit-js/src/wallet/wallet-utils.ts
+++ b/testkit-js/testkit-js/src/wallet/wallet-utils.ts
@@ -87,7 +87,7 @@ export const waitForFunds = async (
   env: EnvironmentConfiguration,
   tokenType: TokenType = shieldedToken(),
   fundFromFaucet = false
-) => {
+): Promise<bigint> => {
   const initialState = await getInitialShieldedState(wallet.shielded);
   logger.info(`Your wallet address is: ${initialState.address.coinPublicKeyString()}, waiting for funds...`);
   if (fundFromFaucet && env.faucet) {
@@ -96,9 +96,12 @@ export const waitForFunds = async (
   }
   const initialBalance = initialState.balances[tokenType.tag];
   if (initialBalance === undefined || initialBalance === 0n) {
-    logger.info(`Your wallet balance is: 0`);
-    logger.info(`Waiting to receive tokens...`);
-    return syncWallet(wallet);
+    logger.info('Your wallet balance is: 0, waiting to receive tokens...');
+    const syncedState = await syncWallet(wallet);
+    const syncedBalance = syncedState.shielded.balances[tokenType.tag] ?? 0n;
+    logger.info(`Your wallet balance after sync is: ${syncedBalance}`);
+    return syncedBalance;
   }
+  logger.info(`Your wallet balance is: ${initialBalance}`);
   return initialBalance;
 };

--- a/testkit-js/testkit-js/test/assertions.ut.test.ts
+++ b/testkit-js/testkit-js/test/assertions.ut.test.ts
@@ -1,0 +1,38 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { StateValue } from '@midnight-ntwrk/compact-runtime';
+
+import { stateValueEqual } from '@/assertions';
+
+const createMockStateValue = (value: string): StateValue => ({
+  toString: (_verbose: boolean) => value
+}) as StateValue;
+
+describe('[Unit tests] Assertions', () => {
+  it('stateValueEqual should return false for different states', () => {
+    const a = createMockStateValue('state-a');
+    const b = createMockStateValue('state-b');
+
+    expect(stateValueEqual(a, b)).toBe(false);
+  });
+
+  it('stateValueEqual should return true for equal states', () => {
+    const a = createMockStateValue('same');
+    const b = createMockStateValue('same');
+
+    expect(stateValueEqual(a, b)).toBe(true);
+  });
+});

--- a/testkit-js/testkit-js/test/bigint-serialization.ut.test.ts
+++ b/testkit-js/testkit-js/test/bigint-serialization.ut.test.ts
@@ -13,14 +13,24 @@
  * limitations under the License.
  */
 
-declare global {
-  interface BigInt {
-    toJSON(): string;
-  }
-}
+import '@/wallet/bigint-serialization';
 
-BigInt.prototype.toJSON = function () {
-  return this.toString();
-};
+describe('[Unit tests] BigInt serialization', () => {
+  it('should serialize BigInt values that exceed Number.MAX_SAFE_INTEGER without precision loss', () => {
+    const large = 500_000_000_000_000_000_000n;
 
-export {};
+    const serialized = JSON.stringify({ value: large });
+    const parsed = JSON.parse(serialized);
+
+    expect(parsed.value).toBe('500000000000000000000');
+  });
+
+  it('should serialize small BigInt values as strings for consistency', () => {
+    const small = 42n;
+
+    const serialized = JSON.stringify({ value: small });
+    const parsed = JSON.parse(serialized);
+
+    expect(parsed.value).toBe('42');
+  });
+});

--- a/testkit-js/testkit-js/test/client-errors.ut.test.ts
+++ b/testkit-js/testkit-js/test/client-errors.ut.test.ts
@@ -1,0 +1,121 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import axios from 'axios';
+import pino from 'pino';
+
+import { FaucetClient } from '@/client/faucet-client';
+import { IndexerClient } from '@/client/indexer-client';
+import { NodeClient } from '@/client/node-client';
+import { ProofServerClient } from '@/client/proof-server-client';
+
+vi.mock('axios');
+const mockedAxios = vi.mocked(axios);
+
+const logger = pino({ level: 'silent' });
+
+describe('[Unit tests] Client error propagation', () => {
+  describe('FaucetClient', () => {
+    it('requestTokens should throw when faucet request fails', async () => {
+      mockedAxios.post.mockRejectedValue(new Error('Connection refused'));
+
+      const client = new FaucetClient('http://localhost:3000', logger);
+
+      await expect(client.requestTokens('addr123')).rejects.toThrow('Connection refused');
+    });
+
+    it('health should throw when faucet is unreachable', async () => {
+      mockedAxios.get.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const client = new FaucetClient('http://localhost:3000', logger);
+
+      await expect(client.health()).rejects.toThrow('ECONNREFUSED');
+    });
+
+    it('health should use the protocol from the configured URL', async () => {
+      mockedAxios.get.mockResolvedValue({ data: { status: 'ok' } });
+
+      const client = new FaucetClient('http://localhost:3000/api/faucet', logger);
+      await client.health();
+
+      expect(mockedAxios.get).toHaveBeenCalledWith('http://localhost:3000/api/health', expect.anything());
+    });
+  });
+
+  describe('ProofServerClient', () => {
+    it('proveTx should throw when proof server request fails', async () => {
+      mockedAxios.post.mockRejectedValue(new Error('Proof generation failed'));
+
+      const client = new ProofServerClient('http://localhost:6300', logger);
+
+      await expect(client.proveTx(new ArrayBuffer(0))).rejects.toThrow('Proof generation failed');
+    });
+
+    it('health should throw when proof server is unreachable', async () => {
+      mockedAxios.get.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const client = new ProofServerClient('http://localhost:6300', logger);
+
+      await expect(client.health()).rejects.toThrow('ECONNREFUSED');
+    });
+
+    it('health should use the protocol from the configured URL', async () => {
+      mockedAxios.get.mockResolvedValue({ data: { status: 'ok' } });
+
+      const client = new ProofServerClient('http://localhost:6300', logger);
+      await client.health();
+
+      expect(mockedAxios.get).toHaveBeenCalledWith('http://localhost:6300/health', expect.anything());
+    });
+  });
+
+  describe('IndexerClient', () => {
+    it('health should throw when indexer is unreachable', async () => {
+      mockedAxios.get.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const client = new IndexerClient('http://localhost:8088', logger);
+
+      await expect(client.health()).rejects.toThrow('ECONNREFUSED');
+    });
+
+    it('health should use the protocol from the configured URL', async () => {
+      mockedAxios.get.mockResolvedValue({ data: { status: 'ok' } });
+
+      const client = new IndexerClient('http://localhost:8088/api/v4/graphql', logger);
+      await client.health();
+
+      expect(mockedAxios.get).toHaveBeenCalledWith('http://localhost:8088/ready', expect.anything());
+    });
+  });
+
+  describe('NodeClient', () => {
+    it('health should throw when node is unreachable', async () => {
+      mockedAxios.get.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const client = new NodeClient('http://localhost:9944', logger);
+
+      await expect(client.health()).rejects.toThrow('ECONNREFUSED');
+    });
+
+    it('health should use the protocol from the configured URL', async () => {
+      mockedAxios.get.mockResolvedValue({ data: { status: 'ok' } });
+
+      const client = new NodeClient('http://localhost:9944', logger);
+      await client.health();
+
+      expect(mockedAxios.get).toHaveBeenCalledWith('http://localhost:9944/health', expect.anything());
+    });
+  });
+});

--- a/testkit-js/testkit-js/test/env-vars.ut.test.ts
+++ b/testkit-js/testkit-js/test/env-vars.ut.test.ts
@@ -16,7 +16,7 @@
 import path from 'path';
 import { WebSocket } from 'ws';
 
-import { getEnvVarWalletSeeds } from '@/env-vars';
+import { getEnvVarWalletSeeds, getMnTestIndexer } from '@/env-vars';
 import { createLogger } from '@/logger';
 
 const logger = createLogger(
@@ -26,24 +26,45 @@ const logger = createLogger(
 // @ts-expect-error: It's needed to enable WebSocket usage through apollo
 globalThis.WebSocket = WebSocket;
 
-describe.concurrent('[Unit tests] EnvVars Testing API', () => {
+describe('[Unit tests] EnvVars Testing API', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
   beforeEach(() => {
     logger.info(`Starting test... ${expect.getState().currentTestName}`);
   });
 
   it('should return wallet seeds from MN_TEST_WALLET_SEED', () => {
     process.env.MN_TEST_WALLET_SEED = '111,222';
+
     expect(getEnvVarWalletSeeds()).toEqual(['111', '222']);
-    delete process.env.MN_TEST_WALLET_SEED;
   });
 
   it('should return wallet seeds from TEST_WALLET_SEED', () => {
     process.env.TEST_WALLET_SEED = '333';
+
     expect(getEnvVarWalletSeeds()).toEqual(['333']);
-    delete process.env.TEST_WALLET_SEED;
   });
 
   it('should return undefined when no wallet seeds are set', () => {
+    delete process.env.MN_TEST_WALLET_SEED;
+    delete process.env.TEST_WALLET_SEED;
+
     expect(getEnvVarWalletSeeds()).toEqual(undefined);
+  });
+
+  it('getMnTestIndexer should read env var at call time, not import time', () => {
+    process.env.MN_TEST_INDEXER = 'https://late-set.example.com';
+
+    expect(getMnTestIndexer()).toBe('https://late-set.example.com');
+  });
+
+  it('getMnTestIndexer should return undefined when not set', () => {
+    delete process.env.MN_TEST_INDEXER;
+
+    expect(getMnTestIndexer()).toBeUndefined();
   });
 });

--- a/testkit-js/testkit-js/test/fluent-wallet-builder.ut.test.ts
+++ b/testkit-js/testkit-js/test/fluent-wallet-builder.ut.test.ts
@@ -1,0 +1,37 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WalletSeeds } from '@/wallet/wallet-seed';
+
+vi.mock('@midnight-ntwrk/wallet-sdk-facade');
+vi.mock('@midnight-ntwrk/wallet-sdk-unshielded-wallet');
+
+describe('[Unit tests] FluentWalletBuilder seed immutability', () => {
+  it('WalletSeeds.generateRandom produces unique seeds each time', () => {
+    const seeds1 = WalletSeeds.generateRandom();
+    const seeds2 = WalletSeeds.generateRandom();
+
+    expect(seeds1.masterSeed).not.toBe(seeds2.masterSeed);
+  });
+
+  it('WalletSeeds.fromMasterSeed is deterministic for the same seed', () => {
+    const seed = 'a'.repeat(64);
+    const seeds1 = WalletSeeds.fromMasterSeed(seed);
+    const seeds2 = WalletSeeds.fromMasterSeed(seed);
+
+    expect(seeds1.masterSeed).toBe(seeds2.masterSeed);
+    expect(seeds1.shielded).toEqual(seeds2.shielded);
+  });
+});

--- a/testkit-js/testkit-js/test/node-client.ut.test.ts
+++ b/testkit-js/testkit-js/test/node-client.ut.test.ts
@@ -1,0 +1,72 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import axios from 'axios';
+import pino from 'pino';
+
+import { NodeClient } from '@/client/node-client';
+
+vi.mock('axios');
+const mockedAxios = vi.mocked(axios);
+
+const logger = pino({ level: 'silent' });
+
+describe('[Unit tests] NodeClient', () => {
+  const nodeURL = 'http://localhost:9944';
+  let client: NodeClient;
+
+  beforeEach(() => {
+    client = new NodeClient(nodeURL, logger);
+    vi.clearAllMocks();
+  });
+
+  it('ledgerStateBlob should pass blockHash to RPC call', async () => {
+    const blockHash = '0xabc123';
+    mockedAxios.post.mockResolvedValue({
+      data: { result: '0001deadbeef' },
+      statusText: 'OK'
+    });
+
+    await client.ledgerStateBlob(blockHash);
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      nodeURL,
+      expect.objectContaining({
+        method: 'midnight_getLedgerState',
+        params: [blockHash]
+      }),
+      expect.anything()
+    );
+  });
+
+  it('ledgerVersion should pass blockHash to RPC call', async () => {
+    const blockHash = '0xdef456';
+    mockedAxios.post.mockResolvedValue({
+      data: { result: 'v1.0.0' },
+      statusText: 'OK'
+    });
+
+    await client.ledgerVersion(blockHash);
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      nodeURL,
+      expect.objectContaining({
+        method: 'midnight_ledgerVersion',
+        params: [blockHash]
+      }),
+      expect.anything()
+    );
+  });
+});

--- a/testkit-js/testkit-js/test/testing-api.ut.test.ts
+++ b/testkit-js/testkit-js/test/testing-api.ut.test.ts
@@ -35,6 +35,12 @@ const logger = createLogger(
 globalThis.WebSocket = WebSocket;
 
 describe('[Unit tests] Testing API', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
   beforeEach(() => {
     logger.info(`Starting test... ${expect.getState().currentTestName}`);
   });
@@ -61,6 +67,10 @@ describe('[Unit tests] Testing API', () => {
 
   it('should fail on wrong MN_TEST_NETWORK_ID for env var remote test environment', () => {
     process.env.MN_TEST_ENVIRONMENT = 'env-var-remote';
+    process.env.MN_TEST_INDEXER = 'https://test.url';
+    process.env.MN_TEST_INDEXER_WS = 'wss://test.url';
+    process.env.MN_TEST_NODE = 'http://test.url';
+    process.env.MN_TEST_NODE_WS = 'ws://test.url';
     delete process.env.MN_TEST_NETWORK_ID;
     expect(() => getTestEnvironment(logger)).toThrow(`Environment variable 'MN_TEST_NETWORK_ID' is required`);
   });

--- a/testkit-js/testkit-js/test/utils.ut.test.ts
+++ b/testkit-js/testkit-js/test/utils.ut.test.ts
@@ -1,0 +1,50 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { rm } from 'node:fs/promises';
+
+import { buildUrlWithPath, tryDeleteDirectory } from '@/utils';
+
+vi.mock('node:fs/promises', () => ({
+  rm: vi.fn()
+}));
+
+const mockedRm = vi.mocked(rm);
+
+describe('[Unit tests] Utils', () => {
+  describe('buildUrlWithPath', () => {
+    it('should preserve http protocol', () => {
+      expect(buildUrlWithPath('http://localhost:3000/api/v1', '/health')).toBe('http://localhost:3000/health');
+    });
+
+    it('should preserve https protocol', () => {
+      expect(buildUrlWithPath('https://indexer.preview.midnight.network/api/v4/graphql', '/ready')).toBe(
+        'https://indexer.preview.midnight.network/ready'
+      );
+    });
+
+    it('should handle URL without port', () => {
+      expect(buildUrlWithPath('https://example.com/path', '/status')).toBe('https://example.com/status');
+    });
+  });
+
+  describe('tryDeleteDirectory', () => {
+    it('should swallow errors from rm and not throw', async () => {
+      mockedRm.mockRejectedValue(new Error('EPERM'));
+
+      await expect(tryDeleteDirectory('/some/path')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/testkit-js/testkit-js/test/wallet-state-provider.ut.test.ts
+++ b/testkit-js/testkit-js/test/wallet-state-provider.ut.test.ts
@@ -1,0 +1,58 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+
+import type { ShieldedWalletAPI } from '@midnight-ntwrk/wallet-sdk-shielded';
+import pino from 'pino';
+
+import { getWalletStateFilename, WalletSaveStateProvider } from '@/wallet/wallet-state-provider';
+
+vi.mock('node:fs');
+vi.mock('@/wallet/gzip-file');
+
+const logger = pino({ level: 'silent' });
+
+describe('[Unit tests] WalletSaveStateProvider', () => {
+  describe('save', () => {
+    it('should propagate errors when mkdirSync fails', async () => {
+      vi.mocked(fs.mkdirSync).mockImplementation(() => {
+        throw new Error('EACCES');
+      });
+
+      const provider = new WalletSaveStateProvider(logger, 'test-seed', '/tmp/test-states');
+      const mockWallet = {
+        serializeState: vi.fn()
+      } as unknown as ShieldedWalletAPI;
+
+      await expect(provider.save(mockWallet)).rejects.toThrow('EACCES');
+    });
+  });
+
+  describe('getWalletStateFilename', () => {
+    it('should produce correct filename with seed', () => {
+      const filename = getWalletStateFilename('my-seed');
+
+      expect(filename).toMatch(/^wallet\..+\.my-seed\.state\.gz$/);
+    });
+
+    it('should produce correct filename without seed', () => {
+      const filename = getWalletStateFilename(undefined);
+
+      expect(filename).toMatch(/^wallet\..+\.state\.gz$/);
+      expect(filename).not.toContain('undefined');
+    });
+  });
+});


### PR DESCRIPTION
# Overview

Fix 15 identified bugs and design issues in the testkit-js package:

- **Missing assertion matchers**: `expectSuccessfulDeployTx` and `expectSuccessfulCallTx` had no-op `expect()` calls without matchers
- **blockHash not passed**: `ledgerStateBlob` and `ledgerVersion` ignored the `blockHash` parameter in RPC calls
- **Inconsistent return type**: `waitForFunds` returned either `bigint` or wallet state object; now consistently returns `bigint`
- **BigInt precision loss**: `BigInt.prototype.toJSON` used `Number(this)` which loses precision for large values; now uses `toString()`
- **Dead field**: Removed unused `envConfiguration` field from `TestEnvironment`
- **Swallowed errors**: `FaucetClient.requestTokens`, `ProofServerClient.proveTx`, all `health()` methods, and `WalletSaveStateProvider.save` caught and logged errors instead of propagating them
- **Hardcoded protocols**: `health()` methods hardcoded `https://` or `http://` instead of deriving from the configured URL; added `buildUrlWithPath` helper
- **Stale env vars**: Module-level constants (`MN_TEST_INDEXER`, etc.) captured env vars at import time; replaced with getter functions
- **Test pollution**: Tests mutated `process.env` without restoring; added `afterEach` cleanup
- **Fragile .gz path**: `WalletSaveStateProvider.save` used `.replaceAll('.gz', '')` which could corrupt paths; now uses `.endsWith('.gz')` + `.slice(0, -3)`
- **Builder mutation**: `FluentWalletBuilder.build()` mutated internal `this.seeds` state; now uses local `const seeds`
- **Unclear intent**: `deleteDirectory` renamed to `tryDeleteDirectory` to make error-swallowing behavior explicit

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README.md file (if relevant)
- [x] Update documentation (if relevant)
- [x] No new todos introduced

## Links

N/A