### PR TITLE
fix(midnight-js): reject HTML responses in FetchZkConfigProvider

### DIFF
--- a/packages/fetch-zk-config-provider/src/fetch-zk-config-provider.ts
+++ b/packages/fetch-zk-config-provider/src/fetch-zk-config-provider.ts
@@ -77,10 +77,7 @@ export class FetchZkConfigProvider<K extends string> extends ZKConfigProvider<K>
     }
     const contentType = response.headers.get('content-type') ?? '';
     if (contentType.includes('text/html')) {
-      throw new Error(
-        `Expected ZK artifact, but received text/html from ${fullUrl}. ` +
-        `This usually means the file does not exist and the server returned an SPA fallback page.`
-      );
+      throw new Error(`Expected ZK artifact, but received text/html from ${fullUrl}. This usually means the file does not exist and the server returned an SPA fallback page.`);
     }
     // The compiler can't infer that this return value is well-typed, so I cast to 'any'
     /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/fetch-zk-config-provider/src/fetch-zk-config-provider.ts
+++ b/packages/fetch-zk-config-provider/src/fetch-zk-config-provider.ts
@@ -68,18 +68,26 @@ export class FetchZkConfigProvider<K extends string> extends ZKConfigProvider<K>
     ext: typeof ZKIR_EXT | typeof PROVER_EXT | typeof VERIFIER_EXT,
     responseType: T
   ): Promise<T extends 'text' ? string : Uint8Array> {
-    const response = await this.fetchFunc(`${this.baseURL}/${url}/${circuitId}${ext}`, {
+    const fullUrl = `${this.baseURL}/${url}/${circuitId}${ext}`;
+    const response = await this.fetchFunc(fullUrl, {
       method: 'GET'
     });
-    if (response.ok) {
-      // The compiler can't infer that this return value is well-typed, so I cast to 'any'
-      /* eslint-disable @typescript-eslint/no-explicit-any */
-      return responseType === 'text'
-        ? ((await response.text()) as any)
-        : ((await response.arrayBuffer().then((arrayBuffer) => new Uint8Array(arrayBuffer))) as any);
-      /* eslint-enable @typescript-eslint/no-explicit-any */
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ZK artifact from ${fullUrl}: ${response.status} ${response.statusText}`);
     }
-    throw new Error(response.statusText);
+    const contentType = response.headers.get('content-type') ?? '';
+    if (contentType.includes('text/html')) {
+      throw new Error(
+        `Expected ZK artifact, but received text/html from ${fullUrl}. ` +
+        `This usually means the file does not exist and the server returned an SPA fallback page.`
+      );
+    }
+    // The compiler can't infer that this return value is well-typed, so I cast to 'any'
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    return responseType === 'text'
+      ? ((await response.text()) as any)
+      : ((await response.arrayBuffer().then((arrayBuffer) => new Uint8Array(arrayBuffer))) as any);
+    /* eslint-enable @typescript-eslint/no-explicit-any */
   }
 
   getProverKey(circuitId: K): Promise<ProverKey> {

--- a/packages/fetch-zk-config-provider/src/test/fetch-zk-config-provider.test.ts
+++ b/packages/fetch-zk-config-provider/src/test/fetch-zk-config-provider.test.ts
@@ -39,7 +39,7 @@ describe('Fetch ZK config Provider', () => {
       res.send(verifierKey);
     });
     app.get('/zkir/set_topic.bzkir', (_, res) => {
-      res.send(zkir);
+      res.type('application/octet-stream').send(zkir);
     });
     server = app.listen();
     const serverAddress = server.address();
@@ -81,5 +81,73 @@ describe('Fetch ZK config Provider', () => {
 
   test('throws on invalid url', () => {
     expect(() => new FetchZkConfigProvider('ws://localhost:5000')).toThrow(/^Invalid protocol scheme: 'ws:'/);
+  });
+
+  describe('rejects HTML responses from SPA fallback', () => {
+    let spaServer: Server;
+    let spaServerURL: string;
+
+    beforeAll(() => {
+      const app = express();
+      app.use((_, res) => {
+        res.type('text/html').send('<html><body>SPA fallback</body></html>');
+      });
+      spaServer = app.listen();
+      const addr = spaServer.address();
+      if (addr === null) {
+        throw new Error('Expected server address to be defined');
+      } else if (typeof addr === 'object') {
+        spaServerURL = `http://localhost:${addr.port}`;
+      }
+    });
+
+    afterAll(() => {
+      spaServer.close();
+    });
+
+    test('rejects HTML response when fetching prover key', async () => {
+      const provider = new FetchZkConfigProvider(spaServerURL);
+      await expect(provider.getProverKey('nonexistent')).rejects.toThrow(/text\/html/);
+      await expect(provider.getProverKey('nonexistent')).rejects.toThrow(/nonexistent/);
+    });
+
+    test('rejects HTML response when fetching verifier key', async () => {
+      const provider = new FetchZkConfigProvider(spaServerURL);
+      await expect(provider.getVerifierKey('nonexistent')).rejects.toThrow(/text\/html/);
+    });
+
+    test('rejects HTML response when fetching ZKIR', async () => {
+      const provider = new FetchZkConfigProvider(spaServerURL);
+      await expect(provider.getZKIR('nonexistent')).rejects.toThrow(/text\/html/);
+    });
+  });
+
+  describe('includes URL and status in error for failed requests', () => {
+    let errorServer: Server;
+    let errorServerURL: string;
+
+    beforeAll(() => {
+      const app = express();
+      app.use((_, res) => {
+        res.status(404).send('Not Found');
+      });
+      errorServer = app.listen();
+      const addr = errorServer.address();
+      if (addr === null) {
+        throw new Error('Expected server address to be defined');
+      } else if (typeof addr === 'object') {
+        errorServerURL = `http://localhost:${addr.port}`;
+      }
+    });
+
+    afterAll(() => {
+      errorServer.close();
+    });
+
+    test('error includes URL and status code for non-ok response', async () => {
+      const provider = new FetchZkConfigProvider(errorServerURL);
+      await expect(provider.getProverKey('missing_circuit')).rejects.toThrow(/missing_circuit/);
+      await expect(provider.getProverKey('missing_circuit')).rejects.toThrow(/404/);
+    });
   });
 });


### PR DESCRIPTION
# Overview

`FetchZkConfigProvider.sendRequest()` only checked `response.ok` with no `Content-Type` validation. When hosted behind an SPA server (Vite, Netlify, nginx with `try_files`), requests for non-existent ZK artifacts received `index.html` (HTTP 200, `text/html`) instead of a 404. The HTML bytes were silently passed to `createProverKey()` / `createVerifierKey()` / `createZKIR()`, causing cryptic proof server 400 errors.

**Changes:**
- Validate `Content-Type` header — reject `text/html` responses with a descriptive error including the full artifact URL
- Include URL and status code in errors for non-ok responses
- Fix existing test server to set proper `Content-Type` for ZKIR responses

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant)
- [ ] Update documentation (if relevant)
- [x] No new todos introduced

## Links

Closes midnightntwrk/midnight-js#782
Related: midnightntwrk/midnight-security#2, midnightntwrk/midnight-js#603

🤖 Generated with [Claude Code](https://claude.com/claude-code)