### PR TITLE
feat: web crypto migration

### DIFF
--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -336,7 +336,8 @@ const isDecryptionError = (error: unknown): boolean => {
     message.includes('salt mismatch') ||
     message.includes('invalid encrypted data') ||
     message.includes('bad decrypt') ||
-    message.includes('unable to authenticate')
+    message.includes('unable to authenticate') ||
+    message.includes('operation failed for an operation-specific reason')
   );
 };
 

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -38,7 +38,7 @@ import { Buffer } from 'buffer';
 import { Level } from 'level';
 import * as superjson from 'superjson';
 
-import { decryptValue, getPasswordFromProvider, type PrivateStoragePasswordProvider, StorageEncryption } from './storage-encryption';
+import { assertWebCryptoAvailable, decryptValue, getPasswordFromProvider, type PrivateStoragePasswordProvider, StorageEncryption } from './storage-encryption';
 
 /**
  * The default name of the indexedDB database for Midnight.
@@ -133,6 +133,7 @@ superjson.registerCustom<Buffer, string>(
 const ACCOUNT_ID_HASH_LENGTH = 32;
 
 const hashAccountId = async (accountId: string): Promise<string> => {
+  assertWebCryptoAvailable();
   const data = new TextEncoder().encode(accountId);
   const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', data);
   return Buffer.from(new Uint8Array(hashBuffer)).toString('hex').substring(0, ACCOUNT_ID_HASH_LENGTH);
@@ -330,6 +331,11 @@ interface RotateStorePasswordParams {
 
 const isDecryptionError = (error: unknown): boolean => {
   if (!(error instanceof Error)) return false;
+
+  if ('name' in error && error.name === 'OperationError') {
+    return true;
+  }
+
   const message = error.message.toLowerCase();
   return (
     message.includes('unsupported state') ||
@@ -708,15 +714,17 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
   const passwordProvider: PrivateStoragePasswordProvider = config.privateStoragePasswordProvider;
 
-  let scopedPrivateStateLevelName: string | null = null;
-  let scopedSigningKeyLevelName: string | null = null;
+  let scopedNamesPromise: Promise<{ privateState: string; signingKey: string }> | null = null;
 
-  const getScopedNames = async (): Promise<{ privateState: string; signingKey: string }> => {
-    if (scopedPrivateStateLevelName === null || scopedSigningKeyLevelName === null) {
-      scopedPrivateStateLevelName = await getScopedLevelName(fullConfig.privateStateStoreName, config.accountId);
-      scopedSigningKeyLevelName = await getScopedLevelName(fullConfig.signingKeyStoreName, config.accountId);
+  const getScopedNames = (): Promise<{ privateState: string; signingKey: string }> => {
+    if (scopedNamesPromise === null) {
+      scopedNamesPromise = (async () => {
+        const privateState = await getScopedLevelName(fullConfig.privateStateStoreName, config.accountId);
+        const signingKey = await getScopedLevelName(fullConfig.signingKeyStoreName, config.accountId);
+        return { privateState, signingKey };
+      })();
     }
-    return { privateState: scopedPrivateStateLevelName, signingKey: scopedSigningKeyLevelName };
+    return scopedNamesPromise;
   };
 
   showBrowserWarning();
@@ -919,7 +927,10 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         const importEncryption = await StorageEncryption.create(importPassword, salt);
         const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
-      } catch {
+      } catch (error: unknown) {
+        if (error instanceof TypeError && error.message.includes('subtle')) {
+          throw new Error('Web Crypto subtle API is not available. In browsers, this requires a secure context (HTTPS or localhost).', { cause: error });
+        }
         // Single generic error - don't reveal whether password was wrong or data was corrupted
         throw new ExportDecryptionError();
       }
@@ -1072,7 +1083,10 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         const importEncryption = await StorageEncryption.create(importPassword, salt);
         const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
-      } catch {
+      } catch (error: unknown) {
+        if (error instanceof TypeError && error.message.includes('subtle')) {
+          throw new Error('Web Crypto subtle API is not available. In browsers, this requires a secure context (HTTPS or localhost).', { cause: error });
+        }
         throw new ExportDecryptionError();
       }
 
@@ -1205,6 +1219,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
     async invalidateEncryptionCache(): Promise<void> {
       const { privateState, signingKey } = await getScopedNames();
+      scopedNamesPromise = null;
       invalidateEncryptionCacheForDb(
         fullConfig.midnightDbName,
         privateState,

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -217,6 +217,7 @@ const getOrCreateSalt = async (dbName: string, levelName: string): Promise<Buffe
       }
     }
 
+    assertWebCryptoAvailable();
     const salt = Buffer.from(globalThis.crypto.getRandomValues(new Uint8Array(32)));
     const metadata = {
       salt: salt.toString('hex'),
@@ -342,8 +343,7 @@ const isDecryptionError = (error: unknown): boolean => {
     message.includes('salt mismatch') ||
     message.includes('invalid encrypted data') ||
     message.includes('bad decrypt') ||
-    message.includes('unable to authenticate') ||
-    message.includes('operation failed for an operation-specific reason')
+    message.includes('unable to authenticate')
   );
 };
 
@@ -722,7 +722,10 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         const privateState = await getScopedLevelName(fullConfig.privateStateStoreName, config.accountId);
         const signingKey = await getScopedLevelName(fullConfig.signingKeyStoreName, config.accountId);
         return { privateState, signingKey };
-      })();
+      })().catch((error: unknown) => {
+        scopedNamesPromise = null;
+        throw error;
+      });
     }
     return scopedNamesPromise;
   };
@@ -927,10 +930,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         const importEncryption = await StorageEncryption.create(importPassword, salt);
         const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
-      } catch (error: unknown) {
-        if (error instanceof TypeError && error.message.includes('subtle')) {
-          throw new Error('Web Crypto subtle API is not available. In browsers, this requires a secure context (HTTPS or localhost).', { cause: error });
-        }
+      } catch {
         // Single generic error - don't reveal whether password was wrong or data was corrupted
         throw new ExportDecryptionError();
       }
@@ -1083,10 +1083,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         const importEncryption = await StorageEncryption.create(importPassword, salt);
         const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
-      } catch (error: unknown) {
-        if (error instanceof TypeError && error.message.includes('subtle')) {
-          throw new Error('Web Crypto subtle API is not available. In browsers, this requires a secure context (HTTPS or localhost).', { cause: error });
-        }
+      } catch {
         throw new ExportDecryptionError();
       }
 
@@ -1218,13 +1215,16 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
     },
 
     async invalidateEncryptionCache(): Promise<void> {
-      const { privateState, signingKey } = await getScopedNames();
+      const cachedPromise = scopedNamesPromise;
       scopedNamesPromise = null;
-      invalidateEncryptionCacheForDb(
-        fullConfig.midnightDbName,
-        privateState,
-        signingKey
-      );
+      if (cachedPromise) {
+        try {
+          const { privateState, signingKey } = await cachedPromise;
+          invalidateEncryptionCacheForDb(fullConfig.midnightDbName, privateState, signingKey);
+        } catch {
+          // Names were never resolved, so no cache entries to invalidate
+        }
+      }
     }
   };
 };

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -804,20 +804,20 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         (subLevel) => subLevel.del(address)
       );
     },
-    async setSigningKey(address: ContractAddress, signingKeyValue: SigningKey): Promise<void> {
-      const { signingKey } = await getScopedNames();
-      await waitForRotationLock(fullConfig.midnightDbName, signingKey);
+    async setSigningKey(address: ContractAddress, signingKey: SigningKey): Promise<void> {
+      const { signingKey: signingKeyLevelName } = await getScopedNames();
+      await waitForRotationLock(fullConfig.midnightDbName, signingKeyLevelName);
       const encryption = await getOrCreateEncryption(
         fullConfig.midnightDbName,
-        signingKey,
+        signingKeyLevelName,
         passwordProvider
       );
-      const serialized = superjson.stringify(signingKeyValue);
+      const serialized = superjson.stringify(signingKey);
       const encrypted = await encryption.encrypt(serialized);
 
       return withSubLevel<ContractAddress, string, void>(
         fullConfig.midnightDbName,
-        signingKey,
+        signingKeyLevelName,
         (subLevel) => subLevel.put(address, encrypted)
       );
     },

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -35,7 +35,6 @@ import {
 } from '@midnight-ntwrk/midnight-js-types';
 import { type AbstractSublevel } from 'abstract-level';
 import { Buffer } from 'buffer';
-import { createHash, randomBytes } from 'crypto';
 import { Level } from 'level';
 import * as superjson from 'superjson';
 
@@ -133,12 +132,14 @@ superjson.registerCustom<Buffer, string>(
 
 const ACCOUNT_ID_HASH_LENGTH = 32;
 
-const hashAccountId = (accountId: string): string => {
-  return createHash('sha256').update(accountId).digest('hex').substring(0, ACCOUNT_ID_HASH_LENGTH);
+const hashAccountId = async (accountId: string): Promise<string> => {
+  const data = new TextEncoder().encode(accountId);
+  const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', data);
+  return Buffer.from(new Uint8Array(hashBuffer)).toString('hex').substring(0, ACCOUNT_ID_HASH_LENGTH);
 };
 
-const getScopedLevelName = (baseLevelName: string, accountId: string): string => {
-  const hashedAccountId = hashAccountId(accountId);
+const getScopedLevelName = async (baseLevelName: string, accountId: string): Promise<string> => {
+  const hashedAccountId = await hashAccountId(accountId);
   return `${baseLevelName}:${hashedAccountId}`;
 };
 
@@ -215,7 +216,7 @@ const getOrCreateSalt = async (dbName: string, levelName: string): Promise<Buffe
       }
     }
 
-    const salt = randomBytes(32);
+    const salt = Buffer.from(globalThis.crypto.getRandomValues(new Uint8Array(32)));
     const metadata = {
       salt: salt.toString('hex'),
       version: 1
@@ -245,16 +246,16 @@ const getOrCreateEncryption = async (
   const cached = encryptionCache.get(cacheKey);
   if (cached && cached.saltHex === saltHex) {
     const password = await getPasswordFromProvider(passwordProvider);
-    if (cached.encryption.verifyPassword(password)) {
+    if (await cached.encryption.verifyPassword(password)) {
       return cached.encryption;
     }
-    const encryption = new StorageEncryption(password, salt);
+    const encryption = await StorageEncryption.create(password, salt);
     encryptionCache.set(cacheKey, { encryption, saltHex });
     return encryption;
   }
 
   const password = await getPasswordFromProvider(passwordProvider);
-  const encryption = new StorageEncryption(password, salt);
+  const encryption = await StorageEncryption.create(password, salt);
   encryptionCache.set(cacheKey, { encryption, saltHex });
   return encryption;
 };
@@ -348,8 +349,8 @@ const rotateStorePassword = async (
   const newPassword = await getPasswordFromProvider(newPasswordProvider);
 
   const salt = await getOrCreateSalt(dbName, storeName);
-  const oldEncryption = new StorageEncryption(oldPassword, salt);
-  const newEncryption = new StorageEncryption(newPassword);
+  const oldEncryption = await StorageEncryption.create(oldPassword, salt);
+  const newEncryption = await StorageEncryption.create(newPassword);
   const newSalt = newEncryption.getSalt();
 
   return withSubLevel<string, string, PasswordRotationResult>(
@@ -376,7 +377,7 @@ const rotateStorePassword = async (
 
         if (!firstEntryValidated) {
           try {
-            decryptValue(encryptedValue, oldEncryption, oldPassword);
+            await decryptValue(encryptedValue, oldEncryption, oldPassword);
           } catch (error: unknown) {
             if (isDecryptionError(error)) {
               throw new Error('Old password is incorrect: failed to decrypt existing data', { cause: error });
@@ -387,7 +388,7 @@ const rotateStorePassword = async (
         }
 
         try {
-          const decryptedValue = decryptValue(encryptedValue, oldEncryption, oldPassword);
+          const decryptedValue = await decryptValue(encryptedValue, oldEncryption, oldPassword);
           entriesToMigrate.push({ key, decryptedValue });
         } catch (error: unknown) {
           const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -410,7 +411,7 @@ const rotateStorePassword = async (
       const operations: { type: 'put'; key: string; value: string }[] = [];
       for (const { key, decryptedValue } of entriesToMigrate) {
         try {
-          const encryptedValue = newEncryption.encrypt(decryptedValue);
+          const encryptedValue = await newEncryption.encrypt(decryptedValue);
           operations.push({ type: 'put', key, value: encryptedValue });
         } catch (error: unknown) {
           const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -468,15 +469,15 @@ const subLevelMaybeGet = async <K, V>(
         const version = StorageEncryption.getVersion(encryptedValue);
         if (version === 1) {
           const password = await getPasswordFromProvider(passwordProvider);
-          decryptedValue = encryption.decryptWithPassword(encryptedValue, password);
-          const reEncrypted = encryption.encrypt(decryptedValue);
+          decryptedValue = await encryption.decryptWithPassword(encryptedValue, password);
+          const reEncrypted = await encryption.encrypt(decryptedValue);
           await subLevel.put(key, reEncrypted);
         } else {
-          decryptedValue = encryption.decrypt(encryptedValue);
+          decryptedValue = await encryption.decrypt(encryptedValue);
         }
       } else {
         decryptedValue = encryptedValue;
-        const reEncrypted = encryption.encrypt(encryptedValue);
+        const reEncrypted = await encryption.encrypt(encryptedValue);
         await subLevel.put(key, reEncrypted);
       }
 
@@ -525,10 +526,10 @@ const getAllEntries = async <K extends string, V>(
           if (password === null) {
             password = await getPasswordFromProvider(passwordProvider);
           }
-          decryptedValue = encryption.decryptWithPassword(encryptedValue, password);
+          decryptedValue = await encryption.decryptWithPassword(encryptedValue, password);
           needsReEncryption = true;
         } else {
-          decryptedValue = encryption.decrypt(encryptedValue);
+          decryptedValue = await encryption.decrypt(encryptedValue);
         }
       } else {
         decryptedValue = encryptedValue;
@@ -536,7 +537,7 @@ const getAllEntries = async <K extends string, V>(
       }
 
       if (needsReEncryption) {
-        const reEncrypted = encryption.encrypt(decryptedValue);
+        const reEncrypted = await encryption.encrypt(decryptedValue);
         await subLevel.put(key, reEncrypted);
       }
 
@@ -676,7 +677,7 @@ const showBrowserWarning = (): void => {
 export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
   config: Partial<LevelPrivateStateProviderConfig> & Pick<LevelPrivateStateProviderConfig, 'privateStoragePasswordProvider' | 'accountId'>
 ): PrivateStateProvider<PSI, PS> & {
-  invalidateEncryptionCache(): void;
+  invalidateEncryptionCache(): Promise<void>;
   changePassword(
     oldPasswordProvider: PrivateStoragePasswordProvider,
     newPasswordProvider: PrivateStoragePasswordProvider,
@@ -706,8 +707,16 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
   const passwordProvider: PrivateStoragePasswordProvider = config.privateStoragePasswordProvider;
 
-  const scopedPrivateStateLevelName = getScopedLevelName(fullConfig.privateStateStoreName, config.accountId);
-  const scopedSigningKeyLevelName = getScopedLevelName(fullConfig.signingKeyStoreName, config.accountId);
+  let scopedPrivateStateLevelName: string | null = null;
+  let scopedSigningKeyLevelName: string | null = null;
+
+  const getScopedNames = async (): Promise<{ privateState: string; signingKey: string }> => {
+    if (scopedPrivateStateLevelName === null || scopedSigningKeyLevelName === null) {
+      scopedPrivateStateLevelName = await getScopedLevelName(fullConfig.privateStateStoreName, config.accountId);
+      scopedSigningKeyLevelName = await getScopedLevelName(fullConfig.signingKeyStoreName, config.accountId);
+    }
+    return { privateState: scopedPrivateStateLevelName, signingKey: scopedSigningKeyLevelName };
+  };
 
   showBrowserWarning();
 
@@ -725,33 +734,36 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       contractAddress = address;
     },
     async get(privateStateId: PSI): Promise<PS | null> {
+      const { privateState } = await getScopedNames();
       const scopedKey = getScopedKey(privateStateId);
       return subLevelMaybeGet<string, PS>(
         fullConfig.midnightDbName,
-        scopedPrivateStateLevelName,
+        privateState,
         scopedKey,
         passwordProvider
       );
     },
     async remove(privateStateId: PSI): Promise<void> {
-      await waitForRotationLock(fullConfig.midnightDbName, scopedPrivateStateLevelName);
+      const { privateState } = await getScopedNames();
+      await waitForRotationLock(fullConfig.midnightDbName, privateState);
       const scopedKey = getScopedKey(privateStateId);
-      return withSubLevel<string, string, void>(fullConfig.midnightDbName, scopedPrivateStateLevelName, (subLevel) =>
+      return withSubLevel<string, string, void>(fullConfig.midnightDbName, privateState, (subLevel) =>
         subLevel.del(scopedKey)
       );
     },
     async set(privateStateId: PSI, state: PS): Promise<void> {
-      await waitForRotationLock(fullConfig.midnightDbName, scopedPrivateStateLevelName);
+      const { privateState } = await getScopedNames();
+      await waitForRotationLock(fullConfig.midnightDbName, privateState);
       const scopedKey = getScopedKey(privateStateId);
       const encryption = await getOrCreateEncryption(
         fullConfig.midnightDbName,
-        scopedPrivateStateLevelName,
+        privateState,
         passwordProvider
       );
       const serialized = superjson.stringify(state);
-      const encrypted = encryption.encrypt(serialized);
+      const encrypted = await encryption.encrypt(serialized);
 
-      return withSubLevel<string, string, void>(fullConfig.midnightDbName, scopedPrivateStateLevelName, (subLevel) =>
+      return withSubLevel<string, string, void>(fullConfig.midnightDbName, privateState, (subLevel) =>
         subLevel.put(scopedKey, encrypted)
       );
     },
@@ -759,42 +771,47 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       if (contractAddress === null) {
         throw new Error('Contract address not set. Call setContractAddress() before accessing private state.');
       }
-      return withSubLevel(fullConfig.midnightDbName, scopedPrivateStateLevelName, (subLevel) => subLevel.clear());
+      const { privateState } = await getScopedNames();
+      return withSubLevel(fullConfig.midnightDbName, privateState, (subLevel) => subLevel.clear());
     },
-    getSigningKey(address: ContractAddress): Promise<SigningKey | null> {
+    async getSigningKey(address: ContractAddress): Promise<SigningKey | null> {
+      const { signingKey } = await getScopedNames();
       return subLevelMaybeGet<ContractAddress, SigningKey>(
         fullConfig.midnightDbName,
-        scopedSigningKeyLevelName,
+        signingKey,
         address,
         passwordProvider
       );
     },
     async removeSigningKey(address: ContractAddress): Promise<void> {
-      await waitForRotationLock(fullConfig.midnightDbName, scopedSigningKeyLevelName);
+      const { signingKey } = await getScopedNames();
+      await waitForRotationLock(fullConfig.midnightDbName, signingKey);
       return withSubLevel<ContractAddress, string, void>(
         fullConfig.midnightDbName,
-        scopedSigningKeyLevelName,
+        signingKey,
         (subLevel) => subLevel.del(address)
       );
     },
-    async setSigningKey(address: ContractAddress, signingKey: SigningKey): Promise<void> {
-      await waitForRotationLock(fullConfig.midnightDbName, scopedSigningKeyLevelName);
+    async setSigningKey(address: ContractAddress, signingKeyValue: SigningKey): Promise<void> {
+      const { signingKey } = await getScopedNames();
+      await waitForRotationLock(fullConfig.midnightDbName, signingKey);
       const encryption = await getOrCreateEncryption(
         fullConfig.midnightDbName,
-        scopedSigningKeyLevelName,
+        signingKey,
         passwordProvider
       );
-      const serialized = superjson.stringify(signingKey);
-      const encrypted = encryption.encrypt(serialized);
+      const serialized = superjson.stringify(signingKeyValue);
+      const encrypted = await encryption.encrypt(serialized);
 
       return withSubLevel<ContractAddress, string, void>(
         fullConfig.midnightDbName,
-        scopedSigningKeyLevelName,
+        signingKey,
         (subLevel) => subLevel.put(address, encrypted)
       );
     },
-    clearSigningKeys(): Promise<void> {
-      return withSubLevel(fullConfig.midnightDbName, scopedSigningKeyLevelName, (subLevel) => subLevel.clear());
+    async clearSigningKeys(): Promise<void> {
+      const { signingKey } = await getScopedNames();
+      return withSubLevel(fullConfig.midnightDbName, signingKey, (subLevel) => subLevel.clear());
     },
 
     async exportPrivateStates(options?: ExportPrivateStatesOptions): Promise<PrivateStateExport> {
@@ -813,9 +830,10 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       const exportPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);
 
       // Get all private states (not signing keys)
+      const { privateState } = await getScopedNames();
       const allStates = await getAllEntries<string, PS>(
         fullConfig.midnightDbName,
-        scopedPrivateStateLevelName,
+        privateState,
         passwordProvider
       );
 
@@ -851,8 +869,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       };
 
       // Create new encryption instance for export (different salt from storage)
-      const exportEncryption = new StorageEncryption(exportPassword);
-      const encryptedPayload = exportEncryption.encrypt(JSON.stringify(payload));
+      const exportEncryption = await StorageEncryption.create(exportPassword);
+      const encryptedPayload = await exportEncryption.encrypt(JSON.stringify(payload));
 
       return {
         format: 'midnight-private-state-export',
@@ -897,8 +915,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       let payload: PrivateStatePayload<PSI>;
       try {
         const salt = Buffer.from(exportData.salt, 'hex');
-        const importEncryption = new StorageEncryption(importPassword, salt);
-        const decryptedJson = importEncryption.decrypt(exportData.encryptedPayload);
+        const importEncryption = await StorageEncryption.create(importPassword, salt);
+        const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
       } catch {
         // Single generic error - don't reveal whether password was wrong or data was corrupted
@@ -990,9 +1008,10 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
       const exportPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);
 
+      const { signingKey: scopedSigningKey } = await getScopedNames();
       const allKeys = await getAllEntries<ContractAddress, SigningKey>(
         fullConfig.midnightDbName,
-        scopedSigningKeyLevelName,
+        scopedSigningKey,
         passwordProvider
       );
 
@@ -1013,8 +1032,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         keys: Object.fromEntries(allKeys.entries()) as Record<ContractAddress, SigningKey>
       };
 
-      const exportEncryption = new StorageEncryption(exportPassword);
-      const encryptedPayload = exportEncryption.encrypt(JSON.stringify(payload));
+      const exportEncryption = await StorageEncryption.create(exportPassword);
+      const encryptedPayload = await exportEncryption.encrypt(JSON.stringify(payload));
 
       return {
         format: 'midnight-signing-key-export',
@@ -1049,8 +1068,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       let payload: SigningKeyPayload;
       try {
         const salt = Buffer.from(exportData.salt, 'hex');
-        const importEncryption = new StorageEncryption(importPassword, salt);
-        const decryptedJson = importEncryption.decrypt(exportData.encryptedPayload);
+        const importEncryption = await StorageEncryption.create(importPassword, salt);
+        const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
       } catch {
         throw new ExportDecryptionError();
@@ -1132,13 +1151,14 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         throw new Error('Contract address not set. Call setContractAddress() before changing password.');
       }
 
-      const lockKey = `${fullConfig.midnightDbName}:${scopedPrivateStateLevelName}`;
+      const { privateState, signingKey } = await getScopedNames();
+      const lockKey = `${fullConfig.midnightDbName}:${privateState}`;
       const prefix = `${contractAddress}:`;
 
       return withPasswordRotationLock(lockKey, async () => {
         const result = await rotateStorePassword({
           dbName: fullConfig.midnightDbName,
-          storeName: scopedPrivateStateLevelName,
+          storeName: privateState,
           oldPasswordProvider,
           newPasswordProvider,
           maxEntries: options?.maxEntries ?? DEFAULT_MAX_ROTATION_ENTRIES,
@@ -1147,8 +1167,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
         invalidateEncryptionCacheForDb(
           fullConfig.midnightDbName,
-          scopedPrivateStateLevelName,
-          scopedSigningKeyLevelName
+          privateState,
+          signingKey
         );
 
         return result;
@@ -1160,12 +1180,13 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       newPasswordProvider: PrivateStoragePasswordProvider,
       options?: PasswordRotationOptions
     ): Promise<PasswordRotationResult> {
-      const lockKey = `${fullConfig.midnightDbName}:${scopedSigningKeyLevelName}`;
+      const { privateState, signingKey } = await getScopedNames();
+      const lockKey = `${fullConfig.midnightDbName}:${signingKey}`;
 
       return withPasswordRotationLock(lockKey, async () => {
         const result = await rotateStorePassword({
           dbName: fullConfig.midnightDbName,
-          storeName: scopedSigningKeyLevelName,
+          storeName: signingKey,
           oldPasswordProvider,
           newPasswordProvider,
           maxEntries: options?.maxEntries ?? DEFAULT_MAX_ROTATION_ENTRIES
@@ -1173,19 +1194,20 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
         invalidateEncryptionCacheForDb(
           fullConfig.midnightDbName,
-          scopedPrivateStateLevelName,
-          scopedSigningKeyLevelName
+          privateState,
+          signingKey
         );
 
         return result;
       });
     },
 
-    invalidateEncryptionCache(): void {
+    async invalidateEncryptionCache(): Promise<void> {
+      const { privateState, signingKey } = await getScopedNames();
       invalidateEncryptionCacheForDb(
         fullConfig.midnightDbName,
-        scopedPrivateStateLevelName,
-        scopedSigningKeyLevelName
+        privateState,
+        signingKey
       );
     }
   };
@@ -1298,11 +1320,11 @@ export const migrateToAccountScoped = async (
     throw new Error('accountId is required for migration');
   }
 
-  const scopedPrivateStateLevelName = getScopedLevelName(
+  const scopedPrivateStateLevelName = await getScopedLevelName(
     fullConfig.privateStateStoreName,
     config.accountId
   );
-  const scopedSigningKeyLevelName = getScopedLevelName(
+  const scopedSigningKeyLevelName = await getScopedLevelName(
     fullConfig.signingKeyStoreName,
     config.accountId
   );

--- a/packages/level-private-state-provider/src/storage-encryption.ts
+++ b/packages/level-private-state-provider/src/storage-encryption.ts
@@ -204,12 +204,12 @@ export class StorageEncryption {
   }
 
   async encrypt(data: string): Promise<string> {
-    const plaintext = Buffer.from(data, 'utf-8');
+    const plaintext = new TextEncoder().encode(data);
     const iv = getRandomBytes(IV_LENGTH);
     const { ciphertext, authTag } = await aesGcmEncrypt(this.encryptionKey, iv, plaintext);
 
-    const version = Buffer.from([CURRENT_ENCRYPTION_VERSION]);
-    const result = Buffer.concat([version, Buffer.from(this.salt), Buffer.from(iv), Buffer.from(authTag), Buffer.from(ciphertext)]);
+    const version = new Uint8Array([CURRENT_ENCRYPTION_VERSION]);
+    const result = Buffer.concat([version, this.salt, iv, authTag, ciphertext]);
 
     return result.toString('base64');
   }

--- a/packages/level-private-state-provider/src/storage-encryption.ts
+++ b/packages/level-private-state-provider/src/storage-encryption.ts
@@ -30,6 +30,19 @@ const CURRENT_ENCRYPTION_VERSION = ENCRYPTION_VERSION_V2;
 const VERSION_PREFIX_LENGTH = 1;
 const HEADER_LENGTH = VERSION_PREFIX_LENGTH + SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH;
 
+export const assertWebCryptoAvailable = (): void => {
+  if (typeof globalThis.crypto === 'undefined') {
+    throw new Error(
+      'Web Crypto API is not available. Ensure you are running in Node.js >= 15 or a browser with Web Crypto support.'
+    );
+  }
+  if (typeof globalThis.crypto.subtle === 'undefined') {
+    throw new Error(
+      'Web Crypto subtle API is not available. In browsers, this requires a secure context (HTTPS or localhost).'
+    );
+  }
+};
+
 const getRandomBytes = (length: number): Uint8Array => {
   return globalThis.crypto.getRandomValues(new Uint8Array(length));
 };
@@ -190,6 +203,7 @@ export class StorageEncryption {
   }
 
   static async create(password: string, existingSalt?: Buffer | Uint8Array): Promise<StorageEncryption> {
+    assertWebCryptoAvailable();
     const salt = existingSalt ? new Uint8Array(existingSalt) : getRandomBytes(SALT_LENGTH);
     const passwordBytes = new TextEncoder().encode(password);
     const encryptionKey = await pbkdf2(passwordBytes, salt, PBKDF2_ITERATIONS_V2, KEY_LENGTH);
@@ -381,7 +395,7 @@ export const decryptValue = async (
   password: string
 ): Promise<string> => {
   if (!StorageEncryption.isEncrypted(encryptedValue)) {
-    console.debug('MIDNIGHT: Encountered unencrypted data during decryption - passing through as-is');
+    console.warn('MIDNIGHT: Encountered unencrypted data during decryption - passing through as-is. This may indicate data corruption or a migration issue.');
     return encryptedValue;
   }
 

--- a/packages/level-private-state-provider/src/storage-encryption.ts
+++ b/packages/level-private-state-provider/src/storage-encryption.ts
@@ -236,7 +236,7 @@ export class StorageEncryption {
       throw new Error('V1 encrypted data requires password for decryption. Use decryptWithPassword() instead.');
     }
 
-    if (!Buffer.from(this.salt).equals(salt)) {
+    if (!timingSafeEqual(Buffer.from(this.salt), salt)) {
       throw new Error('Salt mismatch: data was encrypted with a different password');
     }
 
@@ -248,7 +248,7 @@ export class StorageEncryption {
     const data = Buffer.from(encryptedData, 'base64');
     const { version, salt, iv, authTag, encrypted } = extractEncryptedComponents(data);
 
-    if (!Buffer.from(this.salt).equals(salt)) {
+    if (!timingSafeEqual(Buffer.from(this.salt), salt)) {
       throw new Error('Salt mismatch: data was encrypted with a different password');
     }
 
@@ -395,7 +395,7 @@ export const decryptValue = async (
   password: string
 ): Promise<string> => {
   if (!StorageEncryption.isEncrypted(encryptedValue)) {
-    console.warn('MIDNIGHT: Encountered unencrypted data during decryption - passing through as-is. This may indicate data corruption or a migration issue.');
+    console.debug('MIDNIGHT: Encountered unencrypted data during decryption - passing through as-is');
     return encryptedValue;
   }
 

--- a/packages/level-private-state-provider/src/storage-encryption.ts
+++ b/packages/level-private-state-provider/src/storage-encryption.ts
@@ -14,12 +14,9 @@
  */
 
 import { Buffer } from 'buffer';
-import { createCipheriv, createDecipheriv, createHash, pbkdf2Sync, randomBytes } from 'crypto';
-import * as crypto from 'crypto';
 
 export type PrivateStoragePasswordProvider = () => string | Promise<string>;
 
-const ALGORITHM = 'aes-256-gcm';
 const KEY_LENGTH = 32;
 const IV_LENGTH = 12;
 const AUTH_TAG_LENGTH = 16;
@@ -33,8 +30,74 @@ const CURRENT_ENCRYPTION_VERSION = ENCRYPTION_VERSION_V2;
 const VERSION_PREFIX_LENGTH = 1;
 const HEADER_LENGTH = VERSION_PREFIX_LENGTH + SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH;
 
-const HAS_NATIVE_TIMINGSAFEEQUAL =
-  'timingSafeEqual' in crypto && typeof crypto.timingSafeEqual === 'function';
+const getRandomBytes = (length: number): Uint8Array => {
+  return globalThis.crypto.getRandomValues(new Uint8Array(length));
+};
+
+const sha256 = async (data: Uint8Array): Promise<Uint8Array> => {
+  const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', data);
+  return new Uint8Array(hashBuffer);
+};
+
+const pbkdf2 = async (
+  password: Uint8Array,
+  salt: Uint8Array,
+  iterations: number,
+  keyLength: number
+): Promise<Uint8Array> => {
+  const baseKey = await globalThis.crypto.subtle.importKey(
+    'raw',
+    password,
+    'PBKDF2',
+    false,
+    ['deriveBits']
+  );
+  const derived = await globalThis.crypto.subtle.deriveBits(
+    { name: 'PBKDF2', salt, iterations, hash: 'SHA-256' },
+    baseKey,
+    keyLength * 8
+  );
+  return new Uint8Array(derived);
+};
+
+const aesGcmEncrypt = async (
+  key: Uint8Array,
+  iv: Uint8Array,
+  plaintext: Uint8Array
+): Promise<{ ciphertext: Uint8Array; authTag: Uint8Array }> => {
+  const cryptoKey = await globalThis.crypto.subtle.importKey(
+    'raw', key, 'AES-GCM', false, ['encrypt']
+  );
+  const result = await globalThis.crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv, tagLength: AUTH_TAG_LENGTH * 8 },
+    cryptoKey,
+    plaintext
+  );
+  const resultBytes = new Uint8Array(result);
+  const ciphertext = resultBytes.slice(0, resultBytes.length - AUTH_TAG_LENGTH);
+  const authTag = resultBytes.slice(resultBytes.length - AUTH_TAG_LENGTH);
+  return { ciphertext, authTag };
+};
+
+const aesGcmDecrypt = async (
+  key: Uint8Array,
+  iv: Uint8Array,
+  ciphertext: Uint8Array,
+  authTag: Uint8Array
+): Promise<Uint8Array> => {
+  const cryptoKey = await globalThis.crypto.subtle.importKey(
+    'raw', key, 'AES-GCM', false, ['decrypt']
+  );
+  const combined = new Uint8Array(ciphertext.length + authTag.length);
+  combined.set(ciphertext, 0);
+  combined.set(authTag, ciphertext.length);
+  const result = await globalThis.crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv, tagLength: AUTH_TAG_LENGTH * 8 },
+    cryptoKey,
+    combined
+  );
+  return new Uint8Array(result);
+};
 
 interface EncryptedComponents {
   version: number;
@@ -77,8 +140,10 @@ const getIterationsForVersion = (version: number): number => {
   }
 };
 
-const hashPassword = (password: string): string => {
-  return createHash('sha256').update(password).digest('hex');
+const hashPassword = async (password: string): Promise<string> => {
+  const data = new TextEncoder().encode(password);
+  const hash = await sha256(data);
+  return Buffer.from(hash).toString('hex');
 };
 
 const constantTimeBufferEqual = (aBuf: Buffer, bBuf: Buffer): boolean => {
@@ -98,7 +163,7 @@ const constantTimeBufferEqual = (aBuf: Buffer, bBuf: Buffer): boolean => {
  * @param a - First buffer to compare.
  * @param b - Second buffer to compare.
  * @returns `true` if the buffers are equal, `false` otherwise.
- * 
+ *
  * @remarks
  * If the inputs differ in length, an error is thrown (not constant-time for length mismatch).
  * This matches the Node.js native timingSafeEqual behavior (which throws on length mismatch).
@@ -109,50 +174,47 @@ const constantTimeBufferEqual = (aBuf: Buffer, bBuf: Buffer): boolean => {
 export const timingSafeEqual = (a: Buffer | Uint8Array, b: Buffer | Uint8Array): boolean => {
   const aBuf = Buffer.isBuffer(a) ? a : Buffer.from(a);
   const bBuf = Buffer.isBuffer(b) ? b : Buffer.from(b);
-  if (HAS_NATIVE_TIMINGSAFEEQUAL) {
-    // Use the native `timingSafeEqual` function and let any errors propagate.
-    return crypto.timingSafeEqual(aBuf, bBuf);
-  }
   return constantTimeBufferEqual(aBuf, bBuf);
 };
 
 
 export class StorageEncryption {
-  private readonly encryptionKey: Buffer;
-  private readonly salt: Buffer;
+  private readonly encryptionKey: Uint8Array;
+  private readonly salt: Uint8Array;
   private readonly passwordHash: string;
 
-  constructor(password: string, existingSalt?: Buffer) {
-    this.salt = existingSalt ?? randomBytes(SALT_LENGTH);
-    this.encryptionKey = this.deriveKey(password, this.salt, PBKDF2_ITERATIONS_V2);
-    this.passwordHash = hashPassword(password);
+  private constructor(encryptionKey: Uint8Array, salt: Uint8Array, passwordHash: string) {
+    this.encryptionKey = encryptionKey;
+    this.salt = salt;
+    this.passwordHash = passwordHash;
   }
 
-  private deriveKey(password: string, salt: Buffer, iterations: number): Buffer {
-    return pbkdf2Sync(password, salt, iterations, KEY_LENGTH, 'sha256');
+  static async create(password: string, existingSalt?: Buffer | Uint8Array): Promise<StorageEncryption> {
+    const salt = existingSalt ? new Uint8Array(existingSalt) : getRandomBytes(SALT_LENGTH);
+    const passwordBytes = new TextEncoder().encode(password);
+    const encryptionKey = await pbkdf2(passwordBytes, salt, PBKDF2_ITERATIONS_V2, KEY_LENGTH);
+    const passwordHash = await hashPassword(password);
+    return new StorageEncryption(encryptionKey, salt, passwordHash);
   }
 
-  verifyPassword(password: string): boolean {
-    const inputHash = Buffer.from(hashPassword(password), 'hex');
+  async verifyPassword(password: string): Promise<boolean> {
+    const inputHash = Buffer.from(await hashPassword(password), 'hex');
     const storedHash = Buffer.from(this.passwordHash, 'hex');
     return timingSafeEqual(inputHash, storedHash);
   }
 
-  encrypt(data: string): string {
+  async encrypt(data: string): Promise<string> {
     const plaintext = Buffer.from(data, 'utf-8');
-    const iv = randomBytes(IV_LENGTH);
-    const cipher = createCipheriv(ALGORITHM, this.encryptionKey, iv);
-
-    const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
-    const authTag = cipher.getAuthTag();
+    const iv = getRandomBytes(IV_LENGTH);
+    const { ciphertext, authTag } = await aesGcmEncrypt(this.encryptionKey, iv, plaintext);
 
     const version = Buffer.from([CURRENT_ENCRYPTION_VERSION]);
-    const result = Buffer.concat([version, this.salt, iv, authTag, encrypted]);
+    const result = Buffer.concat([version, Buffer.from(this.salt), Buffer.from(iv), Buffer.from(authTag), Buffer.from(ciphertext)]);
 
     return result.toString('base64');
   }
 
-  decrypt(encryptedData: string): string {
+  async decrypt(encryptedData: string): Promise<string> {
     const data = Buffer.from(encryptedData, 'base64');
     const { version, salt, iv, authTag, encrypted } = extractEncryptedComponents(data);
 
@@ -160,35 +222,33 @@ export class StorageEncryption {
       throw new Error('V1 encrypted data requires password for decryption. Use decryptWithPassword() instead.');
     }
 
-    if (!this.salt.equals(salt)) {
+    if (!Buffer.from(this.salt).equals(salt)) {
       throw new Error('Salt mismatch: data was encrypted with a different password');
     }
 
-    const decipher = createDecipheriv(ALGORITHM, this.encryptionKey, iv, { authTagLength: AUTH_TAG_LENGTH });
-    decipher.setAuthTag(authTag);
-
-    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
-    return decrypted.toString('utf-8');
+    const decrypted = await aesGcmDecrypt(this.encryptionKey, iv, encrypted, authTag);
+    return Buffer.from(decrypted).toString('utf-8');
   }
 
-  decryptWithPassword(encryptedData: string, password: string): string {
+  async decryptWithPassword(encryptedData: string, password: string): Promise<string> {
     const data = Buffer.from(encryptedData, 'base64');
     const { version, salt, iv, authTag, encrypted } = extractEncryptedComponents(data);
 
-    if (!this.salt.equals(salt)) {
+    if (!Buffer.from(this.salt).equals(salt)) {
       throw new Error('Salt mismatch: data was encrypted with a different password');
     }
 
     const iterations = getIterationsForVersion(version);
-    const decryptionKey = version === CURRENT_ENCRYPTION_VERSION
-      ? this.encryptionKey
-      : this.deriveKey(password, salt, iterations);
+    let decryptionKey: Uint8Array;
+    if (version === CURRENT_ENCRYPTION_VERSION) {
+      decryptionKey = this.encryptionKey;
+    } else {
+      const passwordBytes = new TextEncoder().encode(password);
+      decryptionKey = await pbkdf2(passwordBytes, salt, iterations, KEY_LENGTH);
+    }
 
-    const decipher = createDecipheriv(ALGORITHM, decryptionKey, iv, { authTagLength: AUTH_TAG_LENGTH });
-    decipher.setAuthTag(authTag);
-
-    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
-    return decrypted.toString('utf-8');
+    const decrypted = await aesGcmDecrypt(decryptionKey, iv, encrypted, authTag);
+    return Buffer.from(decrypted).toString('utf-8');
   }
 
   static isEncrypted(data: string): boolean {
@@ -211,7 +271,7 @@ export class StorageEncryption {
   }
 
   getSalt(): Buffer {
-    return this.salt;
+    return Buffer.from(this.salt);
   }
 }
 
@@ -315,11 +375,11 @@ export const getPasswordFromProvider = async (provider: PrivateStoragePasswordPr
   return password;
 };
 
-export const decryptValue = (
+export const decryptValue = async (
   encryptedValue: string,
   encryption: StorageEncryption,
   password: string
-): string => {
+): Promise<string> => {
   if (!StorageEncryption.isEncrypted(encryptedValue)) {
     console.debug('MIDNIGHT: Encountered unencrypted data during decryption - passing through as-is');
     return encryptedValue;

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -701,8 +701,8 @@ describe('Level Private State Provider', (): void => {
 
         // Create encryption with a known salt and encrypt non-JSON data
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const notJson = encryption.encrypt('this is not JSON');
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const notJson = await encryption.encrypt('this is not JSON');
 
         const badExport: PrivateStateExport = {
           format: 'midnight-private-state-export',
@@ -720,9 +720,9 @@ describe('Level Private State Provider', (): void => {
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
         // Valid JSON but missing required 'states' field
-        const invalidPayload = encryption.encrypt(JSON.stringify({
+        const invalidPayload = await encryption.encrypt(JSON.stringify({
           version: 1,
           exportedAt: new Date().toISOString(),
           stateCount: 0
@@ -745,9 +745,9 @@ describe('Level Private State Provider', (): void => {
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
         // Valid JSON but missing required 'version' field
-        const invalidPayload = encryption.encrypt(JSON.stringify({
+        const invalidPayload = await encryption.encrypt(JSON.stringify({
           exportedAt: new Date().toISOString(),
           stateCount: 0,
           states: {}
@@ -769,9 +769,9 @@ describe('Level Private State Provider', (): void => {
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
         // stateCount says 5 but only 1 state present
-        const mismatchedPayload = encryption.encrypt(JSON.stringify({
+        const mismatchedPayload = await encryption.encrypt(JSON.stringify({
           version: 1,
           exportedAt: new Date().toISOString(),
           stateCount: 5,
@@ -796,8 +796,8 @@ describe('Level Private State Provider', (): void => {
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const unsupportedVersionPayload = encryption.encrypt(JSON.stringify({
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const unsupportedVersionPayload = await encryption.encrypt(JSON.stringify({
           version: 999,
           exportedAt: new Date().toISOString(),
           stateCount: 0,
@@ -820,9 +820,9 @@ describe('Level Private State Provider', (): void => {
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
         // State value is not valid superjson
-        const invalidStatePayload = encryption.encrypt(JSON.stringify({
+        const invalidStatePayload = await encryption.encrypt(JSON.stringify({
           version: 1,
           exportedAt: new Date().toISOString(),
           stateCount: 1,
@@ -884,8 +884,8 @@ describe('Level Private State Provider', (): void => {
         // Uppercase hex should still be valid (the regex allows both cases)
         const uppercaseSalt = 'A'.repeat(64);
         const salt = Buffer.from(uppercaseSalt, 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const validPayload = encryption.encrypt(JSON.stringify({
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const validPayload = await encryption.encrypt(JSON.stringify({
           version: 1,
           exportedAt: new Date().toISOString(),
           stateCount: 0,
@@ -1188,8 +1188,8 @@ describe('Level Private State Provider', (): void => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const notJson = encryption.encrypt('this is not JSON');
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const notJson = await encryption.encrypt('this is not JSON');
 
         const badExport: SigningKeyExport = {
           format: 'midnight-signing-key-export',
@@ -1206,8 +1206,8 @@ describe('Level Private State Provider', (): void => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const invalidPayload = encryption.encrypt(JSON.stringify({
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const invalidPayload = await encryption.encrypt(JSON.stringify({
           version: 1,
           exportedAt: new Date().toISOString(),
           keyCount: 0
@@ -1228,8 +1228,8 @@ describe('Level Private State Provider', (): void => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const invalidPayload = encryption.encrypt(JSON.stringify({
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const invalidPayload = await encryption.encrypt(JSON.stringify({
           exportedAt: new Date().toISOString(),
           keyCount: 0,
           keys: {}
@@ -1250,8 +1250,8 @@ describe('Level Private State Provider', (): void => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const mismatchedPayload = encryption.encrypt(JSON.stringify({
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const mismatchedPayload = await encryption.encrypt(JSON.stringify({
           version: 1,
           exportedAt: new Date().toISOString(),
           keyCount: 5,
@@ -1275,8 +1275,8 @@ describe('Level Private State Provider', (): void => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const unsupportedVersionPayload = encryption.encrypt(JSON.stringify({
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const unsupportedVersionPayload = await encryption.encrypt(JSON.stringify({
           version: 999,
           exportedAt: new Date().toISOString(),
           keyCount: 0,
@@ -1574,11 +1574,11 @@ describe('Level Private State Provider', (): void => {
 
       await db.set('key-1', 'value-1');
       expect(verifyPasswordSpy).toHaveBeenCalledTimes(1);
-      expect(verifyPasswordSpy).toHaveLastReturnedWith(true);
+      await expect(verifyPasswordSpy).toHaveLastResolvedWith(true);
 
       await db.set('key-2', 'value-2');
       expect(verifyPasswordSpy).toHaveBeenCalledTimes(2);
-      expect(verifyPasswordSpy).toHaveLastReturnedWith(true);
+      await expect(verifyPasswordSpy).toHaveLastResolvedWith(true);
 
       verifyPasswordSpy.mockRestore();
     });
@@ -2528,9 +2528,9 @@ describe('Level Private State Provider', (): void => {
         await level.open();
         await unscopedSubLevel.open();
 
-        const encryption = new StorageEncryption(TEST_PASSWORD);
-        await unscopedSubLevel.put('contract1:state1', encryption.encrypt(superjson.stringify('value1')));
-        await unscopedSubLevel.put('contract1:state2', encryption.encrypt(superjson.stringify('value2')));
+        const encryption = await StorageEncryption.create(TEST_PASSWORD);
+        await unscopedSubLevel.put('contract1:state1', await encryption.encrypt(superjson.stringify('value1')));
+        await unscopedSubLevel.put('contract1:state2', await encryption.encrypt(superjson.stringify('value2')));
       } finally {
         await unscopedSubLevel.close();
         await level.close();
@@ -2555,8 +2555,8 @@ describe('Level Private State Provider', (): void => {
         await level.open();
         await unscopedSubLevel.open();
 
-        const encryption = new StorageEncryption(TEST_PASSWORD);
-        await unscopedSubLevel.put('contract1', encryption.encrypt(superjson.stringify({ key: 'data' })));
+        const encryption = await StorageEncryption.create(TEST_PASSWORD);
+        await unscopedSubLevel.put('contract1', await encryption.encrypt(superjson.stringify({ key: 'data' })));
       } finally {
         await unscopedSubLevel.close();
         await level.close();
@@ -2605,7 +2605,7 @@ describe('Level Private State Provider', (): void => {
         valueEncoding: 'utf-8'
       });
 
-      const encryption = new StorageEncryption(TEST_PASSWORD);
+      const encryption = await StorageEncryption.create(TEST_PASSWORD);
       const CONTRACT_ADDR = 'test-contract' as ContractAddress;
       const METADATA_KEY = '__midnight_encryption_metadata__';
 
@@ -2617,7 +2617,7 @@ describe('Level Private State Provider', (): void => {
         await unscopedSubLevel.put(METADATA_KEY, JSON.stringify(metadata));
         await unscopedSubLevel.put(
           `${CONTRACT_ADDR}:migrated-key`,
-          encryption.encrypt(superjson.stringify('migrated-value'))
+          await encryption.encrypt(superjson.stringify('migrated-value'))
         );
       } finally {
         await unscopedSubLevel.close();
@@ -2646,7 +2646,7 @@ describe('Level Private State Provider', (): void => {
         valueEncoding: 'utf-8'
       });
 
-      const encryption = new StorageEncryption(TEST_PASSWORD);
+      const encryption = await StorageEncryption.create(TEST_PASSWORD);
       const CONTRACT_ADDR = 'test-contract' as ContractAddress;
       const METADATA_KEY = '__midnight_encryption_metadata__';
 
@@ -2658,7 +2658,7 @@ describe('Level Private State Provider', (): void => {
         await unscopedSubLevel.put(METADATA_KEY, JSON.stringify(metadata));
         await unscopedSubLevel.put(
           `${CONTRACT_ADDR}:idempotent-key`,
-          encryption.encrypt(superjson.stringify('idempotent-value'))
+          await encryption.encrypt(superjson.stringify('idempotent-value'))
         );
       } finally {
         await unscopedSubLevel.close();
@@ -2695,8 +2695,8 @@ describe('Level Private State Provider', (): void => {
         valueEncoding: 'utf-8'
       });
 
-      const encryption = new StorageEncryption(TEST_PASSWORD);
-      const originalEncryptedValue = encryption.encrypt(superjson.stringify('original-value'));
+      const encryption = await StorageEncryption.create(TEST_PASSWORD);
+      const originalEncryptedValue = await encryption.encrypt(superjson.stringify('original-value'));
 
       try {
         await level.open();

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -1614,7 +1614,7 @@ describe('Level Private State Provider', (): void => {
       db.setContractAddress(CACHE_CONTRACT_ADDRESS);
       await db.set('test-key', 'test-value');
 
-      db.invalidateEncryptionCache();
+      await db.invalidateEncryptionCache();
 
       const value = await db.get('test-key');
       expect(value).toBe('test-value');

--- a/packages/level-private-state-provider/src/test/storage-encryption.test.ts
+++ b/packages/level-private-state-provider/src/test/storage-encryption.test.ts
@@ -29,135 +29,135 @@ describe('StorageEncryption', () => {
   };
 
   describe('encrypt and decrypt', () => {
-    test('successfully encrypts and decrypts data', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('successfully encrypts and decrypts data', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      const encrypted = encryption.encrypt(testData);
-      const decrypted = encryption.decrypt(encrypted);
+      const encrypted = await encryption.encrypt(testData);
+      const decrypted = await encryption.decrypt(encrypted);
 
       expect(decrypted).toBe(testData);
       expect(decrypted).not.toBe(encrypted);
     });
 
-    test('produces different ciphertext for same plaintext', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('produces different ciphertext for same plaintext', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      const encrypted1 = encryption.encrypt(testData);
-      const encrypted2 = encryption.encrypt(testData);
+      const encrypted1 = await encryption.encrypt(testData);
+      const encrypted2 = await encryption.encrypt(testData);
 
       expect(encrypted1).not.toBe(encrypted2);
-      expect(encryption.decrypt(encrypted1)).toBe(testData);
-      expect(encryption.decrypt(encrypted2)).toBe(testData);
+      expect(await encryption.decrypt(encrypted1)).toBe(testData);
+      expect(await encryption.decrypt(encrypted2)).toBe(testData);
     });
 
-    test('handles empty string', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('handles empty string', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      const encrypted = encryption.encrypt('');
-      const decrypted = encryption.decrypt(encrypted);
+      const encrypted = await encryption.encrypt('');
+      const decrypted = await encryption.decrypt(encrypted);
 
       expect(decrypted).toBe('');
     });
 
-    test('handles unicode characters', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('handles unicode characters', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
       const unicodeData = '🔐 Encrypted data with émojis and spëcial çhars 中文';
 
-      const encrypted = encryption.encrypt(unicodeData);
-      const decrypted = encryption.decrypt(encrypted);
+      const encrypted = await encryption.encrypt(unicodeData);
+      const decrypted = await encryption.decrypt(encrypted);
 
       expect(decrypted).toBe(unicodeData);
     });
   });
 
   describe('error handling', () => {
-    test('throws on wrong password', () => {
-      const encryption1 = new StorageEncryption('Correct-Pass-123!');
-      const encrypted = encryption1.encrypt(testData);
+    test('throws on wrong password', async () => {
+      const encryption1 = await StorageEncryption.create('Correct-Pass-123!');
+      const encrypted = await encryption1.encrypt(testData);
 
-      const encryption2 = new StorageEncryption('Wrong-Password-1!', encryption1.getSalt());
+      const encryption2 = await StorageEncryption.create('Wrong-Password-1!', encryption1.getSalt());
 
-      expect(() => encryption2.decrypt(encrypted)).toThrow();
+      await expect(encryption2.decrypt(encrypted)).rejects.toThrow();
     });
   });
 
   describe('version migration', () => {
-    test('decrypts v1 encrypted data with 100k iterations using decryptWithPassword', () => {
+    test('decrypts v1 encrypted data with 100k iterations using decryptWithPassword', async () => {
       const salt = Buffer.from(V1_FIXTURES.salt, 'hex');
-      const encryption = new StorageEncryption(V1_FIXTURES.password, salt);
+      const encryption = await StorageEncryption.create(V1_FIXTURES.password, salt);
 
-      const decrypted = encryption.decryptWithPassword(V1_FIXTURES.encrypted, V1_FIXTURES.password);
+      const decrypted = await encryption.decryptWithPassword(V1_FIXTURES.encrypted, V1_FIXTURES.password);
 
       expect(decrypted).toBe(V1_FIXTURES.plaintext);
     });
 
-    test('new encryption uses version 2', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('new encryption uses version 2', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      const encrypted = encryption.encrypt(testData);
+      const encrypted = await encryption.encrypt(testData);
       const buffer = Buffer.from(encrypted, 'base64');
 
       expect(buffer[0]).toBe(2);
     });
 
-    test('v2 encrypted data can be decrypted', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('v2 encrypted data can be decrypted', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      const encrypted = encryption.encrypt(testData);
-      const decrypted = encryption.decrypt(encrypted);
+      const encrypted = await encryption.encrypt(testData);
+      const decrypted = await encryption.decrypt(encrypted);
 
       expect(decrypted).toBe(testData);
     });
 
-    test('detects encryption version correctly', () => {
+    test('detects encryption version correctly', async () => {
       expect(StorageEncryption.getVersion(V1_FIXTURES.encrypted)).toBe(1);
 
-      const encryption = new StorageEncryption(testPassword);
-      const v2Encrypted = encryption.encrypt(testData);
+      const encryption = await StorageEncryption.create(testPassword);
+      const v2Encrypted = await encryption.encrypt(testData);
       expect(StorageEncryption.getVersion(v2Encrypted)).toBe(2);
     });
 
-    test('decrypt throws when V1 data is encountered without password', () => {
+    test('decrypt throws when V1 data is encountered without password', async () => {
       const salt = Buffer.from(V1_FIXTURES.salt, 'hex');
-      const encryption = new StorageEncryption(V1_FIXTURES.password, salt);
+      const encryption = await StorageEncryption.create(V1_FIXTURES.password, salt);
 
-      expect(() => encryption.decrypt(V1_FIXTURES.encrypted)).toThrow(
+      await expect(encryption.decrypt(V1_FIXTURES.encrypted)).rejects.toThrow(
         'V1 encrypted data requires password for decryption'
       );
     });
 
-    test('decryptWithPassword works for V2 data as well', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('decryptWithPassword works for V2 data as well', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      const encrypted = encryption.encrypt(testData);
-      const decrypted = encryption.decryptWithPassword(encrypted, testPassword);
+      const encrypted = await encryption.encrypt(testData);
+      const decrypted = await encryption.decryptWithPassword(encrypted, testPassword);
 
       expect(decrypted).toBe(testData);
     });
   });
 
   describe('password verification', () => {
-    test('verifyPassword returns true for correct password', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('verifyPassword returns true for correct password', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      expect(encryption.verifyPassword(testPassword)).toBe(true);
+      expect(await encryption.verifyPassword(testPassword)).toBe(true);
     });
 
-    test('verifyPassword returns false for incorrect password', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('verifyPassword returns false for incorrect password', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      expect(encryption.verifyPassword('Wrong-Password-1!')).toBe(false);
+      expect(await encryption.verifyPassword('Wrong-Password-1!')).toBe(false);
     });
 
-    test('verifyPassword is case-sensitive', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('verifyPassword is case-sensitive', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      expect(encryption.verifyPassword(testPassword.toLowerCase())).toBe(false);
-      expect(encryption.verifyPassword(testPassword.toUpperCase())).toBe(false);
+      expect(await encryption.verifyPassword(testPassword.toLowerCase())).toBe(false);
+      expect(await encryption.verifyPassword(testPassword.toUpperCase())).toBe(false);
     });
 
-    test('password is not stored in plaintext', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('password is not stored in plaintext', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
       const encryptionAsRecord = encryption as unknown as Record<string, unknown>;
       const allValues = Object.values(encryptionAsRecord);
@@ -205,20 +205,6 @@ describe('StorageEncryption', () => {
     const a = Buffer.from([]);
     const b = Buffer.from([]);
     expect(timingSafeEqual(a, b)).toBe(true);
-  });
-
-  test('timingSafeEqual fallback is used if native is missing', () => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const crypto = require('crypto');
-    const orig = crypto.timingSafeEqual;
-    crypto.timingSafeEqual = undefined;
-    // Use dynamic import to force re-evaluation
-    return import('../storage-encryption').then(mod => {
-      const a = Buffer.from([1, 2, 3]);
-      const b = Buffer.from([1, 2, 3]);
-      expect(mod.timingSafeEqual(a, b)).toBe(true);
-      crypto.timingSafeEqual = orig;
-    });
   });
 
   describe('getPasswordFromProvider', () => {

--- a/packages/level-private-state-provider/src/test/storage-encryption.test.ts
+++ b/packages/level-private-state-provider/src/test/storage-encryption.test.ts
@@ -15,7 +15,7 @@
 
 import { Buffer } from 'buffer';
 
-import { getPasswordFromProvider, StorageEncryption, timingSafeEqual } from '../storage-encryption';
+import { decryptValue, getPasswordFromProvider, StorageEncryption, timingSafeEqual } from '../storage-encryption';
 
 describe('StorageEncryption', () => {
   const testPassword = 'Test-Password-123!';
@@ -78,6 +78,69 @@ describe('StorageEncryption', () => {
       const encryption2 = await StorageEncryption.create('Wrong-Password-1!', encryption1.getSalt());
 
       await expect(encryption2.decrypt(encrypted)).rejects.toThrow();
+    });
+
+    test('rejects tampered ciphertext', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
+      const encrypted = await encryption.encrypt(testData);
+
+      const buffer = Buffer.from(encrypted, 'base64');
+      buffer[buffer.length - 1] ^= 0xff;
+      const tampered = buffer.toString('base64');
+
+      await expect(encryption.decrypt(tampered)).rejects.toThrow();
+    });
+  });
+
+  describe('create with Uint8Array salt', () => {
+    test('produces working encryption with Uint8Array salt', async () => {
+      const salt = new Uint8Array(32);
+      globalThis.crypto.getRandomValues(salt);
+
+      const encryption = await StorageEncryption.create(testPassword, salt);
+      const encrypted = await encryption.encrypt(testData);
+      const decrypted = await encryption.decrypt(encrypted);
+
+      expect(decrypted).toBe(testData);
+    });
+
+    test('Uint8Array salt produces same results as Buffer salt', async () => {
+      const rawBytes = new Uint8Array(32);
+      globalThis.crypto.getRandomValues(rawBytes);
+
+      const encryptionFromUint8 = await StorageEncryption.create(testPassword, rawBytes);
+      const encryptionFromBuffer = await StorageEncryption.create(testPassword, Buffer.from(rawBytes));
+
+      expect(encryptionFromUint8.getSalt()).toEqual(encryptionFromBuffer.getSalt());
+    });
+  });
+
+  describe('decryptValue', () => {
+    test('passes through unencrypted data as-is', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
+      const plaintext = 'not-encrypted-data';
+
+      const result = await decryptValue(plaintext, encryption, testPassword);
+
+      expect(result).toBe(plaintext);
+    });
+
+    test('decrypts V2 encrypted data', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
+      const encrypted = await encryption.encrypt(testData);
+
+      const result = await decryptValue(encrypted, encryption, testPassword);
+
+      expect(result).toBe(testData);
+    });
+
+    test('decrypts V1 encrypted data with password', async () => {
+      const salt = Buffer.from(V1_FIXTURES.salt, 'hex');
+      const encryption = await StorageEncryption.create(V1_FIXTURES.password, salt);
+
+      const result = await decryptValue(V1_FIXTURES.encrypted, encryption, V1_FIXTURES.password);
+
+      expect(result).toBe(V1_FIXTURES.plaintext);
     });
   });
 


### PR DESCRIPTION
Resolve: https://github.com/midnightntwrk/midnight-js/issues/828

Migrate level-private-state-provider from Node.js crypto to Web Crypto API (globalThis.crypto.subtle).
                                                                                                                                                                                                   
  - Replace createCipheriv/createDecipheriv/pbkdf2Sync/randomBytes with async Web Crypto equivalents                                                                                               
  - Convert StorageEncryption constructor to async factory (StorageEncryption.create())                                                                                                            
  - Add assertWebCryptoAvailable() guards with clear error messages for non-secure contexts                                                                                                        
  - Fix isDecryptionError for cross-platform Web Crypto support (OperationError DOMException)
  - Cache getScopedNames promise with rejection recovery to prevent unrecoverable state                                                                                                            
  - Preserve V1 backward compatibility (old encrypted data still decryptable)
                                                                                                                                                                                                   
  Breaking changes                                                 
              
  All crypto operations are now async. StorageEncryption constructor replaced with await StorageEncryption.create().                                                                               
   
