### PR TITLE
chore: replace CLA with DCO sign-off

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -8,6 +8,7 @@
 
 - [ ] Useful pull request description
 - [ ] Tests are provided (if possible)
+- [ ] All commits are signed off (`git commit -s`) for the [DCO](https://developercertificate.org/)
 - [ ] Key commits have useful messages
 - [ ] All check jobs of the CI have succeeded
 - [ ] Self-reviewed the diff

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -6,9 +6,9 @@
 
 <!-- Please check all the boxes that apply to your pull request. -->
 
+- [ ] All commits are signed off (`git commit -s`) for the [DCO](https://developercertificate.org/)
 - [ ] Useful pull request description
 - [ ] Tests are provided (if possible)
-- [ ] All commits are signed off (`git commit -s`) for the [DCO](https://developercertificate.org/)
 - [ ] Key commits have useful messages
 - [ ] All check jobs of the CI have succeeded
 - [ ] Self-reviewed the diff

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -30,6 +30,25 @@ jobs:
           fetch-depth: 0
 
       - name: Check DCO sign-off
-        uses: dco-org/dco-action@v1
-        with:
-          require-sign-off: true
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+
+          missing=()
+          while IFS= read -r sha; do
+            msg=$(git log -1 --format="%B" "$sha")
+            if ! echo "$msg" | grep -qE "^Signed-off-by: .+ <.+>"; then
+              missing+=("$sha $(git log -1 --format='%s' $sha)")
+            fi
+          done < <(git log --format="%H" "$base..$head")
+
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "The following commits are missing a Signed-off-by trailer:"
+            printf '  %s\n' "${missing[@]}"
+            echo ""
+            echo "Please sign off your commits with: git commit -s"
+            echo "To fix existing commits: git rebase --signoff HEAD~${#missing[@]}"
+            exit 1
+          fi
+
+          echo "All commits are signed off."

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -20,19 +20,27 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   dco:
     name: DCO Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # ratchet:actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Check DCO sign-off
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          base="${{ github.event.pull_request.base.sha }}"
-          head="${{ github.event.pull_request.head.sha }}"
+          set -euo pipefail
+
+          base="$BASE_SHA"
+          head="$HEAD_SHA"
 
           missing=()
           while IFS= read -r sha; do
@@ -40,7 +48,7 @@ jobs:
             if ! echo "$msg" | grep -qE "^Signed-off-by: .+ <.+>"; then
               missing+=("$sha $(git log -1 --format='%s' $sha)")
             fi
-          done < <(git log --format="%H" "$base..$head")
+          done < <(git log --no-merges --format="%H" "$base..$head")
 
           if [ ${#missing[@]} -gt 0 ]; then
             echo "The following commits are missing a Signed-off-by trailer:"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,35 @@
+# This file is part of midnight-js.
+# Copyright (C) 2025-2026 Midnight Foundation
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: DCO
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  dco:
+    name: DCO Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check DCO sign-off
+        uses: dco-org/dco-action@v1
+        with:
+          require-sign-off: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,34 @@ Ensure the title is a clear summary of the requirement and provides enough conte
 * **Feature Request:** Clearly describe your feature, its benefits, and most importantly, the expected outcome. This helps us analyze the proposed solution and develop alternatives.
 * **Enhancement:** (WIP)
 
+## Developer Certificate of Origin (DCO)
+
+All contributions must include a sign-off in every commit message, certifying that you have the right to submit the code under the project license. This is done by adding a `Signed-off-by` trailer using `git commit -s`:
+
+```
+git commit -s -m "feat: your commit message"
+```
+
+This produces a commit message like:
+
+```
+feat: your commit message
+
+Signed-off-by: Your Name <your@email.com>
+```
+
+By signing off, you agree to the [Developer Certificate of Origin (version 1.1)](https://developercertificate.org/).
+
+If you have forgotten to sign off past commits in a PR, you can amend them:
+
+```bash
+# Amend the last commit
+git commit --amend -s --no-edit
+
+# Or rebase to sign off multiple commits (replace N with the number of commits)
+git rebase --signoff HEAD~N
+```
+
 ## Code Contribution Process
 
 * **Pull Requests:** Code contributions are submitted via Pull Requests.
@@ -27,7 +55,7 @@ Ensure the title is a clear summary of the requirement and provides enough conte
 * **Create a Branch:** Make your changes in a separate branch.
 * **Follow Coding Standards:** Adhere to the coding style guides specified in our documentation.
 * **Write Tests:** Include unit tests and integration tests to cover your changes.
-* **Commit Messages:** Write clear and concise commit messages.
+* **Commit Messages:** Write clear and concise commit messages, and always sign off with `git commit -s`.
 * **Submit Pull Request:** Submit your pull request to the appropriate branch in the main repository.
 * **Code Review:** All pull requests undergo code review by project maintainers. Be prepared to address feedback from reviewers.
 


### PR DESCRIPTION
## Summary

- Removes centralised CLA Assistant dependency (external bot, `license/claExpected` required check)
- Adds DCO enforcement via `dco-org/dco-action` GitHub Actions workflow
- Updates `CONTRIBUTING.md` with DCO sign-off instructions (`git commit -s`)
- Adds DCO checklist item to PR template

## Admin steps required after merge

1. **Branch protection on `main`**: remove `license/claExpected` from required status checks, add `DCO Check`
2. **Disable CLA Assistant**: go to `cla-assistant.io/midnightntwrk/midnight-js` and remove the repo; uninstall the GitHub App from the org if installed

## Test plan

- [ ] Verify DCO workflow triggers on new PRs
- [ ] Confirm `Signed-off-by` commits pass, unsigned commits fail
- [ ] Admin updates branch protection and disables CLA Assistant