### PR TITLE
feat: add injectable levelFactory for React Native storage support

### DIFF
--- a/packages/level-private-state-provider/package.json
+++ b/packages/level-private-state-provider/package.json
@@ -27,6 +27,8 @@
   },
   "dependencies": {
     "@midnight-ntwrk/midnight-js-types": "workspace:*",
+    "@noble/ciphers": "^2.0.0",
+    "@noble/hashes": "^2.0.0",
     "abstract-level": "^3.0.0",
     "buffer": "^6.0.3",
     "fp-ts": "^2.16.1",

--- a/packages/level-private-state-provider/src/crypto-backend-noble.ts
+++ b/packages/level-private-state-provider/src/crypto-backend-noble.ts
@@ -1,0 +1,53 @@
+import { gcm } from '@noble/ciphers/aes.js';
+import { pbkdf2 as noblePbkdf2 } from '@noble/hashes/pbkdf2.js';
+import { sha256 as nobleSha256 } from '@noble/hashes/sha2.js';
+import { randomBytes as nobleRandomBytes } from '@noble/hashes/utils.js';
+
+import type { CryptoBackend } from './crypto-backend';
+
+const AUTH_TAG_LENGTH = 16;
+
+export class NobleCryptoBackend implements CryptoBackend {
+  randomBytes(length: number): Uint8Array {
+    return nobleRandomBytes(length);
+  }
+
+  async sha256(data: Uint8Array): Promise<Uint8Array> {
+    return nobleSha256(data);
+  }
+
+  async pbkdf2(
+    password: Uint8Array,
+    salt: Uint8Array,
+    iterations: number,
+    keyLength: number,
+  ): Promise<Uint8Array> {
+    return noblePbkdf2(nobleSha256, password, salt, {
+      c: iterations,
+      dkLen: keyLength,
+    });
+  }
+
+  async aesGcmEncrypt(
+    key: Uint8Array,
+    iv: Uint8Array,
+    plaintext: Uint8Array,
+  ): Promise<{ ciphertext: Uint8Array; authTag: Uint8Array }> {
+    const encryptedWithTag = gcm(key, iv).encrypt(plaintext);
+    const ciphertext = encryptedWithTag.slice(0, encryptedWithTag.length - AUTH_TAG_LENGTH);
+    const authTag = encryptedWithTag.slice(encryptedWithTag.length - AUTH_TAG_LENGTH);
+    return { ciphertext, authTag };
+  }
+
+  async aesGcmDecrypt(
+    key: Uint8Array,
+    iv: Uint8Array,
+    ciphertext: Uint8Array,
+    authTag: Uint8Array,
+  ): Promise<Uint8Array> {
+    const combined = new Uint8Array(ciphertext.length + authTag.length);
+    combined.set(ciphertext, 0);
+    combined.set(authTag, ciphertext.length);
+    return gcm(key, iv).decrypt(combined);
+  }
+}

--- a/packages/level-private-state-provider/src/crypto-backend-webcrypto.ts
+++ b/packages/level-private-state-provider/src/crypto-backend-webcrypto.ts
@@ -1,0 +1,74 @@
+import type { CryptoBackend } from './crypto-backend';
+
+const AUTH_TAG_LENGTH = 16;
+
+export class WebCryptoCryptoBackend implements CryptoBackend {
+  randomBytes(length: number): Uint8Array {
+    return globalThis.crypto.getRandomValues(new Uint8Array(length));
+  }
+
+  async sha256(data: Uint8Array): Promise<Uint8Array> {
+    const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', data);
+    return new Uint8Array(hashBuffer);
+  }
+
+  async pbkdf2(
+    password: Uint8Array,
+    salt: Uint8Array,
+    iterations: number,
+    keyLength: number,
+  ): Promise<Uint8Array> {
+    const baseKey = await globalThis.crypto.subtle.importKey(
+      'raw',
+      password,
+      'PBKDF2',
+      false,
+      ['deriveBits'],
+    );
+    const derived = await globalThis.crypto.subtle.deriveBits(
+      { name: 'PBKDF2', salt, iterations, hash: 'SHA-256' },
+      baseKey,
+      keyLength * 8,
+    );
+    return new Uint8Array(derived);
+  }
+
+  async aesGcmEncrypt(
+    key: Uint8Array,
+    iv: Uint8Array,
+    plaintext: Uint8Array,
+  ): Promise<{ ciphertext: Uint8Array; authTag: Uint8Array }> {
+    const cryptoKey = await globalThis.crypto.subtle.importKey(
+      'raw', key, 'AES-GCM', false, ['encrypt'],
+    );
+    const result = await globalThis.crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv, tagLength: AUTH_TAG_LENGTH * 8 },
+      cryptoKey,
+      plaintext,
+    );
+    const resultBytes = new Uint8Array(result);
+    const ciphertext = resultBytes.slice(0, resultBytes.length - AUTH_TAG_LENGTH);
+    const authTag = resultBytes.slice(resultBytes.length - AUTH_TAG_LENGTH);
+    return { ciphertext, authTag };
+  }
+
+  async aesGcmDecrypt(
+    key: Uint8Array,
+    iv: Uint8Array,
+    ciphertext: Uint8Array,
+    authTag: Uint8Array,
+  ): Promise<Uint8Array> {
+    const cryptoKey = await globalThis.crypto.subtle.importKey(
+      'raw', key, 'AES-GCM', false, ['decrypt'],
+    );
+    const combined = new Uint8Array(ciphertext.length + authTag.length);
+    combined.set(ciphertext, 0);
+    combined.set(authTag, ciphertext.length);
+    const result = await globalThis.crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv, tagLength: AUTH_TAG_LENGTH * 8 },
+      cryptoKey,
+      combined,
+    );
+    return new Uint8Array(result);
+  }
+}

--- a/packages/level-private-state-provider/src/crypto-backend.ts
+++ b/packages/level-private-state-provider/src/crypto-backend.ts
@@ -1,0 +1,49 @@
+import { NobleCryptoBackend } from './crypto-backend-noble';
+import { WebCryptoCryptoBackend } from './crypto-backend-webcrypto';
+
+export interface CryptoBackend {
+  randomBytes(length: number): Uint8Array;
+  sha256(data: Uint8Array): Promise<Uint8Array>;
+  pbkdf2(
+    password: Uint8Array,
+    salt: Uint8Array,
+    iterations: number,
+    keyLength: number,
+  ): Promise<Uint8Array>;
+  aesGcmEncrypt(
+    key: Uint8Array,
+    iv: Uint8Array,
+    plaintext: Uint8Array,
+  ): Promise<{ ciphertext: Uint8Array; authTag: Uint8Array }>;
+  aesGcmDecrypt(
+    key: Uint8Array,
+    iv: Uint8Array,
+    ciphertext: Uint8Array,
+    authTag: Uint8Array,
+  ): Promise<Uint8Array>;
+}
+
+export type CryptoBackendType = 'webcrypto' | 'noble';
+
+export const isWebCryptoAvailable = (): boolean =>
+  typeof globalThis.crypto !== 'undefined' &&
+  typeof globalThis.crypto.subtle !== 'undefined';
+
+export const resolveCryptoBackend = (preference?: CryptoBackendType): CryptoBackend => {
+  if (preference === 'noble') {
+    return new NobleCryptoBackend();
+  }
+  if (preference === 'webcrypto') {
+    if (!isWebCryptoAvailable()) {
+      throw new Error(
+        'Web Crypto API is not available. Use the \'noble\' crypto backend or run in a secure context (HTTPS or localhost).',
+      );
+    }
+    return new WebCryptoCryptoBackend();
+  }
+
+  if (isWebCryptoAvailable()) {
+    return new WebCryptoCryptoBackend();
+  }
+  return new NobleCryptoBackend();
+};

--- a/packages/level-private-state-provider/src/index.ts
+++ b/packages/level-private-state-provider/src/index.ts
@@ -18,6 +18,7 @@ export {
   type CryptoBackendType,
 } from './crypto-backend';
 export {
+  type DatabaseLevel,
   DEFAULT_CONFIG,
   type LevelFactory,
   levelPrivateStateProvider,

--- a/packages/level-private-state-provider/src/index.ts
+++ b/packages/level-private-state-provider/src/index.ts
@@ -14,16 +14,21 @@
  */
 
 export {
+  type CryptoBackend,
+  type CryptoBackendType,
+} from './crypto-backend';
+export {
   DEFAULT_CONFIG,
   levelPrivateStateProvider,
   type LevelPrivateStateProviderConfig,
   migrateToAccountScoped,
   type MigrationResult,
   type PasswordRotationOptions,
-  type PasswordRotationResult
+  type PasswordRotationResult,
 } from './level-private-state-provider';
 export {
   decryptValue,
   type PrivateStoragePasswordProvider,
-  StorageEncryption
+  StorageEncryption,
+  type StorageEncryptionOptions,
 } from './storage-encryption';

--- a/packages/level-private-state-provider/src/index.ts
+++ b/packages/level-private-state-provider/src/index.ts
@@ -19,6 +19,7 @@ export {
 } from './crypto-backend';
 export {
   DEFAULT_CONFIG,
+  type LevelFactory,
   levelPrivateStateProvider,
   type LevelPrivateStateProviderConfig,
   migrateToAccountScoped,

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -336,7 +336,8 @@ const isDecryptionError = (error: unknown): boolean => {
     message.includes('salt mismatch') ||
     message.includes('invalid encrypted data') ||
     message.includes('bad decrypt') ||
-    message.includes('unable to authenticate')
+    message.includes('unable to authenticate') ||
+    message.includes('operation failed for an operation-specific reason')
   );
 };
 

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -105,7 +105,10 @@ export interface LevelPrivateStateProviderConfig {
    */
   readonly accountId: string;
   readonly cryptoBackend?: CryptoBackendType;
+  readonly levelFactory?: LevelFactory;
 }
+
+export type LevelFactory = (dbName: string) => Level;
 
 /**
  * The default configuration for the level database.
@@ -146,14 +149,16 @@ const getScopedLevelName = (baseLevelName: string, accountId: string): string =>
   return `${baseLevelName}:${hashedAccountId}`;
 };
 
+const defaultLevelFactory: LevelFactory = (dbName: string) =>
+  new Level(dbName, { createIfMissing: true });
+
 const withSubLevel = async <K, V, A>(
   dbName: string,
   levelName: string,
-  thunk: (subLevel: AbstractSublevel<Level, string | Uint8Array | Buffer, K, V>) => Promise<A>
+  thunk: (subLevel: AbstractSublevel<Level, string | Uint8Array | Buffer, K, V>) => Promise<A>,
+  createLevel: LevelFactory = defaultLevelFactory,
 ): Promise<A> => {
-  const level = new Level(dbName, {
-    createIfMissing: true
-  });
+  const level = createLevel(dbName);
   const subLevel = level.sublevel<K, V>(levelName, {
     valueEncoding: 'utf-8'
   });
@@ -198,7 +203,7 @@ interface EncryptionCacheEntry {
  */
 const encryptionCache = new Map<string, EncryptionCacheEntry>();
 
-const getOrCreateSalt = async (dbName: string, levelName: string): Promise<Buffer> => {
+const getOrCreateSalt = async (dbName: string, levelName: string, createLevel: LevelFactory = defaultLevelFactory): Promise<Buffer> => {
   const lockKey = `${dbName}:${levelName}`;
 
   const existingPromise = encryptionInitPromises.get(lockKey);
@@ -226,7 +231,7 @@ const getOrCreateSalt = async (dbName: string, levelName: string): Promise<Buffe
     };
     await subLevel.put(METADATA_KEY, JSON.stringify(metadata));
     return salt;
-  });
+  }, createLevel);
 
   encryptionInitPromises.set(lockKey, initPromise);
 
@@ -241,10 +246,11 @@ const getOrCreateEncryption = async (
   dbName: string,
   levelName: string,
   passwordProvider: PrivateStoragePasswordProvider,
-  cryptoBackend?: CryptoBackendType
+  cryptoBackend?: CryptoBackendType,
+  createLevel: LevelFactory = defaultLevelFactory,
 ): Promise<StorageEncryption> => {
   const cacheKey = `${dbName}:${levelName}`;
-  const salt = await getOrCreateSalt(dbName, levelName);
+  const salt = await getOrCreateSalt(dbName, levelName, createLevel);
   const saltHex = salt.toString('hex');
 
   const cached = encryptionCache.get(cacheKey);
@@ -331,6 +337,7 @@ interface RotateStorePasswordParams {
   readonly maxEntries: number;
   readonly shouldProceed?: (key: string) => boolean;
   readonly cryptoBackend?: CryptoBackendType;
+  readonly createLevel?: LevelFactory;
 }
 
 const isDecryptionError = (error: unknown): boolean => {
@@ -354,12 +361,13 @@ const isDecryptionError = (error: unknown): boolean => {
 const rotateStorePassword = async (
   params: RotateStorePasswordParams
 ): Promise<PasswordRotationResult> => {
-  const { dbName, storeName, oldPasswordProvider, newPasswordProvider, maxEntries, shouldProceed, cryptoBackend } = params;
+  const { dbName, storeName, oldPasswordProvider, newPasswordProvider, maxEntries, shouldProceed, cryptoBackend, createLevel: lvlFactory } = params;
+  const lvlCreate = lvlFactory ?? defaultLevelFactory;
 
   const oldPassword = await getPasswordFromProvider(oldPasswordProvider);
   const newPassword = await getPasswordFromProvider(newPasswordProvider);
 
-  const salt = await getOrCreateSalt(dbName, storeName);
+  const salt = await getOrCreateSalt(dbName, storeName, lvlCreate);
   const oldEncryption = await StorageEncryption.create(oldPassword, { existingSalt: salt, cryptoBackend });
   const newEncryption = await StorageEncryption.create(newPassword, { cryptoBackend });
   const newSalt = newEncryption.getSalt();
@@ -453,7 +461,8 @@ const rotateStorePassword = async (
       }
 
       return { entriesMigrated: entriesToMigrate.length };
-    }
+    },
+    lvlCreate,
   );
 };
 
@@ -462,10 +471,11 @@ const subLevelMaybeGet = async <K, V>(
   levelName: string,
   key: K,
   passwordProvider: PrivateStoragePasswordProvider,
-  cryptoBackend?: CryptoBackendType
+  cryptoBackend?: CryptoBackendType,
+  createLevel: LevelFactory = defaultLevelFactory,
 ): Promise<V | null> => {
   await waitForRotationLock(dbName, levelName);
-  const encryption = await getOrCreateEncryption(dbName, levelName, passwordProvider, cryptoBackend);
+  const encryption = await getOrCreateEncryption(dbName, levelName, passwordProvider, cryptoBackend, createLevel);
 
   return withSubLevel<K, string, V | null>(dbName, levelName, async (subLevel) => {
     try {
@@ -506,7 +516,7 @@ const subLevelMaybeGet = async <K, V>(
       }
       throw error;
     }
-  });
+  }, createLevel);
 };
 
 /**
@@ -516,10 +526,11 @@ const getAllEntries = async <K extends string, V>(
   dbName: string,
   levelName: string,
   passwordProvider: PrivateStoragePasswordProvider,
-  cryptoBackend?: CryptoBackendType
+  cryptoBackend?: CryptoBackendType,
+  createLevel: LevelFactory = defaultLevelFactory,
 ): Promise<Map<K, V>> => {
   await waitForRotationLock(dbName, levelName);
-  const encryption = await getOrCreateEncryption(dbName, levelName, passwordProvider, cryptoBackend);
+  const encryption = await getOrCreateEncryption(dbName, levelName, passwordProvider, cryptoBackend, createLevel);
 
   return withSubLevel<K, string, Map<K, V>>(dbName, levelName, async (subLevel) => {
     const entries = new Map<K, V>();
@@ -559,7 +570,7 @@ const getAllEntries = async <K extends string, V>(
     }
 
     return entries;
-  });
+  }, createLevel);
 };
 
 /**
@@ -720,6 +731,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
   const passwordProvider: PrivateStoragePasswordProvider = config.privateStoragePasswordProvider;
   const cryptoBackend = config.cryptoBackend;
+  const createLevel = fullConfig.levelFactory ?? defaultLevelFactory;
 
   const scopedNames = {
     privateState: getScopedLevelName(fullConfig.privateStateStoreName, config.accountId),
@@ -749,7 +761,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         privateState,
         scopedKey,
         passwordProvider,
-        cryptoBackend
+        cryptoBackend,
+        createLevel,
       );
     },
     async remove(privateStateId: PSI): Promise<void> {
@@ -757,7 +770,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       await waitForRotationLock(fullConfig.midnightDbName, privateState);
       const scopedKey = getScopedKey(privateStateId);
       return withSubLevel<string, string, void>(fullConfig.midnightDbName, privateState, (subLevel) =>
-        subLevel.del(scopedKey)
+        subLevel.del(scopedKey), createLevel,
       );
     },
     async set(privateStateId: PSI, state: PS): Promise<void> {
@@ -768,13 +781,14 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         fullConfig.midnightDbName,
         privateState,
         passwordProvider,
-        cryptoBackend
+        cryptoBackend,
+        createLevel,
       );
       const serialized = superjson.stringify(state);
       const encrypted = await encryption.encrypt(serialized);
 
       return withSubLevel<string, string, void>(fullConfig.midnightDbName, privateState, (subLevel) =>
-        subLevel.put(scopedKey, encrypted)
+        subLevel.put(scopedKey, encrypted), createLevel,
       );
     },
     async clear(): Promise<void> {
@@ -782,7 +796,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         throw new Error('Contract address not set. Call setContractAddress() before accessing private state.');
       }
       const { privateState } = scopedNames;
-      return withSubLevel(fullConfig.midnightDbName, privateState, (subLevel) => subLevel.clear());
+      return withSubLevel(fullConfig.midnightDbName, privateState, (subLevel) => subLevel.clear(), createLevel);
     },
     async getSigningKey(address: ContractAddress): Promise<SigningKey | null> {
       const { signingKey } = scopedNames;
@@ -791,7 +805,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         signingKey,
         address,
         passwordProvider,
-        cryptoBackend
+        cryptoBackend,
+        createLevel,
       );
     },
     async removeSigningKey(address: ContractAddress): Promise<void> {
@@ -800,7 +815,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       return withSubLevel<ContractAddress, string, void>(
         fullConfig.midnightDbName,
         signingKey,
-        (subLevel) => subLevel.del(address)
+        (subLevel) => subLevel.del(address),
+        createLevel,
       );
     },
     async setSigningKey(address: ContractAddress, signingKey: SigningKey): Promise<void> {
@@ -811,6 +827,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         signingKeyLevelName,
         passwordProvider,
         cryptoBackend,
+        createLevel,
       );
       const serialized = superjson.stringify(signingKey);
       const encrypted = await encryption.encrypt(serialized);
@@ -818,12 +835,13 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       return withSubLevel<ContractAddress, string, void>(
         fullConfig.midnightDbName,
         signingKeyLevelName,
-        (subLevel) => subLevel.put(address, encrypted)
+        (subLevel) => subLevel.put(address, encrypted),
+        createLevel,
       );
     },
     async clearSigningKeys(): Promise<void> {
       const { signingKey } = scopedNames;
-      return withSubLevel(fullConfig.midnightDbName, signingKey, (subLevel) => subLevel.clear());
+      return withSubLevel(fullConfig.midnightDbName, signingKey, (subLevel) => subLevel.clear(), createLevel);
     },
 
     async exportPrivateStates(options?: ExportPrivateStatesOptions): Promise<PrivateStateExport> {
@@ -847,7 +865,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         fullConfig.midnightDbName,
         privateState,
         passwordProvider,
-        cryptoBackend
+        cryptoBackend,
+        createLevel,
       );
 
       // Filter and extract only states for the current contract address
@@ -1026,7 +1045,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         fullConfig.midnightDbName,
         scopedSigningKey,
         passwordProvider,
-        cryptoBackend
+        cryptoBackend,
+        createLevel,
       );
 
       if (allKeys.size === 0) {
@@ -1177,7 +1197,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
           newPasswordProvider,
           maxEntries: options?.maxEntries ?? DEFAULT_MAX_ROTATION_ENTRIES,
           shouldProceed: (key) => key.startsWith(prefix),
-          cryptoBackend
+          cryptoBackend,
+          createLevel: createLevel,
         });
 
         invalidateEncryptionCacheForDb(
@@ -1205,7 +1226,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
           oldPasswordProvider,
           newPasswordProvider,
           maxEntries: options?.maxEntries ?? DEFAULT_MAX_ROTATION_ENTRIES,
-          cryptoBackend
+          cryptoBackend,
+          createLevel: createLevel,
         });
 
         invalidateEncryptionCacheForDb(
@@ -1233,9 +1255,10 @@ export interface MigrationResult {
 const migrateSublevel = async (
   dbName: string,
   oldLevelName: string,
-  newLevelName: string
+  newLevelName: string,
+  createLevel: LevelFactory = defaultLevelFactory,
 ): Promise<number> => {
-  const level = new Level(dbName, { createIfMissing: true });
+  const level = createLevel(dbName);
 
   try {
     await level.open();
@@ -1327,6 +1350,7 @@ export const migrateToAccountScoped = async (
   config: Partial<LevelPrivateStateProviderConfig> & Pick<LevelPrivateStateProviderConfig, 'accountId'>
 ): Promise<MigrationResult> => {
   const fullConfig = { ...DEFAULT_CONFIG, ...config };
+  const lvlCreate = fullConfig.levelFactory ?? defaultLevelFactory;
 
   if (!config.accountId || config.accountId.trim().length === 0) {
     throw new Error('accountId is required for migration');
@@ -1347,7 +1371,8 @@ export const migrateToAccountScoped = async (
     privateStatesMigrated = await migrateSublevel(
       fullConfig.midnightDbName,
       fullConfig.privateStateStoreName,
-      scopedPrivateStateLevelName
+      scopedPrivateStateLevelName,
+      lvlCreate,
     );
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -1364,7 +1389,8 @@ export const migrateToAccountScoped = async (
     signingKeysMigrated = await migrateSublevel(
       fullConfig.midnightDbName,
       fullConfig.signingKeyStoreName,
-      scopedSigningKeyLevelName
+      scopedSigningKeyLevelName,
+      lvlCreate,
     );
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -346,6 +346,7 @@ const isDecryptionError = (error: unknown): boolean => {
     message.includes('salt mismatch') ||
     message.includes('invalid encrypted data') ||
     message.includes('bad decrypt') ||
+    message.includes('invalid tag') ||
     message.includes('unable to authenticate')
   );
 };

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -33,12 +33,15 @@ import {
   type SigningKeyExport,
   SigningKeyExportError
 } from '@midnight-ntwrk/midnight-js-types';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex, randomBytes } from '@noble/hashes/utils.js';
 import { type AbstractSublevel } from 'abstract-level';
 import { Buffer } from 'buffer';
 import { Level } from 'level';
 import * as superjson from 'superjson';
 
-import { assertWebCryptoAvailable, decryptValue, getPasswordFromProvider, type PrivateStoragePasswordProvider, StorageEncryption } from './storage-encryption';
+import type { CryptoBackendType } from './crypto-backend';
+import { decryptValue, getPasswordFromProvider, type PrivateStoragePasswordProvider, StorageEncryption } from './storage-encryption';
 
 /**
  * The default name of the indexedDB database for Midnight.
@@ -101,6 +104,7 @@ export interface LevelPrivateStateProviderConfig {
    * ```
    */
   readonly accountId: string;
+  readonly cryptoBackend?: CryptoBackendType;
 }
 
 /**
@@ -132,15 +136,13 @@ superjson.registerCustom<Buffer, string>(
 
 const ACCOUNT_ID_HASH_LENGTH = 32;
 
-const hashAccountId = async (accountId: string): Promise<string> => {
-  assertWebCryptoAvailable();
+const hashAccountId = (accountId: string): string => {
   const data = new TextEncoder().encode(accountId);
-  const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', data);
-  return Buffer.from(new Uint8Array(hashBuffer)).toString('hex').substring(0, ACCOUNT_ID_HASH_LENGTH);
+  return bytesToHex(sha256(data)).substring(0, ACCOUNT_ID_HASH_LENGTH);
 };
 
-const getScopedLevelName = async (baseLevelName: string, accountId: string): Promise<string> => {
-  const hashedAccountId = await hashAccountId(accountId);
+const getScopedLevelName = (baseLevelName: string, accountId: string): string => {
+  const hashedAccountId = hashAccountId(accountId);
   return `${baseLevelName}:${hashedAccountId}`;
 };
 
@@ -217,8 +219,7 @@ const getOrCreateSalt = async (dbName: string, levelName: string): Promise<Buffe
       }
     }
 
-    assertWebCryptoAvailable();
-    const salt = Buffer.from(globalThis.crypto.getRandomValues(new Uint8Array(32)));
+    const salt = Buffer.from(randomBytes(32));
     const metadata = {
       salt: salt.toString('hex'),
       version: 1
@@ -239,7 +240,8 @@ const getOrCreateSalt = async (dbName: string, levelName: string): Promise<Buffe
 const getOrCreateEncryption = async (
   dbName: string,
   levelName: string,
-  passwordProvider: PrivateStoragePasswordProvider
+  passwordProvider: PrivateStoragePasswordProvider,
+  cryptoBackend?: CryptoBackendType
 ): Promise<StorageEncryption> => {
   const cacheKey = `${dbName}:${levelName}`;
   const salt = await getOrCreateSalt(dbName, levelName);
@@ -251,13 +253,13 @@ const getOrCreateEncryption = async (
     if (await cached.encryption.verifyPassword(password)) {
       return cached.encryption;
     }
-    const encryption = await StorageEncryption.create(password, salt);
+    const encryption = await StorageEncryption.create(password, { existingSalt: salt, cryptoBackend });
     encryptionCache.set(cacheKey, { encryption, saltHex });
     return encryption;
   }
 
   const password = await getPasswordFromProvider(passwordProvider);
-  const encryption = await StorageEncryption.create(password, salt);
+  const encryption = await StorageEncryption.create(password, { existingSalt: salt, cryptoBackend });
   encryptionCache.set(cacheKey, { encryption, saltHex });
   return encryption;
 };
@@ -328,6 +330,7 @@ interface RotateStorePasswordParams {
   readonly newPasswordProvider: PrivateStoragePasswordProvider;
   readonly maxEntries: number;
   readonly shouldProceed?: (key: string) => boolean;
+  readonly cryptoBackend?: CryptoBackendType;
 }
 
 const isDecryptionError = (error: unknown): boolean => {
@@ -350,14 +353,14 @@ const isDecryptionError = (error: unknown): boolean => {
 const rotateStorePassword = async (
   params: RotateStorePasswordParams
 ): Promise<PasswordRotationResult> => {
-  const { dbName, storeName, oldPasswordProvider, newPasswordProvider, maxEntries, shouldProceed } = params;
+  const { dbName, storeName, oldPasswordProvider, newPasswordProvider, maxEntries, shouldProceed, cryptoBackend } = params;
 
   const oldPassword = await getPasswordFromProvider(oldPasswordProvider);
   const newPassword = await getPasswordFromProvider(newPasswordProvider);
 
   const salt = await getOrCreateSalt(dbName, storeName);
-  const oldEncryption = await StorageEncryption.create(oldPassword, salt);
-  const newEncryption = await StorageEncryption.create(newPassword);
+  const oldEncryption = await StorageEncryption.create(oldPassword, { existingSalt: salt, cryptoBackend });
+  const newEncryption = await StorageEncryption.create(newPassword, { cryptoBackend });
   const newSalt = newEncryption.getSalt();
 
   return withSubLevel<string, string, PasswordRotationResult>(
@@ -457,10 +460,11 @@ const subLevelMaybeGet = async <K, V>(
   dbName: string,
   levelName: string,
   key: K,
-  passwordProvider: PrivateStoragePasswordProvider
+  passwordProvider: PrivateStoragePasswordProvider,
+  cryptoBackend?: CryptoBackendType
 ): Promise<V | null> => {
   await waitForRotationLock(dbName, levelName);
-  const encryption = await getOrCreateEncryption(dbName, levelName, passwordProvider);
+  const encryption = await getOrCreateEncryption(dbName, levelName, passwordProvider, cryptoBackend);
 
   return withSubLevel<K, string, V | null>(dbName, levelName, async (subLevel) => {
     try {
@@ -510,10 +514,11 @@ const subLevelMaybeGet = async <K, V>(
 const getAllEntries = async <K extends string, V>(
   dbName: string,
   levelName: string,
-  passwordProvider: PrivateStoragePasswordProvider
+  passwordProvider: PrivateStoragePasswordProvider,
+  cryptoBackend?: CryptoBackendType
 ): Promise<Map<K, V>> => {
   await waitForRotationLock(dbName, levelName);
-  const encryption = await getOrCreateEncryption(dbName, levelName, passwordProvider);
+  const encryption = await getOrCreateEncryption(dbName, levelName, passwordProvider, cryptoBackend);
 
   return withSubLevel<K, string, Map<K, V>>(dbName, levelName, async (subLevel) => {
     const entries = new Map<K, V>();
@@ -713,21 +718,11 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
   }
 
   const passwordProvider: PrivateStoragePasswordProvider = config.privateStoragePasswordProvider;
+  const cryptoBackend = config.cryptoBackend;
 
-  let scopedNamesPromise: Promise<{ privateState: string; signingKey: string }> | null = null;
-
-  const getScopedNames = (): Promise<{ privateState: string; signingKey: string }> => {
-    if (scopedNamesPromise === null) {
-      scopedNamesPromise = (async () => {
-        const privateState = await getScopedLevelName(fullConfig.privateStateStoreName, config.accountId);
-        const signingKey = await getScopedLevelName(fullConfig.signingKeyStoreName, config.accountId);
-        return { privateState, signingKey };
-      })().catch((error: unknown) => {
-        scopedNamesPromise = null;
-        throw error;
-      });
-    }
-    return scopedNamesPromise;
+  const scopedNames = {
+    privateState: getScopedLevelName(fullConfig.privateStateStoreName, config.accountId),
+    signingKey: getScopedLevelName(fullConfig.signingKeyStoreName, config.accountId),
   };
 
   showBrowserWarning();
@@ -746,17 +741,18 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       contractAddress = address;
     },
     async get(privateStateId: PSI): Promise<PS | null> {
-      const { privateState } = await getScopedNames();
+      const { privateState } = scopedNames;
       const scopedKey = getScopedKey(privateStateId);
       return subLevelMaybeGet<string, PS>(
         fullConfig.midnightDbName,
         privateState,
         scopedKey,
-        passwordProvider
+        passwordProvider,
+        cryptoBackend
       );
     },
     async remove(privateStateId: PSI): Promise<void> {
-      const { privateState } = await getScopedNames();
+      const { privateState } = scopedNames;
       await waitForRotationLock(fullConfig.midnightDbName, privateState);
       const scopedKey = getScopedKey(privateStateId);
       return withSubLevel<string, string, void>(fullConfig.midnightDbName, privateState, (subLevel) =>
@@ -764,13 +760,14 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       );
     },
     async set(privateStateId: PSI, state: PS): Promise<void> {
-      const { privateState } = await getScopedNames();
+      const { privateState } = scopedNames;
       await waitForRotationLock(fullConfig.midnightDbName, privateState);
       const scopedKey = getScopedKey(privateStateId);
       const encryption = await getOrCreateEncryption(
         fullConfig.midnightDbName,
         privateState,
-        passwordProvider
+        passwordProvider,
+        cryptoBackend
       );
       const serialized = superjson.stringify(state);
       const encrypted = await encryption.encrypt(serialized);
@@ -783,20 +780,21 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       if (contractAddress === null) {
         throw new Error('Contract address not set. Call setContractAddress() before accessing private state.');
       }
-      const { privateState } = await getScopedNames();
+      const { privateState } = scopedNames;
       return withSubLevel(fullConfig.midnightDbName, privateState, (subLevel) => subLevel.clear());
     },
     async getSigningKey(address: ContractAddress): Promise<SigningKey | null> {
-      const { signingKey } = await getScopedNames();
+      const { signingKey } = scopedNames;
       return subLevelMaybeGet<ContractAddress, SigningKey>(
         fullConfig.midnightDbName,
         signingKey,
         address,
-        passwordProvider
+        passwordProvider,
+        cryptoBackend
       );
     },
     async removeSigningKey(address: ContractAddress): Promise<void> {
-      const { signingKey } = await getScopedNames();
+      const { signingKey } = scopedNames;
       await waitForRotationLock(fullConfig.midnightDbName, signingKey);
       return withSubLevel<ContractAddress, string, void>(
         fullConfig.midnightDbName,
@@ -805,12 +803,13 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       );
     },
     async setSigningKey(address: ContractAddress, signingKey: SigningKey): Promise<void> {
-      const { signingKey: signingKeyLevelName } = await getScopedNames();
+      const { signingKey: signingKeyLevelName } = scopedNames;
       await waitForRotationLock(fullConfig.midnightDbName, signingKeyLevelName);
       const encryption = await getOrCreateEncryption(
         fullConfig.midnightDbName,
         signingKeyLevelName,
-        passwordProvider
+        passwordProvider,
+        cryptoBackend,
       );
       const serialized = superjson.stringify(signingKey);
       const encrypted = await encryption.encrypt(serialized);
@@ -822,7 +821,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       );
     },
     async clearSigningKeys(): Promise<void> {
-      const { signingKey } = await getScopedNames();
+      const { signingKey } = scopedNames;
       return withSubLevel(fullConfig.midnightDbName, signingKey, (subLevel) => subLevel.clear());
     },
 
@@ -842,11 +841,12 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       const exportPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);
 
       // Get all private states (not signing keys)
-      const { privateState } = await getScopedNames();
+      const { privateState } = scopedNames;
       const allStates = await getAllEntries<string, PS>(
         fullConfig.midnightDbName,
         privateState,
-        passwordProvider
+        passwordProvider,
+        cryptoBackend
       );
 
       // Filter and extract only states for the current contract address
@@ -881,7 +881,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       };
 
       // Create new encryption instance for export (different salt from storage)
-      const exportEncryption = await StorageEncryption.create(exportPassword);
+      const exportEncryption = await StorageEncryption.create(exportPassword, { cryptoBackend });
       const encryptedPayload = await exportEncryption.encrypt(JSON.stringify(payload));
 
       return {
@@ -927,7 +927,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       let payload: PrivateStatePayload<PSI>;
       try {
         const salt = Buffer.from(exportData.salt, 'hex');
-        const importEncryption = await StorageEncryption.create(importPassword, salt);
+        const importEncryption = await StorageEncryption.create(importPassword, { existingSalt: salt, cryptoBackend });
         const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
       } catch {
@@ -1020,11 +1020,12 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
       const exportPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);
 
-      const { signingKey: scopedSigningKey } = await getScopedNames();
+      const { signingKey: scopedSigningKey } = scopedNames;
       const allKeys = await getAllEntries<ContractAddress, SigningKey>(
         fullConfig.midnightDbName,
         scopedSigningKey,
-        passwordProvider
+        passwordProvider,
+        cryptoBackend
       );
 
       if (allKeys.size === 0) {
@@ -1044,7 +1045,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         keys: Object.fromEntries(allKeys.entries()) as Record<ContractAddress, SigningKey>
       };
 
-      const exportEncryption = await StorageEncryption.create(exportPassword);
+      const exportEncryption = await StorageEncryption.create(exportPassword, { cryptoBackend });
       const encryptedPayload = await exportEncryption.encrypt(JSON.stringify(payload));
 
       return {
@@ -1080,7 +1081,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       let payload: SigningKeyPayload;
       try {
         const salt = Buffer.from(exportData.salt, 'hex');
-        const importEncryption = await StorageEncryption.create(importPassword, salt);
+        const importEncryption = await StorageEncryption.create(importPassword, { existingSalt: salt, cryptoBackend });
         const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
       } catch {
@@ -1163,7 +1164,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         throw new Error('Contract address not set. Call setContractAddress() before changing password.');
       }
 
-      const { privateState, signingKey } = await getScopedNames();
+      const { privateState, signingKey } = scopedNames;
       const lockKey = `${fullConfig.midnightDbName}:${privateState}`;
       const prefix = `${contractAddress}:`;
 
@@ -1174,7 +1175,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
           oldPasswordProvider,
           newPasswordProvider,
           maxEntries: options?.maxEntries ?? DEFAULT_MAX_ROTATION_ENTRIES,
-          shouldProceed: (key) => key.startsWith(prefix)
+          shouldProceed: (key) => key.startsWith(prefix),
+          cryptoBackend
         });
 
         invalidateEncryptionCacheForDb(
@@ -1192,7 +1194,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       newPasswordProvider: PrivateStoragePasswordProvider,
       options?: PasswordRotationOptions
     ): Promise<PasswordRotationResult> {
-      const { privateState, signingKey } = await getScopedNames();
+      const { privateState, signingKey } = scopedNames;
       const lockKey = `${fullConfig.midnightDbName}:${signingKey}`;
 
       return withPasswordRotationLock(lockKey, async () => {
@@ -1201,7 +1203,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
           storeName: signingKey,
           oldPasswordProvider,
           newPasswordProvider,
-          maxEntries: options?.maxEntries ?? DEFAULT_MAX_ROTATION_ENTRIES
+          maxEntries: options?.maxEntries ?? DEFAULT_MAX_ROTATION_ENTRIES,
+          cryptoBackend
         });
 
         invalidateEncryptionCacheForDb(
@@ -1215,16 +1218,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
     },
 
     async invalidateEncryptionCache(): Promise<void> {
-      const cachedPromise = scopedNamesPromise;
-      scopedNamesPromise = null;
-      if (cachedPromise) {
-        try {
-          const { privateState, signingKey } = await cachedPromise;
-          invalidateEncryptionCacheForDb(fullConfig.midnightDbName, privateState, signingKey);
-        } catch {
-          // Names were never resolved, so no cache entries to invalidate
-        }
-      }
+      const { privateState, signingKey } = scopedNames;
+      invalidateEncryptionCacheForDb(fullConfig.midnightDbName, privateState, signingKey);
     }
   };
 };
@@ -1336,11 +1331,11 @@ export const migrateToAccountScoped = async (
     throw new Error('accountId is required for migration');
   }
 
-  const scopedPrivateStateLevelName = await getScopedLevelName(
+  const scopedPrivateStateLevelName = getScopedLevelName(
     fullConfig.privateStateStoreName,
     config.accountId
   );
-  const scopedSigningKeyLevelName = await getScopedLevelName(
+  const scopedSigningKeyLevelName = getScopedLevelName(
     fullConfig.signingKeyStoreName,
     config.accountId
   );

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -38,7 +38,7 @@ import { Buffer } from 'buffer';
 import { Level } from 'level';
 import * as superjson from 'superjson';
 
-import { decryptValue, getPasswordFromProvider, type PrivateStoragePasswordProvider, StorageEncryption } from './storage-encryption';
+import { assertWebCryptoAvailable, decryptValue, getPasswordFromProvider, type PrivateStoragePasswordProvider, StorageEncryption } from './storage-encryption';
 
 /**
  * The default name of the indexedDB database for Midnight.
@@ -133,6 +133,7 @@ superjson.registerCustom<Buffer, string>(
 const ACCOUNT_ID_HASH_LENGTH = 32;
 
 const hashAccountId = async (accountId: string): Promise<string> => {
+  assertWebCryptoAvailable();
   const data = new TextEncoder().encode(accountId);
   const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', data);
   return Buffer.from(new Uint8Array(hashBuffer)).toString('hex').substring(0, ACCOUNT_ID_HASH_LENGTH);
@@ -330,6 +331,11 @@ interface RotateStorePasswordParams {
 
 const isDecryptionError = (error: unknown): boolean => {
   if (!(error instanceof Error)) return false;
+
+  if ('name' in error && error.name === 'OperationError') {
+    return true;
+  }
+
   const message = error.message.toLowerCase();
   return (
     message.includes('unsupported state') ||
@@ -708,15 +714,17 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
   const passwordProvider: PrivateStoragePasswordProvider = config.privateStoragePasswordProvider;
 
-  let scopedPrivateStateLevelName: string | null = null;
-  let scopedSigningKeyLevelName: string | null = null;
+  let scopedNamesPromise: Promise<{ privateState: string; signingKey: string }> | null = null;
 
-  const getScopedNames = async (): Promise<{ privateState: string; signingKey: string }> => {
-    if (scopedPrivateStateLevelName === null || scopedSigningKeyLevelName === null) {
-      scopedPrivateStateLevelName = await getScopedLevelName(fullConfig.privateStateStoreName, config.accountId);
-      scopedSigningKeyLevelName = await getScopedLevelName(fullConfig.signingKeyStoreName, config.accountId);
+  const getScopedNames = (): Promise<{ privateState: string; signingKey: string }> => {
+    if (scopedNamesPromise === null) {
+      scopedNamesPromise = (async () => {
+        const privateState = await getScopedLevelName(fullConfig.privateStateStoreName, config.accountId);
+        const signingKey = await getScopedLevelName(fullConfig.signingKeyStoreName, config.accountId);
+        return { privateState, signingKey };
+      })();
     }
-    return { privateState: scopedPrivateStateLevelName, signingKey: scopedSigningKeyLevelName };
+    return scopedNamesPromise;
   };
 
   showBrowserWarning();
@@ -919,7 +927,10 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         const importEncryption = await StorageEncryption.create(importPassword, salt);
         const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
-      } catch {
+      } catch (error: unknown) {
+        if (error instanceof TypeError && error.message.includes('subtle')) {
+          throw new Error('Web Crypto subtle API is not available. In browsers, this requires a secure context (HTTPS or localhost).', { cause: error });
+        }
         // Single generic error - don't reveal whether password was wrong or data was corrupted
         throw new ExportDecryptionError();
       }
@@ -1072,7 +1083,10 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         const importEncryption = await StorageEncryption.create(importPassword, salt);
         const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
-      } catch {
+      } catch (error: unknown) {
+        if (error instanceof TypeError && error.message.includes('subtle')) {
+          throw new Error('Web Crypto subtle API is not available. In browsers, this requires a secure context (HTTPS or localhost).', { cause: error });
+        }
         throw new ExportDecryptionError();
       }
 
@@ -1205,6 +1219,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
     async invalidateEncryptionCache(): Promise<void> {
       const { privateState, signingKey } = await getScopedNames();
+      scopedNamesPromise = null;
       invalidateEncryptionCacheForDb(
         fullConfig.midnightDbName,
         privateState,

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -217,6 +217,7 @@ const getOrCreateSalt = async (dbName: string, levelName: string): Promise<Buffe
       }
     }
 
+    assertWebCryptoAvailable();
     const salt = Buffer.from(globalThis.crypto.getRandomValues(new Uint8Array(32)));
     const metadata = {
       salt: salt.toString('hex'),
@@ -342,8 +343,7 @@ const isDecryptionError = (error: unknown): boolean => {
     message.includes('salt mismatch') ||
     message.includes('invalid encrypted data') ||
     message.includes('bad decrypt') ||
-    message.includes('unable to authenticate') ||
-    message.includes('operation failed for an operation-specific reason')
+    message.includes('unable to authenticate')
   );
 };
 
@@ -722,7 +722,10 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         const privateState = await getScopedLevelName(fullConfig.privateStateStoreName, config.accountId);
         const signingKey = await getScopedLevelName(fullConfig.signingKeyStoreName, config.accountId);
         return { privateState, signingKey };
-      })();
+      })().catch((error: unknown) => {
+        scopedNamesPromise = null;
+        throw error;
+      });
     }
     return scopedNamesPromise;
   };
@@ -927,10 +930,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         const importEncryption = await StorageEncryption.create(importPassword, salt);
         const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
-      } catch (error: unknown) {
-        if (error instanceof TypeError && error.message.includes('subtle')) {
-          throw new Error('Web Crypto subtle API is not available. In browsers, this requires a secure context (HTTPS or localhost).', { cause: error });
-        }
+      } catch {
         // Single generic error - don't reveal whether password was wrong or data was corrupted
         throw new ExportDecryptionError();
       }
@@ -1083,10 +1083,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         const importEncryption = await StorageEncryption.create(importPassword, salt);
         const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
-      } catch (error: unknown) {
-        if (error instanceof TypeError && error.message.includes('subtle')) {
-          throw new Error('Web Crypto subtle API is not available. In browsers, this requires a secure context (HTTPS or localhost).', { cause: error });
-        }
+      } catch {
         throw new ExportDecryptionError();
       }
 
@@ -1218,13 +1215,16 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
     },
 
     async invalidateEncryptionCache(): Promise<void> {
-      const { privateState, signingKey } = await getScopedNames();
+      const cachedPromise = scopedNamesPromise;
       scopedNamesPromise = null;
-      invalidateEncryptionCacheForDb(
-        fullConfig.midnightDbName,
-        privateState,
-        signingKey
-      );
+      if (cachedPromise) {
+        try {
+          const { privateState, signingKey } = await cachedPromise;
+          invalidateEncryptionCacheForDb(fullConfig.midnightDbName, privateState, signingKey);
+        } catch {
+          // Names were never resolved, so no cache entries to invalidate
+        }
+      }
     }
   };
 };

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -35,7 +35,7 @@ import {
 } from '@midnight-ntwrk/midnight-js-types';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex, randomBytes } from '@noble/hashes/utils.js';
-import { type AbstractSublevel } from 'abstract-level';
+import { type AbstractLevel, type AbstractSublevel } from 'abstract-level';
 import { Buffer } from 'buffer';
 import { Level } from 'level';
 import * as superjson from 'superjson';
@@ -108,7 +108,15 @@ export interface LevelPrivateStateProviderConfig {
   readonly levelFactory?: LevelFactory;
 }
 
-export type LevelFactory = (dbName: string) => Level;
+export type DatabaseLevel = AbstractLevel<string | Buffer | Uint8Array, string, string>;
+
+export type LevelFactory = (dbName: string) => DatabaseLevel;
+
+interface StorageContext {
+  readonly dbName: string;
+  readonly createLevel: LevelFactory;
+  readonly cryptoBackend?: CryptoBackendType;
+}
 
 /**
  * The default configuration for the level database.
@@ -149,16 +157,18 @@ const getScopedLevelName = (baseLevelName: string, accountId: string): string =>
   return `${baseLevelName}:${hashedAccountId}`;
 };
 
+// Level extends AbstractLevel but TypeScript can't prove assignability
+// due to invariance in AbstractSublevel/AbstractBatchOperation generics.
+// The cast is safe: Level<string, string> truly implements DatabaseLevel.
 const defaultLevelFactory: LevelFactory = (dbName: string) =>
-  new Level(dbName, { createIfMissing: true });
+  new Level(dbName, { createIfMissing: true }) as DatabaseLevel;
 
 const withSubLevel = async <K, V, A>(
-  dbName: string,
+  ctx: StorageContext,
   levelName: string,
-  thunk: (subLevel: AbstractSublevel<Level, string | Uint8Array | Buffer, K, V>) => Promise<A>,
-  createLevel: LevelFactory = defaultLevelFactory,
+  thunk: (subLevel: AbstractSublevel<DatabaseLevel, string | Uint8Array | Buffer, K, V>) => Promise<A>,
 ): Promise<A> => {
-  const level = createLevel(dbName);
+  const level = ctx.createLevel(ctx.dbName);
   const subLevel = level.sublevel<K, V>(levelName, {
     valueEncoding: 'utf-8'
   });
@@ -203,15 +213,15 @@ interface EncryptionCacheEntry {
  */
 const encryptionCache = new Map<string, EncryptionCacheEntry>();
 
-const getOrCreateSalt = async (dbName: string, levelName: string, createLevel: LevelFactory = defaultLevelFactory): Promise<Buffer> => {
-  const lockKey = `${dbName}:${levelName}`;
+const getOrCreateSalt = async (ctx: StorageContext, levelName: string): Promise<Buffer> => {
+  const lockKey = `${ctx.dbName}:${levelName}`;
 
   const existingPromise = encryptionInitPromises.get(lockKey);
   if (existingPromise) {
     return existingPromise;
   }
 
-  const initPromise = withSubLevel<string, string, Buffer>(dbName, levelName, async (subLevel) => {
+  const initPromise = withSubLevel<string, string, Buffer>(ctx, levelName, async (subLevel) => {
     try {
       const metadataJson = await subLevel.get(METADATA_KEY);
       if (metadataJson) {
@@ -231,7 +241,7 @@ const getOrCreateSalt = async (dbName: string, levelName: string, createLevel: L
     };
     await subLevel.put(METADATA_KEY, JSON.stringify(metadata));
     return salt;
-  }, createLevel);
+  });
 
   encryptionInitPromises.set(lockKey, initPromise);
 
@@ -243,14 +253,12 @@ const getOrCreateSalt = async (dbName: string, levelName: string, createLevel: L
 };
 
 const getOrCreateEncryption = async (
-  dbName: string,
+  ctx: StorageContext,
   levelName: string,
   passwordProvider: PrivateStoragePasswordProvider,
-  cryptoBackend?: CryptoBackendType,
-  createLevel: LevelFactory = defaultLevelFactory,
 ): Promise<StorageEncryption> => {
-  const cacheKey = `${dbName}:${levelName}`;
-  const salt = await getOrCreateSalt(dbName, levelName, createLevel);
+  const cacheKey = `${ctx.dbName}:${levelName}`;
+  const salt = await getOrCreateSalt(ctx, levelName);
   const saltHex = salt.toString('hex');
 
   const cached = encryptionCache.get(cacheKey);
@@ -259,13 +267,13 @@ const getOrCreateEncryption = async (
     if (await cached.encryption.verifyPassword(password)) {
       return cached.encryption;
     }
-    const encryption = await StorageEncryption.create(password, { existingSalt: salt, cryptoBackend });
+    const encryption = await StorageEncryption.create(password, { existingSalt: salt, cryptoBackend: ctx.cryptoBackend });
     encryptionCache.set(cacheKey, { encryption, saltHex });
     return encryption;
   }
 
   const password = await getPasswordFromProvider(passwordProvider);
-  const encryption = await StorageEncryption.create(password, { existingSalt: salt, cryptoBackend });
+  const encryption = await StorageEncryption.create(password, { existingSalt: salt, cryptoBackend: ctx.cryptoBackend });
   encryptionCache.set(cacheKey, { encryption, saltHex });
   return encryption;
 };
@@ -330,14 +338,12 @@ const waitForRotationLock = async (
 };
 
 interface RotateStorePasswordParams {
-  readonly dbName: string;
+  readonly ctx: StorageContext;
   readonly storeName: string;
   readonly oldPasswordProvider: PrivateStoragePasswordProvider;
   readonly newPasswordProvider: PrivateStoragePasswordProvider;
   readonly maxEntries: number;
   readonly shouldProceed?: (key: string) => boolean;
-  readonly cryptoBackend?: CryptoBackendType;
-  readonly createLevel?: LevelFactory;
 }
 
 const isDecryptionError = (error: unknown): boolean => {
@@ -361,19 +367,18 @@ const isDecryptionError = (error: unknown): boolean => {
 const rotateStorePassword = async (
   params: RotateStorePasswordParams
 ): Promise<PasswordRotationResult> => {
-  const { dbName, storeName, oldPasswordProvider, newPasswordProvider, maxEntries, shouldProceed, cryptoBackend, createLevel: lvlFactory } = params;
-  const lvlCreate = lvlFactory ?? defaultLevelFactory;
+  const { ctx, storeName, oldPasswordProvider, newPasswordProvider, maxEntries, shouldProceed } = params;
 
   const oldPassword = await getPasswordFromProvider(oldPasswordProvider);
   const newPassword = await getPasswordFromProvider(newPasswordProvider);
 
-  const salt = await getOrCreateSalt(dbName, storeName, lvlCreate);
-  const oldEncryption = await StorageEncryption.create(oldPassword, { existingSalt: salt, cryptoBackend });
-  const newEncryption = await StorageEncryption.create(newPassword, { cryptoBackend });
+  const salt = await getOrCreateSalt(ctx, storeName);
+  const oldEncryption = await StorageEncryption.create(oldPassword, { existingSalt: salt, cryptoBackend: ctx.cryptoBackend });
+  const newEncryption = await StorageEncryption.create(newPassword, { cryptoBackend: ctx.cryptoBackend });
   const newSalt = newEncryption.getSalt();
 
   return withSubLevel<string, string, PasswordRotationResult>(
-    dbName,
+    ctx,
     storeName,
     async (subLevel) => {
       const entriesToMigrate: { key: string; decryptedValue: string }[] = [];
@@ -462,22 +467,19 @@ const rotateStorePassword = async (
 
       return { entriesMigrated: entriesToMigrate.length };
     },
-    lvlCreate,
   );
 };
 
 const subLevelMaybeGet = async <K, V>(
-  dbName: string,
+  ctx: StorageContext,
   levelName: string,
   key: K,
   passwordProvider: PrivateStoragePasswordProvider,
-  cryptoBackend?: CryptoBackendType,
-  createLevel: LevelFactory = defaultLevelFactory,
 ): Promise<V | null> => {
-  await waitForRotationLock(dbName, levelName);
-  const encryption = await getOrCreateEncryption(dbName, levelName, passwordProvider, cryptoBackend, createLevel);
+  await waitForRotationLock(ctx.dbName, levelName);
+  const encryption = await getOrCreateEncryption(ctx, levelName, passwordProvider);
 
-  return withSubLevel<K, string, V | null>(dbName, levelName, async (subLevel) => {
+  return withSubLevel<K, string, V | null>(ctx, levelName, async (subLevel) => {
     try {
       const encryptedValue = await subLevel.get(key);
 
@@ -516,23 +518,21 @@ const subLevelMaybeGet = async <K, V>(
       }
       throw error;
     }
-  }, createLevel);
+  });
 };
 
 /**
  * Iterate all key-value pairs in a sublevel, excluding metadata keys.
  */
 const getAllEntries = async <K extends string, V>(
-  dbName: string,
+  ctx: StorageContext,
   levelName: string,
   passwordProvider: PrivateStoragePasswordProvider,
-  cryptoBackend?: CryptoBackendType,
-  createLevel: LevelFactory = defaultLevelFactory,
 ): Promise<Map<K, V>> => {
-  await waitForRotationLock(dbName, levelName);
-  const encryption = await getOrCreateEncryption(dbName, levelName, passwordProvider, cryptoBackend, createLevel);
+  await waitForRotationLock(ctx.dbName, levelName);
+  const encryption = await getOrCreateEncryption(ctx, levelName, passwordProvider);
 
-  return withSubLevel<K, string, Map<K, V>>(dbName, levelName, async (subLevel) => {
+  return withSubLevel<K, string, Map<K, V>>(ctx, levelName, async (subLevel) => {
     const entries = new Map<K, V>();
     let password: string | null = null;
 
@@ -570,7 +570,7 @@ const getAllEntries = async <K extends string, V>(
     }
 
     return entries;
-  }, createLevel);
+  });
 };
 
 /**
@@ -730,8 +730,11 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
   }
 
   const passwordProvider: PrivateStoragePasswordProvider = config.privateStoragePasswordProvider;
-  const cryptoBackend = config.cryptoBackend;
-  const createLevel = fullConfig.levelFactory ?? defaultLevelFactory;
+  const ctx: StorageContext = {
+    dbName: fullConfig.midnightDbName,
+    createLevel: fullConfig.levelFactory ?? defaultLevelFactory,
+    cryptoBackend: config.cryptoBackend,
+  };
 
   const scopedNames = {
     privateState: getScopedLevelName(fullConfig.privateStateStoreName, config.accountId),
@@ -756,39 +759,26 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
     async get(privateStateId: PSI): Promise<PS | null> {
       const { privateState } = scopedNames;
       const scopedKey = getScopedKey(privateStateId);
-      return subLevelMaybeGet<string, PS>(
-        fullConfig.midnightDbName,
-        privateState,
-        scopedKey,
-        passwordProvider,
-        cryptoBackend,
-        createLevel,
-      );
+      return subLevelMaybeGet<string, PS>(ctx, privateState, scopedKey, passwordProvider);
     },
     async remove(privateStateId: PSI): Promise<void> {
       const { privateState } = scopedNames;
-      await waitForRotationLock(fullConfig.midnightDbName, privateState);
+      await waitForRotationLock(ctx.dbName, privateState);
       const scopedKey = getScopedKey(privateStateId);
-      return withSubLevel<string, string, void>(fullConfig.midnightDbName, privateState, (subLevel) =>
-        subLevel.del(scopedKey), createLevel,
+      return withSubLevel<string, string, void>(ctx, privateState, (subLevel) =>
+        subLevel.del(scopedKey),
       );
     },
     async set(privateStateId: PSI, state: PS): Promise<void> {
       const { privateState } = scopedNames;
-      await waitForRotationLock(fullConfig.midnightDbName, privateState);
+      await waitForRotationLock(ctx.dbName, privateState);
       const scopedKey = getScopedKey(privateStateId);
-      const encryption = await getOrCreateEncryption(
-        fullConfig.midnightDbName,
-        privateState,
-        passwordProvider,
-        cryptoBackend,
-        createLevel,
-      );
+      const encryption = await getOrCreateEncryption(ctx, privateState, passwordProvider);
       const serialized = superjson.stringify(state);
       const encrypted = await encryption.encrypt(serialized);
 
-      return withSubLevel<string, string, void>(fullConfig.midnightDbName, privateState, (subLevel) =>
-        subLevel.put(scopedKey, encrypted), createLevel,
+      return withSubLevel<string, string, void>(ctx, privateState, (subLevel) =>
+        subLevel.put(scopedKey, encrypted),
       );
     },
     async clear(): Promise<void> {
@@ -796,52 +786,33 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         throw new Error('Contract address not set. Call setContractAddress() before accessing private state.');
       }
       const { privateState } = scopedNames;
-      return withSubLevel(fullConfig.midnightDbName, privateState, (subLevel) => subLevel.clear(), createLevel);
+      return withSubLevel(ctx, privateState, (subLevel) => subLevel.clear());
     },
     async getSigningKey(address: ContractAddress): Promise<SigningKey | null> {
       const { signingKey } = scopedNames;
-      return subLevelMaybeGet<ContractAddress, SigningKey>(
-        fullConfig.midnightDbName,
-        signingKey,
-        address,
-        passwordProvider,
-        cryptoBackend,
-        createLevel,
-      );
+      return subLevelMaybeGet<ContractAddress, SigningKey>(ctx, signingKey, address, passwordProvider);
     },
     async removeSigningKey(address: ContractAddress): Promise<void> {
       const { signingKey } = scopedNames;
-      await waitForRotationLock(fullConfig.midnightDbName, signingKey);
-      return withSubLevel<ContractAddress, string, void>(
-        fullConfig.midnightDbName,
-        signingKey,
-        (subLevel) => subLevel.del(address),
-        createLevel,
+      await waitForRotationLock(ctx.dbName, signingKey);
+      return withSubLevel<ContractAddress, string, void>(ctx, signingKey, (subLevel) =>
+        subLevel.del(address),
       );
     },
     async setSigningKey(address: ContractAddress, signingKey: SigningKey): Promise<void> {
       const { signingKey: signingKeyLevelName } = scopedNames;
-      await waitForRotationLock(fullConfig.midnightDbName, signingKeyLevelName);
-      const encryption = await getOrCreateEncryption(
-        fullConfig.midnightDbName,
-        signingKeyLevelName,
-        passwordProvider,
-        cryptoBackend,
-        createLevel,
-      );
+      await waitForRotationLock(ctx.dbName, signingKeyLevelName);
+      const encryption = await getOrCreateEncryption(ctx, signingKeyLevelName, passwordProvider);
       const serialized = superjson.stringify(signingKey);
       const encrypted = await encryption.encrypt(serialized);
 
-      return withSubLevel<ContractAddress, string, void>(
-        fullConfig.midnightDbName,
-        signingKeyLevelName,
-        (subLevel) => subLevel.put(address, encrypted),
-        createLevel,
+      return withSubLevel<ContractAddress, string, void>(ctx, signingKeyLevelName, (subLevel) =>
+        subLevel.put(address, encrypted),
       );
     },
     async clearSigningKeys(): Promise<void> {
       const { signingKey } = scopedNames;
-      return withSubLevel(fullConfig.midnightDbName, signingKey, (subLevel) => subLevel.clear(), createLevel);
+      return withSubLevel(ctx, signingKey, (subLevel) => subLevel.clear());
     },
 
     async exportPrivateStates(options?: ExportPrivateStatesOptions): Promise<PrivateStateExport> {
@@ -861,13 +832,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
       // Get all private states (not signing keys)
       const { privateState } = scopedNames;
-      const allStates = await getAllEntries<string, PS>(
-        fullConfig.midnightDbName,
-        privateState,
-        passwordProvider,
-        cryptoBackend,
-        createLevel,
-      );
+      const allStates = await getAllEntries<string, PS>(ctx, privateState, passwordProvider);
 
       // Filter and extract only states for the current contract address
       const prefix = `${contractAddress}:`;
@@ -901,7 +866,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       };
 
       // Create new encryption instance for export (different salt from storage)
-      const exportEncryption = await StorageEncryption.create(exportPassword, { cryptoBackend });
+      const exportEncryption = await StorageEncryption.create(exportPassword, { cryptoBackend: ctx.cryptoBackend });
       const encryptedPayload = await exportEncryption.encrypt(JSON.stringify(payload));
 
       return {
@@ -947,7 +912,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       let payload: PrivateStatePayload<PSI>;
       try {
         const salt = Buffer.from(exportData.salt, 'hex');
-        const importEncryption = await StorageEncryption.create(importPassword, { existingSalt: salt, cryptoBackend });
+        const importEncryption = await StorageEncryption.create(importPassword, { existingSalt: salt, cryptoBackend: ctx.cryptoBackend });
         const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
       } catch {
@@ -1041,13 +1006,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       const exportPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);
 
       const { signingKey: scopedSigningKey } = scopedNames;
-      const allKeys = await getAllEntries<ContractAddress, SigningKey>(
-        fullConfig.midnightDbName,
-        scopedSigningKey,
-        passwordProvider,
-        cryptoBackend,
-        createLevel,
-      );
+      const allKeys = await getAllEntries<ContractAddress, SigningKey>(ctx, scopedSigningKey, passwordProvider);
 
       if (allKeys.size === 0) {
         throw new SigningKeyExportError('No signing keys to export');
@@ -1066,7 +1025,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         keys: Object.fromEntries(allKeys.entries()) as Record<ContractAddress, SigningKey>
       };
 
-      const exportEncryption = await StorageEncryption.create(exportPassword, { cryptoBackend });
+      const exportEncryption = await StorageEncryption.create(exportPassword, { cryptoBackend: ctx.cryptoBackend });
       const encryptedPayload = await exportEncryption.encrypt(JSON.stringify(payload));
 
       return {
@@ -1102,7 +1061,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       let payload: SigningKeyPayload;
       try {
         const salt = Buffer.from(exportData.salt, 'hex');
-        const importEncryption = await StorageEncryption.create(importPassword, { existingSalt: salt, cryptoBackend });
+        const importEncryption = await StorageEncryption.create(importPassword, { existingSalt: salt, cryptoBackend: ctx.cryptoBackend });
         const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
       } catch {
@@ -1186,26 +1145,20 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       }
 
       const { privateState, signingKey } = scopedNames;
-      const lockKey = `${fullConfig.midnightDbName}:${privateState}`;
+      const lockKey = `${ctx.dbName}:${privateState}`;
       const prefix = `${contractAddress}:`;
 
       return withPasswordRotationLock(lockKey, async () => {
         const result = await rotateStorePassword({
-          dbName: fullConfig.midnightDbName,
+          ctx,
           storeName: privateState,
           oldPasswordProvider,
           newPasswordProvider,
           maxEntries: options?.maxEntries ?? DEFAULT_MAX_ROTATION_ENTRIES,
           shouldProceed: (key) => key.startsWith(prefix),
-          cryptoBackend,
-          createLevel: createLevel,
         });
 
-        invalidateEncryptionCacheForDb(
-          fullConfig.midnightDbName,
-          privateState,
-          signingKey
-        );
+        invalidateEncryptionCacheForDb(ctx.dbName, privateState, signingKey);
 
         return result;
       });
@@ -1217,24 +1170,18 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       options?: PasswordRotationOptions
     ): Promise<PasswordRotationResult> {
       const { privateState, signingKey } = scopedNames;
-      const lockKey = `${fullConfig.midnightDbName}:${signingKey}`;
+      const lockKey = `${ctx.dbName}:${signingKey}`;
 
       return withPasswordRotationLock(lockKey, async () => {
         const result = await rotateStorePassword({
-          dbName: fullConfig.midnightDbName,
+          ctx,
           storeName: signingKey,
           oldPasswordProvider,
           newPasswordProvider,
           maxEntries: options?.maxEntries ?? DEFAULT_MAX_ROTATION_ENTRIES,
-          cryptoBackend,
-          createLevel: createLevel,
         });
 
-        invalidateEncryptionCacheForDb(
-          fullConfig.midnightDbName,
-          privateState,
-          signingKey
-        );
+        invalidateEncryptionCacheForDb(ctx.dbName, privateState, signingKey);
 
         return result;
       });
@@ -1242,7 +1189,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
     async invalidateEncryptionCache(): Promise<void> {
       const { privateState, signingKey } = scopedNames;
-      invalidateEncryptionCacheForDb(fullConfig.midnightDbName, privateState, signingKey);
+      invalidateEncryptionCacheForDb(ctx.dbName, privateState, signingKey);
     }
   };
 };
@@ -1253,12 +1200,11 @@ export interface MigrationResult {
 }
 
 const migrateSublevel = async (
-  dbName: string,
+  ctx: StorageContext,
   oldLevelName: string,
   newLevelName: string,
-  createLevel: LevelFactory = defaultLevelFactory,
 ): Promise<number> => {
-  const level = createLevel(dbName);
+  const level = ctx.createLevel(ctx.dbName);
 
   try {
     await level.open();
@@ -1350,7 +1296,10 @@ export const migrateToAccountScoped = async (
   config: Partial<LevelPrivateStateProviderConfig> & Pick<LevelPrivateStateProviderConfig, 'accountId'>
 ): Promise<MigrationResult> => {
   const fullConfig = { ...DEFAULT_CONFIG, ...config };
-  const lvlCreate = fullConfig.levelFactory ?? defaultLevelFactory;
+  const ctx: StorageContext = {
+    dbName: fullConfig.midnightDbName,
+    createLevel: fullConfig.levelFactory ?? defaultLevelFactory,
+  };
 
   if (!config.accountId || config.accountId.trim().length === 0) {
     throw new Error('accountId is required for migration');
@@ -1368,12 +1317,7 @@ export const migrateToAccountScoped = async (
   let privateStatesMigrated: number;
 
   try {
-    privateStatesMigrated = await migrateSublevel(
-      fullConfig.midnightDbName,
-      fullConfig.privateStateStoreName,
-      scopedPrivateStateLevelName,
-      lvlCreate,
-    );
+    privateStatesMigrated = await migrateSublevel(ctx, fullConfig.privateStateStoreName, scopedPrivateStateLevelName);
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     throw new Error(
@@ -1386,12 +1330,7 @@ export const migrateToAccountScoped = async (
   let signingKeysMigrated: number;
 
   try {
-    signingKeysMigrated = await migrateSublevel(
-      fullConfig.midnightDbName,
-      fullConfig.signingKeyStoreName,
-      scopedSigningKeyLevelName,
-      lvlCreate,
-    );
+    signingKeysMigrated = await migrateSublevel(ctx, fullConfig.signingKeyStoreName, scopedSigningKeyLevelName);
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     throw new Error(

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -804,20 +804,20 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         (subLevel) => subLevel.del(address)
       );
     },
-    async setSigningKey(address: ContractAddress, signingKeyValue: SigningKey): Promise<void> {
-      const { signingKey } = await getScopedNames();
-      await waitForRotationLock(fullConfig.midnightDbName, signingKey);
+    async setSigningKey(address: ContractAddress, signingKey: SigningKey): Promise<void> {
+      const { signingKey: signingKeyLevelName } = await getScopedNames();
+      await waitForRotationLock(fullConfig.midnightDbName, signingKeyLevelName);
       const encryption = await getOrCreateEncryption(
         fullConfig.midnightDbName,
-        signingKey,
+        signingKeyLevelName,
         passwordProvider
       );
-      const serialized = superjson.stringify(signingKeyValue);
+      const serialized = superjson.stringify(signingKey);
       const encrypted = await encryption.encrypt(serialized);
 
       return withSubLevel<ContractAddress, string, void>(
         fullConfig.midnightDbName,
-        signingKey,
+        signingKeyLevelName,
         (subLevel) => subLevel.put(address, encrypted)
       );
     },

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -35,7 +35,6 @@ import {
 } from '@midnight-ntwrk/midnight-js-types';
 import { type AbstractSublevel } from 'abstract-level';
 import { Buffer } from 'buffer';
-import { createHash, randomBytes } from 'crypto';
 import { Level } from 'level';
 import * as superjson from 'superjson';
 
@@ -133,12 +132,14 @@ superjson.registerCustom<Buffer, string>(
 
 const ACCOUNT_ID_HASH_LENGTH = 32;
 
-const hashAccountId = (accountId: string): string => {
-  return createHash('sha256').update(accountId).digest('hex').substring(0, ACCOUNT_ID_HASH_LENGTH);
+const hashAccountId = async (accountId: string): Promise<string> => {
+  const data = new TextEncoder().encode(accountId);
+  const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', data);
+  return Buffer.from(new Uint8Array(hashBuffer)).toString('hex').substring(0, ACCOUNT_ID_HASH_LENGTH);
 };
 
-const getScopedLevelName = (baseLevelName: string, accountId: string): string => {
-  const hashedAccountId = hashAccountId(accountId);
+const getScopedLevelName = async (baseLevelName: string, accountId: string): Promise<string> => {
+  const hashedAccountId = await hashAccountId(accountId);
   return `${baseLevelName}:${hashedAccountId}`;
 };
 
@@ -215,7 +216,7 @@ const getOrCreateSalt = async (dbName: string, levelName: string): Promise<Buffe
       }
     }
 
-    const salt = randomBytes(32);
+    const salt = Buffer.from(globalThis.crypto.getRandomValues(new Uint8Array(32)));
     const metadata = {
       salt: salt.toString('hex'),
       version: 1
@@ -245,16 +246,16 @@ const getOrCreateEncryption = async (
   const cached = encryptionCache.get(cacheKey);
   if (cached && cached.saltHex === saltHex) {
     const password = await getPasswordFromProvider(passwordProvider);
-    if (cached.encryption.verifyPassword(password)) {
+    if (await cached.encryption.verifyPassword(password)) {
       return cached.encryption;
     }
-    const encryption = new StorageEncryption(password, salt);
+    const encryption = await StorageEncryption.create(password, salt);
     encryptionCache.set(cacheKey, { encryption, saltHex });
     return encryption;
   }
 
   const password = await getPasswordFromProvider(passwordProvider);
-  const encryption = new StorageEncryption(password, salt);
+  const encryption = await StorageEncryption.create(password, salt);
   encryptionCache.set(cacheKey, { encryption, saltHex });
   return encryption;
 };
@@ -348,8 +349,8 @@ const rotateStorePassword = async (
   const newPassword = await getPasswordFromProvider(newPasswordProvider);
 
   const salt = await getOrCreateSalt(dbName, storeName);
-  const oldEncryption = new StorageEncryption(oldPassword, salt);
-  const newEncryption = new StorageEncryption(newPassword);
+  const oldEncryption = await StorageEncryption.create(oldPassword, salt);
+  const newEncryption = await StorageEncryption.create(newPassword);
   const newSalt = newEncryption.getSalt();
 
   return withSubLevel<string, string, PasswordRotationResult>(
@@ -376,7 +377,7 @@ const rotateStorePassword = async (
 
         if (!firstEntryValidated) {
           try {
-            decryptValue(encryptedValue, oldEncryption, oldPassword);
+            await decryptValue(encryptedValue, oldEncryption, oldPassword);
           } catch (error: unknown) {
             if (isDecryptionError(error)) {
               throw new Error('Old password is incorrect: failed to decrypt existing data', { cause: error });
@@ -387,7 +388,7 @@ const rotateStorePassword = async (
         }
 
         try {
-          const decryptedValue = decryptValue(encryptedValue, oldEncryption, oldPassword);
+          const decryptedValue = await decryptValue(encryptedValue, oldEncryption, oldPassword);
           entriesToMigrate.push({ key, decryptedValue });
         } catch (error: unknown) {
           const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -410,7 +411,7 @@ const rotateStorePassword = async (
       const operations: { type: 'put'; key: string; value: string }[] = [];
       for (const { key, decryptedValue } of entriesToMigrate) {
         try {
-          const encryptedValue = newEncryption.encrypt(decryptedValue);
+          const encryptedValue = await newEncryption.encrypt(decryptedValue);
           operations.push({ type: 'put', key, value: encryptedValue });
         } catch (error: unknown) {
           const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -468,15 +469,15 @@ const subLevelMaybeGet = async <K, V>(
         const version = StorageEncryption.getVersion(encryptedValue);
         if (version === 1) {
           const password = await getPasswordFromProvider(passwordProvider);
-          decryptedValue = encryption.decryptWithPassword(encryptedValue, password);
-          const reEncrypted = encryption.encrypt(decryptedValue);
+          decryptedValue = await encryption.decryptWithPassword(encryptedValue, password);
+          const reEncrypted = await encryption.encrypt(decryptedValue);
           await subLevel.put(key, reEncrypted);
         } else {
-          decryptedValue = encryption.decrypt(encryptedValue);
+          decryptedValue = await encryption.decrypt(encryptedValue);
         }
       } else {
         decryptedValue = encryptedValue;
-        const reEncrypted = encryption.encrypt(encryptedValue);
+        const reEncrypted = await encryption.encrypt(encryptedValue);
         await subLevel.put(key, reEncrypted);
       }
 
@@ -525,10 +526,10 @@ const getAllEntries = async <K extends string, V>(
           if (password === null) {
             password = await getPasswordFromProvider(passwordProvider);
           }
-          decryptedValue = encryption.decryptWithPassword(encryptedValue, password);
+          decryptedValue = await encryption.decryptWithPassword(encryptedValue, password);
           needsReEncryption = true;
         } else {
-          decryptedValue = encryption.decrypt(encryptedValue);
+          decryptedValue = await encryption.decrypt(encryptedValue);
         }
       } else {
         decryptedValue = encryptedValue;
@@ -536,7 +537,7 @@ const getAllEntries = async <K extends string, V>(
       }
 
       if (needsReEncryption) {
-        const reEncrypted = encryption.encrypt(decryptedValue);
+        const reEncrypted = await encryption.encrypt(decryptedValue);
         await subLevel.put(key, reEncrypted);
       }
 
@@ -676,7 +677,7 @@ const showBrowserWarning = (): void => {
 export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
   config: Partial<LevelPrivateStateProviderConfig> & Pick<LevelPrivateStateProviderConfig, 'privateStoragePasswordProvider' | 'accountId'>
 ): PrivateStateProvider<PSI, PS> & {
-  invalidateEncryptionCache(): void;
+  invalidateEncryptionCache(): Promise<void>;
   changePassword(
     oldPasswordProvider: PrivateStoragePasswordProvider,
     newPasswordProvider: PrivateStoragePasswordProvider,
@@ -706,8 +707,16 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
   const passwordProvider: PrivateStoragePasswordProvider = config.privateStoragePasswordProvider;
 
-  const scopedPrivateStateLevelName = getScopedLevelName(fullConfig.privateStateStoreName, config.accountId);
-  const scopedSigningKeyLevelName = getScopedLevelName(fullConfig.signingKeyStoreName, config.accountId);
+  let scopedPrivateStateLevelName: string | null = null;
+  let scopedSigningKeyLevelName: string | null = null;
+
+  const getScopedNames = async (): Promise<{ privateState: string; signingKey: string }> => {
+    if (scopedPrivateStateLevelName === null || scopedSigningKeyLevelName === null) {
+      scopedPrivateStateLevelName = await getScopedLevelName(fullConfig.privateStateStoreName, config.accountId);
+      scopedSigningKeyLevelName = await getScopedLevelName(fullConfig.signingKeyStoreName, config.accountId);
+    }
+    return { privateState: scopedPrivateStateLevelName, signingKey: scopedSigningKeyLevelName };
+  };
 
   showBrowserWarning();
 
@@ -725,33 +734,36 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       contractAddress = address;
     },
     async get(privateStateId: PSI): Promise<PS | null> {
+      const { privateState } = await getScopedNames();
       const scopedKey = getScopedKey(privateStateId);
       return subLevelMaybeGet<string, PS>(
         fullConfig.midnightDbName,
-        scopedPrivateStateLevelName,
+        privateState,
         scopedKey,
         passwordProvider
       );
     },
     async remove(privateStateId: PSI): Promise<void> {
-      await waitForRotationLock(fullConfig.midnightDbName, scopedPrivateStateLevelName);
+      const { privateState } = await getScopedNames();
+      await waitForRotationLock(fullConfig.midnightDbName, privateState);
       const scopedKey = getScopedKey(privateStateId);
-      return withSubLevel<string, string, void>(fullConfig.midnightDbName, scopedPrivateStateLevelName, (subLevel) =>
+      return withSubLevel<string, string, void>(fullConfig.midnightDbName, privateState, (subLevel) =>
         subLevel.del(scopedKey)
       );
     },
     async set(privateStateId: PSI, state: PS): Promise<void> {
-      await waitForRotationLock(fullConfig.midnightDbName, scopedPrivateStateLevelName);
+      const { privateState } = await getScopedNames();
+      await waitForRotationLock(fullConfig.midnightDbName, privateState);
       const scopedKey = getScopedKey(privateStateId);
       const encryption = await getOrCreateEncryption(
         fullConfig.midnightDbName,
-        scopedPrivateStateLevelName,
+        privateState,
         passwordProvider
       );
       const serialized = superjson.stringify(state);
-      const encrypted = encryption.encrypt(serialized);
+      const encrypted = await encryption.encrypt(serialized);
 
-      return withSubLevel<string, string, void>(fullConfig.midnightDbName, scopedPrivateStateLevelName, (subLevel) =>
+      return withSubLevel<string, string, void>(fullConfig.midnightDbName, privateState, (subLevel) =>
         subLevel.put(scopedKey, encrypted)
       );
     },
@@ -759,42 +771,47 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       if (contractAddress === null) {
         throw new Error('Contract address not set. Call setContractAddress() before accessing private state.');
       }
-      return withSubLevel(fullConfig.midnightDbName, scopedPrivateStateLevelName, (subLevel) => subLevel.clear());
+      const { privateState } = await getScopedNames();
+      return withSubLevel(fullConfig.midnightDbName, privateState, (subLevel) => subLevel.clear());
     },
-    getSigningKey(address: ContractAddress): Promise<SigningKey | null> {
+    async getSigningKey(address: ContractAddress): Promise<SigningKey | null> {
+      const { signingKey } = await getScopedNames();
       return subLevelMaybeGet<ContractAddress, SigningKey>(
         fullConfig.midnightDbName,
-        scopedSigningKeyLevelName,
+        signingKey,
         address,
         passwordProvider
       );
     },
     async removeSigningKey(address: ContractAddress): Promise<void> {
-      await waitForRotationLock(fullConfig.midnightDbName, scopedSigningKeyLevelName);
+      const { signingKey } = await getScopedNames();
+      await waitForRotationLock(fullConfig.midnightDbName, signingKey);
       return withSubLevel<ContractAddress, string, void>(
         fullConfig.midnightDbName,
-        scopedSigningKeyLevelName,
+        signingKey,
         (subLevel) => subLevel.del(address)
       );
     },
-    async setSigningKey(address: ContractAddress, signingKey: SigningKey): Promise<void> {
-      await waitForRotationLock(fullConfig.midnightDbName, scopedSigningKeyLevelName);
+    async setSigningKey(address: ContractAddress, signingKeyValue: SigningKey): Promise<void> {
+      const { signingKey } = await getScopedNames();
+      await waitForRotationLock(fullConfig.midnightDbName, signingKey);
       const encryption = await getOrCreateEncryption(
         fullConfig.midnightDbName,
-        scopedSigningKeyLevelName,
+        signingKey,
         passwordProvider
       );
-      const serialized = superjson.stringify(signingKey);
-      const encrypted = encryption.encrypt(serialized);
+      const serialized = superjson.stringify(signingKeyValue);
+      const encrypted = await encryption.encrypt(serialized);
 
       return withSubLevel<ContractAddress, string, void>(
         fullConfig.midnightDbName,
-        scopedSigningKeyLevelName,
+        signingKey,
         (subLevel) => subLevel.put(address, encrypted)
       );
     },
-    clearSigningKeys(): Promise<void> {
-      return withSubLevel(fullConfig.midnightDbName, scopedSigningKeyLevelName, (subLevel) => subLevel.clear());
+    async clearSigningKeys(): Promise<void> {
+      const { signingKey } = await getScopedNames();
+      return withSubLevel(fullConfig.midnightDbName, signingKey, (subLevel) => subLevel.clear());
     },
 
     async exportPrivateStates(options?: ExportPrivateStatesOptions): Promise<PrivateStateExport> {
@@ -813,9 +830,10 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       const exportPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);
 
       // Get all private states (not signing keys)
+      const { privateState } = await getScopedNames();
       const allStates = await getAllEntries<string, PS>(
         fullConfig.midnightDbName,
-        scopedPrivateStateLevelName,
+        privateState,
         passwordProvider
       );
 
@@ -851,8 +869,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       };
 
       // Create new encryption instance for export (different salt from storage)
-      const exportEncryption = new StorageEncryption(exportPassword);
-      const encryptedPayload = exportEncryption.encrypt(JSON.stringify(payload));
+      const exportEncryption = await StorageEncryption.create(exportPassword);
+      const encryptedPayload = await exportEncryption.encrypt(JSON.stringify(payload));
 
       return {
         format: 'midnight-private-state-export',
@@ -897,8 +915,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       let payload: PrivateStatePayload<PSI>;
       try {
         const salt = Buffer.from(exportData.salt, 'hex');
-        const importEncryption = new StorageEncryption(importPassword, salt);
-        const decryptedJson = importEncryption.decrypt(exportData.encryptedPayload);
+        const importEncryption = await StorageEncryption.create(importPassword, salt);
+        const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
       } catch {
         // Single generic error - don't reveal whether password was wrong or data was corrupted
@@ -990,9 +1008,10 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
       const exportPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);
 
+      const { signingKey: scopedSigningKey } = await getScopedNames();
       const allKeys = await getAllEntries<ContractAddress, SigningKey>(
         fullConfig.midnightDbName,
-        scopedSigningKeyLevelName,
+        scopedSigningKey,
         passwordProvider
       );
 
@@ -1013,8 +1032,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         keys: Object.fromEntries(allKeys.entries()) as Record<ContractAddress, SigningKey>
       };
 
-      const exportEncryption = new StorageEncryption(exportPassword);
-      const encryptedPayload = exportEncryption.encrypt(JSON.stringify(payload));
+      const exportEncryption = await StorageEncryption.create(exportPassword);
+      const encryptedPayload = await exportEncryption.encrypt(JSON.stringify(payload));
 
       return {
         format: 'midnight-signing-key-export',
@@ -1049,8 +1068,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       let payload: SigningKeyPayload;
       try {
         const salt = Buffer.from(exportData.salt, 'hex');
-        const importEncryption = new StorageEncryption(importPassword, salt);
-        const decryptedJson = importEncryption.decrypt(exportData.encryptedPayload);
+        const importEncryption = await StorageEncryption.create(importPassword, salt);
+        const decryptedJson = await importEncryption.decrypt(exportData.encryptedPayload);
         payload = JSON.parse(decryptedJson);
       } catch {
         throw new ExportDecryptionError();
@@ -1132,13 +1151,14 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         throw new Error('Contract address not set. Call setContractAddress() before changing password.');
       }
 
-      const lockKey = `${fullConfig.midnightDbName}:${scopedPrivateStateLevelName}`;
+      const { privateState, signingKey } = await getScopedNames();
+      const lockKey = `${fullConfig.midnightDbName}:${privateState}`;
       const prefix = `${contractAddress}:`;
 
       return withPasswordRotationLock(lockKey, async () => {
         const result = await rotateStorePassword({
           dbName: fullConfig.midnightDbName,
-          storeName: scopedPrivateStateLevelName,
+          storeName: privateState,
           oldPasswordProvider,
           newPasswordProvider,
           maxEntries: options?.maxEntries ?? DEFAULT_MAX_ROTATION_ENTRIES,
@@ -1147,8 +1167,8 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
         invalidateEncryptionCacheForDb(
           fullConfig.midnightDbName,
-          scopedPrivateStateLevelName,
-          scopedSigningKeyLevelName
+          privateState,
+          signingKey
         );
 
         return result;
@@ -1160,12 +1180,13 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       newPasswordProvider: PrivateStoragePasswordProvider,
       options?: PasswordRotationOptions
     ): Promise<PasswordRotationResult> {
-      const lockKey = `${fullConfig.midnightDbName}:${scopedSigningKeyLevelName}`;
+      const { privateState, signingKey } = await getScopedNames();
+      const lockKey = `${fullConfig.midnightDbName}:${signingKey}`;
 
       return withPasswordRotationLock(lockKey, async () => {
         const result = await rotateStorePassword({
           dbName: fullConfig.midnightDbName,
-          storeName: scopedSigningKeyLevelName,
+          storeName: signingKey,
           oldPasswordProvider,
           newPasswordProvider,
           maxEntries: options?.maxEntries ?? DEFAULT_MAX_ROTATION_ENTRIES
@@ -1173,19 +1194,20 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
         invalidateEncryptionCacheForDb(
           fullConfig.midnightDbName,
-          scopedPrivateStateLevelName,
-          scopedSigningKeyLevelName
+          privateState,
+          signingKey
         );
 
         return result;
       });
     },
 
-    invalidateEncryptionCache(): void {
+    async invalidateEncryptionCache(): Promise<void> {
+      const { privateState, signingKey } = await getScopedNames();
       invalidateEncryptionCacheForDb(
         fullConfig.midnightDbName,
-        scopedPrivateStateLevelName,
-        scopedSigningKeyLevelName
+        privateState,
+        signingKey
       );
     }
   };
@@ -1298,11 +1320,11 @@ export const migrateToAccountScoped = async (
     throw new Error('accountId is required for migration');
   }
 
-  const scopedPrivateStateLevelName = getScopedLevelName(
+  const scopedPrivateStateLevelName = await getScopedLevelName(
     fullConfig.privateStateStoreName,
     config.accountId
   );
-  const scopedSigningKeyLevelName = getScopedLevelName(
+  const scopedSigningKeyLevelName = await getScopedLevelName(
     fullConfig.signingKeyStoreName,
     config.accountId
   );

--- a/packages/level-private-state-provider/src/storage-encryption.ts
+++ b/packages/level-private-state-provider/src/storage-encryption.ts
@@ -15,7 +15,14 @@
 
 import { Buffer } from 'buffer';
 
+import { type CryptoBackend, type CryptoBackendType, resolveCryptoBackend } from './crypto-backend';
+
 export type PrivateStoragePasswordProvider = () => string | Promise<string>;
+
+export interface StorageEncryptionOptions {
+  existingSalt?: Buffer | Uint8Array;
+  cryptoBackend?: CryptoBackendType;
+}
 
 const KEY_LENGTH = 32;
 const IV_LENGTH = 12;
@@ -29,88 +36,6 @@ const CURRENT_ENCRYPTION_VERSION = ENCRYPTION_VERSION_V2;
 
 const VERSION_PREFIX_LENGTH = 1;
 const HEADER_LENGTH = VERSION_PREFIX_LENGTH + SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH;
-
-export const assertWebCryptoAvailable = (): void => {
-  if (typeof globalThis.crypto === 'undefined') {
-    throw new Error(
-      'Web Crypto API is not available. Ensure you are running in Node.js >= 15 or a browser with Web Crypto support.'
-    );
-  }
-  if (typeof globalThis.crypto.subtle === 'undefined') {
-    throw new Error(
-      'Web Crypto subtle API is not available. In browsers, this requires a secure context (HTTPS or localhost).'
-    );
-  }
-};
-
-const getRandomBytes = (length: number): Uint8Array => {
-  return globalThis.crypto.getRandomValues(new Uint8Array(length));
-};
-
-const sha256 = async (data: Uint8Array): Promise<Uint8Array> => {
-  const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', data);
-  return new Uint8Array(hashBuffer);
-};
-
-const pbkdf2 = async (
-  password: Uint8Array,
-  salt: Uint8Array,
-  iterations: number,
-  keyLength: number
-): Promise<Uint8Array> => {
-  const baseKey = await globalThis.crypto.subtle.importKey(
-    'raw',
-    password,
-    'PBKDF2',
-    false,
-    ['deriveBits']
-  );
-  const derived = await globalThis.crypto.subtle.deriveBits(
-    { name: 'PBKDF2', salt, iterations, hash: 'SHA-256' },
-    baseKey,
-    keyLength * 8
-  );
-  return new Uint8Array(derived);
-};
-
-const aesGcmEncrypt = async (
-  key: Uint8Array,
-  iv: Uint8Array,
-  plaintext: Uint8Array
-): Promise<{ ciphertext: Uint8Array; authTag: Uint8Array }> => {
-  const cryptoKey = await globalThis.crypto.subtle.importKey(
-    'raw', key, 'AES-GCM', false, ['encrypt']
-  );
-  const result = await globalThis.crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv, tagLength: AUTH_TAG_LENGTH * 8 },
-    cryptoKey,
-    plaintext
-  );
-  const resultBytes = new Uint8Array(result);
-  const ciphertext = resultBytes.slice(0, resultBytes.length - AUTH_TAG_LENGTH);
-  const authTag = resultBytes.slice(resultBytes.length - AUTH_TAG_LENGTH);
-  return { ciphertext, authTag };
-};
-
-const aesGcmDecrypt = async (
-  key: Uint8Array,
-  iv: Uint8Array,
-  ciphertext: Uint8Array,
-  authTag: Uint8Array
-): Promise<Uint8Array> => {
-  const cryptoKey = await globalThis.crypto.subtle.importKey(
-    'raw', key, 'AES-GCM', false, ['decrypt']
-  );
-  const combined = new Uint8Array(ciphertext.length + authTag.length);
-  combined.set(ciphertext, 0);
-  combined.set(authTag, ciphertext.length);
-  const result = await globalThis.crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv, tagLength: AUTH_TAG_LENGTH * 8 },
-    cryptoKey,
-    combined
-  );
-  return new Uint8Array(result);
-};
 
 interface EncryptedComponents {
   version: number;
@@ -153,9 +78,9 @@ const getIterationsForVersion = (version: number): number => {
   }
 };
 
-const hashPassword = async (password: string): Promise<string> => {
+const hashPassword = async (backend: CryptoBackend, password: string): Promise<string> => {
   const data = new TextEncoder().encode(password);
-  const hash = await sha256(data);
+  const hash = await backend.sha256(data);
   return Buffer.from(hash).toString('hex');
 };
 
@@ -195,32 +120,34 @@ export class StorageEncryption {
   private readonly encryptionKey: Uint8Array;
   private readonly salt: Uint8Array;
   private readonly passwordHash: string;
+  private readonly backend: CryptoBackend;
 
-  private constructor(encryptionKey: Uint8Array, salt: Uint8Array, passwordHash: string) {
+  private constructor(encryptionKey: Uint8Array, salt: Uint8Array, passwordHash: string, backend: CryptoBackend) {
     this.encryptionKey = encryptionKey;
     this.salt = salt;
     this.passwordHash = passwordHash;
+    this.backend = backend;
   }
 
-  static async create(password: string, existingSalt?: Buffer | Uint8Array): Promise<StorageEncryption> {
-    assertWebCryptoAvailable();
-    const salt = existingSalt ? new Uint8Array(existingSalt) : getRandomBytes(SALT_LENGTH);
+  static async create(password: string, options?: StorageEncryptionOptions): Promise<StorageEncryption> {
+    const backend = resolveCryptoBackend(options?.cryptoBackend);
+    const salt = options?.existingSalt ? new Uint8Array(options.existingSalt) : backend.randomBytes(SALT_LENGTH);
     const passwordBytes = new TextEncoder().encode(password);
-    const encryptionKey = await pbkdf2(passwordBytes, salt, PBKDF2_ITERATIONS_V2, KEY_LENGTH);
-    const passwordHash = await hashPassword(password);
-    return new StorageEncryption(encryptionKey, salt, passwordHash);
+    const encryptionKey = await backend.pbkdf2(passwordBytes, salt, PBKDF2_ITERATIONS_V2, KEY_LENGTH);
+    const passwordHash = await hashPassword(backend, password);
+    return new StorageEncryption(encryptionKey, salt, passwordHash, backend);
   }
 
   async verifyPassword(password: string): Promise<boolean> {
-    const inputHash = Buffer.from(await hashPassword(password), 'hex');
+    const inputHash = Buffer.from(await hashPassword(this.backend, password), 'hex');
     const storedHash = Buffer.from(this.passwordHash, 'hex');
     return timingSafeEqual(inputHash, storedHash);
   }
 
   async encrypt(data: string): Promise<string> {
     const plaintext = new TextEncoder().encode(data);
-    const iv = getRandomBytes(IV_LENGTH);
-    const { ciphertext, authTag } = await aesGcmEncrypt(this.encryptionKey, iv, plaintext);
+    const iv = this.backend.randomBytes(IV_LENGTH);
+    const { ciphertext, authTag } = await this.backend.aesGcmEncrypt(this.encryptionKey, iv, plaintext);
 
     const version = new Uint8Array([CURRENT_ENCRYPTION_VERSION]);
     const result = Buffer.concat([version, this.salt, iv, authTag, ciphertext]);
@@ -240,7 +167,7 @@ export class StorageEncryption {
       throw new Error('Salt mismatch: data was encrypted with a different password');
     }
 
-    const decrypted = await aesGcmDecrypt(this.encryptionKey, iv, encrypted, authTag);
+    const decrypted = await this.backend.aesGcmDecrypt(this.encryptionKey, iv, encrypted, authTag);
     return Buffer.from(decrypted).toString('utf-8');
   }
 
@@ -258,10 +185,10 @@ export class StorageEncryption {
       decryptionKey = this.encryptionKey;
     } else {
       const passwordBytes = new TextEncoder().encode(password);
-      decryptionKey = await pbkdf2(passwordBytes, salt, iterations, KEY_LENGTH);
+      decryptionKey = await this.backend.pbkdf2(passwordBytes, salt, iterations, KEY_LENGTH);
     }
 
-    const decrypted = await aesGcmDecrypt(decryptionKey, iv, encrypted, authTag);
+    const decrypted = await this.backend.aesGcmDecrypt(decryptionKey, iv, encrypted, authTag);
     return Buffer.from(decrypted).toString('utf-8');
   }
 

--- a/packages/level-private-state-provider/src/storage-encryption.ts
+++ b/packages/level-private-state-provider/src/storage-encryption.ts
@@ -204,12 +204,12 @@ export class StorageEncryption {
   }
 
   async encrypt(data: string): Promise<string> {
-    const plaintext = Buffer.from(data, 'utf-8');
+    const plaintext = new TextEncoder().encode(data);
     const iv = getRandomBytes(IV_LENGTH);
     const { ciphertext, authTag } = await aesGcmEncrypt(this.encryptionKey, iv, plaintext);
 
-    const version = Buffer.from([CURRENT_ENCRYPTION_VERSION]);
-    const result = Buffer.concat([version, Buffer.from(this.salt), Buffer.from(iv), Buffer.from(authTag), Buffer.from(ciphertext)]);
+    const version = new Uint8Array([CURRENT_ENCRYPTION_VERSION]);
+    const result = Buffer.concat([version, this.salt, iv, authTag, ciphertext]);
 
     return result.toString('base64');
   }

--- a/packages/level-private-state-provider/src/storage-encryption.ts
+++ b/packages/level-private-state-provider/src/storage-encryption.ts
@@ -30,6 +30,19 @@ const CURRENT_ENCRYPTION_VERSION = ENCRYPTION_VERSION_V2;
 const VERSION_PREFIX_LENGTH = 1;
 const HEADER_LENGTH = VERSION_PREFIX_LENGTH + SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH;
 
+export const assertWebCryptoAvailable = (): void => {
+  if (typeof globalThis.crypto === 'undefined') {
+    throw new Error(
+      'Web Crypto API is not available. Ensure you are running in Node.js >= 15 or a browser with Web Crypto support.'
+    );
+  }
+  if (typeof globalThis.crypto.subtle === 'undefined') {
+    throw new Error(
+      'Web Crypto subtle API is not available. In browsers, this requires a secure context (HTTPS or localhost).'
+    );
+  }
+};
+
 const getRandomBytes = (length: number): Uint8Array => {
   return globalThis.crypto.getRandomValues(new Uint8Array(length));
 };
@@ -190,6 +203,7 @@ export class StorageEncryption {
   }
 
   static async create(password: string, existingSalt?: Buffer | Uint8Array): Promise<StorageEncryption> {
+    assertWebCryptoAvailable();
     const salt = existingSalt ? new Uint8Array(existingSalt) : getRandomBytes(SALT_LENGTH);
     const passwordBytes = new TextEncoder().encode(password);
     const encryptionKey = await pbkdf2(passwordBytes, salt, PBKDF2_ITERATIONS_V2, KEY_LENGTH);
@@ -381,7 +395,7 @@ export const decryptValue = async (
   password: string
 ): Promise<string> => {
   if (!StorageEncryption.isEncrypted(encryptedValue)) {
-    console.debug('MIDNIGHT: Encountered unencrypted data during decryption - passing through as-is');
+    console.warn('MIDNIGHT: Encountered unencrypted data during decryption - passing through as-is. This may indicate data corruption or a migration issue.');
     return encryptedValue;
   }
 

--- a/packages/level-private-state-provider/src/storage-encryption.ts
+++ b/packages/level-private-state-provider/src/storage-encryption.ts
@@ -236,7 +236,7 @@ export class StorageEncryption {
       throw new Error('V1 encrypted data requires password for decryption. Use decryptWithPassword() instead.');
     }
 
-    if (!Buffer.from(this.salt).equals(salt)) {
+    if (!timingSafeEqual(Buffer.from(this.salt), salt)) {
       throw new Error('Salt mismatch: data was encrypted with a different password');
     }
 
@@ -248,7 +248,7 @@ export class StorageEncryption {
     const data = Buffer.from(encryptedData, 'base64');
     const { version, salt, iv, authTag, encrypted } = extractEncryptedComponents(data);
 
-    if (!Buffer.from(this.salt).equals(salt)) {
+    if (!timingSafeEqual(Buffer.from(this.salt), salt)) {
       throw new Error('Salt mismatch: data was encrypted with a different password');
     }
 
@@ -395,7 +395,7 @@ export const decryptValue = async (
   password: string
 ): Promise<string> => {
   if (!StorageEncryption.isEncrypted(encryptedValue)) {
-    console.warn('MIDNIGHT: Encountered unencrypted data during decryption - passing through as-is. This may indicate data corruption or a migration issue.');
+    console.debug('MIDNIGHT: Encountered unencrypted data during decryption - passing through as-is');
     return encryptedValue;
   }
 

--- a/packages/level-private-state-provider/src/storage-encryption.ts
+++ b/packages/level-private-state-provider/src/storage-encryption.ts
@@ -14,12 +14,9 @@
  */
 
 import { Buffer } from 'buffer';
-import { createCipheriv, createDecipheriv, createHash, pbkdf2Sync, randomBytes } from 'crypto';
-import * as crypto from 'crypto';
 
 export type PrivateStoragePasswordProvider = () => string | Promise<string>;
 
-const ALGORITHM = 'aes-256-gcm';
 const KEY_LENGTH = 32;
 const IV_LENGTH = 12;
 const AUTH_TAG_LENGTH = 16;
@@ -33,8 +30,74 @@ const CURRENT_ENCRYPTION_VERSION = ENCRYPTION_VERSION_V2;
 const VERSION_PREFIX_LENGTH = 1;
 const HEADER_LENGTH = VERSION_PREFIX_LENGTH + SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH;
 
-const HAS_NATIVE_TIMINGSAFEEQUAL =
-  'timingSafeEqual' in crypto && typeof crypto.timingSafeEqual === 'function';
+const getRandomBytes = (length: number): Uint8Array => {
+  return globalThis.crypto.getRandomValues(new Uint8Array(length));
+};
+
+const sha256 = async (data: Uint8Array): Promise<Uint8Array> => {
+  const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', data);
+  return new Uint8Array(hashBuffer);
+};
+
+const pbkdf2 = async (
+  password: Uint8Array,
+  salt: Uint8Array,
+  iterations: number,
+  keyLength: number
+): Promise<Uint8Array> => {
+  const baseKey = await globalThis.crypto.subtle.importKey(
+    'raw',
+    password,
+    'PBKDF2',
+    false,
+    ['deriveBits']
+  );
+  const derived = await globalThis.crypto.subtle.deriveBits(
+    { name: 'PBKDF2', salt, iterations, hash: 'SHA-256' },
+    baseKey,
+    keyLength * 8
+  );
+  return new Uint8Array(derived);
+};
+
+const aesGcmEncrypt = async (
+  key: Uint8Array,
+  iv: Uint8Array,
+  plaintext: Uint8Array
+): Promise<{ ciphertext: Uint8Array; authTag: Uint8Array }> => {
+  const cryptoKey = await globalThis.crypto.subtle.importKey(
+    'raw', key, 'AES-GCM', false, ['encrypt']
+  );
+  const result = await globalThis.crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv, tagLength: AUTH_TAG_LENGTH * 8 },
+    cryptoKey,
+    plaintext
+  );
+  const resultBytes = new Uint8Array(result);
+  const ciphertext = resultBytes.slice(0, resultBytes.length - AUTH_TAG_LENGTH);
+  const authTag = resultBytes.slice(resultBytes.length - AUTH_TAG_LENGTH);
+  return { ciphertext, authTag };
+};
+
+const aesGcmDecrypt = async (
+  key: Uint8Array,
+  iv: Uint8Array,
+  ciphertext: Uint8Array,
+  authTag: Uint8Array
+): Promise<Uint8Array> => {
+  const cryptoKey = await globalThis.crypto.subtle.importKey(
+    'raw', key, 'AES-GCM', false, ['decrypt']
+  );
+  const combined = new Uint8Array(ciphertext.length + authTag.length);
+  combined.set(ciphertext, 0);
+  combined.set(authTag, ciphertext.length);
+  const result = await globalThis.crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv, tagLength: AUTH_TAG_LENGTH * 8 },
+    cryptoKey,
+    combined
+  );
+  return new Uint8Array(result);
+};
 
 interface EncryptedComponents {
   version: number;
@@ -77,8 +140,10 @@ const getIterationsForVersion = (version: number): number => {
   }
 };
 
-const hashPassword = (password: string): string => {
-  return createHash('sha256').update(password).digest('hex');
+const hashPassword = async (password: string): Promise<string> => {
+  const data = new TextEncoder().encode(password);
+  const hash = await sha256(data);
+  return Buffer.from(hash).toString('hex');
 };
 
 const constantTimeBufferEqual = (aBuf: Buffer, bBuf: Buffer): boolean => {
@@ -98,7 +163,7 @@ const constantTimeBufferEqual = (aBuf: Buffer, bBuf: Buffer): boolean => {
  * @param a - First buffer to compare.
  * @param b - Second buffer to compare.
  * @returns `true` if the buffers are equal, `false` otherwise.
- * 
+ *
  * @remarks
  * If the inputs differ in length, an error is thrown (not constant-time for length mismatch).
  * This matches the Node.js native timingSafeEqual behavior (which throws on length mismatch).
@@ -109,50 +174,47 @@ const constantTimeBufferEqual = (aBuf: Buffer, bBuf: Buffer): boolean => {
 export const timingSafeEqual = (a: Buffer | Uint8Array, b: Buffer | Uint8Array): boolean => {
   const aBuf = Buffer.isBuffer(a) ? a : Buffer.from(a);
   const bBuf = Buffer.isBuffer(b) ? b : Buffer.from(b);
-  if (HAS_NATIVE_TIMINGSAFEEQUAL) {
-    // Use the native `timingSafeEqual` function and let any errors propagate.
-    return crypto.timingSafeEqual(aBuf, bBuf);
-  }
   return constantTimeBufferEqual(aBuf, bBuf);
 };
 
 
 export class StorageEncryption {
-  private readonly encryptionKey: Buffer;
-  private readonly salt: Buffer;
+  private readonly encryptionKey: Uint8Array;
+  private readonly salt: Uint8Array;
   private readonly passwordHash: string;
 
-  constructor(password: string, existingSalt?: Buffer) {
-    this.salt = existingSalt ?? randomBytes(SALT_LENGTH);
-    this.encryptionKey = this.deriveKey(password, this.salt, PBKDF2_ITERATIONS_V2);
-    this.passwordHash = hashPassword(password);
+  private constructor(encryptionKey: Uint8Array, salt: Uint8Array, passwordHash: string) {
+    this.encryptionKey = encryptionKey;
+    this.salt = salt;
+    this.passwordHash = passwordHash;
   }
 
-  private deriveKey(password: string, salt: Buffer, iterations: number): Buffer {
-    return pbkdf2Sync(password, salt, iterations, KEY_LENGTH, 'sha256');
+  static async create(password: string, existingSalt?: Buffer | Uint8Array): Promise<StorageEncryption> {
+    const salt = existingSalt ? new Uint8Array(existingSalt) : getRandomBytes(SALT_LENGTH);
+    const passwordBytes = new TextEncoder().encode(password);
+    const encryptionKey = await pbkdf2(passwordBytes, salt, PBKDF2_ITERATIONS_V2, KEY_LENGTH);
+    const passwordHash = await hashPassword(password);
+    return new StorageEncryption(encryptionKey, salt, passwordHash);
   }
 
-  verifyPassword(password: string): boolean {
-    const inputHash = Buffer.from(hashPassword(password), 'hex');
+  async verifyPassword(password: string): Promise<boolean> {
+    const inputHash = Buffer.from(await hashPassword(password), 'hex');
     const storedHash = Buffer.from(this.passwordHash, 'hex');
     return timingSafeEqual(inputHash, storedHash);
   }
 
-  encrypt(data: string): string {
+  async encrypt(data: string): Promise<string> {
     const plaintext = Buffer.from(data, 'utf-8');
-    const iv = randomBytes(IV_LENGTH);
-    const cipher = createCipheriv(ALGORITHM, this.encryptionKey, iv);
-
-    const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
-    const authTag = cipher.getAuthTag();
+    const iv = getRandomBytes(IV_LENGTH);
+    const { ciphertext, authTag } = await aesGcmEncrypt(this.encryptionKey, iv, plaintext);
 
     const version = Buffer.from([CURRENT_ENCRYPTION_VERSION]);
-    const result = Buffer.concat([version, this.salt, iv, authTag, encrypted]);
+    const result = Buffer.concat([version, Buffer.from(this.salt), Buffer.from(iv), Buffer.from(authTag), Buffer.from(ciphertext)]);
 
     return result.toString('base64');
   }
 
-  decrypt(encryptedData: string): string {
+  async decrypt(encryptedData: string): Promise<string> {
     const data = Buffer.from(encryptedData, 'base64');
     const { version, salt, iv, authTag, encrypted } = extractEncryptedComponents(data);
 
@@ -160,35 +222,33 @@ export class StorageEncryption {
       throw new Error('V1 encrypted data requires password for decryption. Use decryptWithPassword() instead.');
     }
 
-    if (!this.salt.equals(salt)) {
+    if (!Buffer.from(this.salt).equals(salt)) {
       throw new Error('Salt mismatch: data was encrypted with a different password');
     }
 
-    const decipher = createDecipheriv(ALGORITHM, this.encryptionKey, iv, { authTagLength: AUTH_TAG_LENGTH });
-    decipher.setAuthTag(authTag);
-
-    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
-    return decrypted.toString('utf-8');
+    const decrypted = await aesGcmDecrypt(this.encryptionKey, iv, encrypted, authTag);
+    return Buffer.from(decrypted).toString('utf-8');
   }
 
-  decryptWithPassword(encryptedData: string, password: string): string {
+  async decryptWithPassword(encryptedData: string, password: string): Promise<string> {
     const data = Buffer.from(encryptedData, 'base64');
     const { version, salt, iv, authTag, encrypted } = extractEncryptedComponents(data);
 
-    if (!this.salt.equals(salt)) {
+    if (!Buffer.from(this.salt).equals(salt)) {
       throw new Error('Salt mismatch: data was encrypted with a different password');
     }
 
     const iterations = getIterationsForVersion(version);
-    const decryptionKey = version === CURRENT_ENCRYPTION_VERSION
-      ? this.encryptionKey
-      : this.deriveKey(password, salt, iterations);
+    let decryptionKey: Uint8Array;
+    if (version === CURRENT_ENCRYPTION_VERSION) {
+      decryptionKey = this.encryptionKey;
+    } else {
+      const passwordBytes = new TextEncoder().encode(password);
+      decryptionKey = await pbkdf2(passwordBytes, salt, iterations, KEY_LENGTH);
+    }
 
-    const decipher = createDecipheriv(ALGORITHM, decryptionKey, iv, { authTagLength: AUTH_TAG_LENGTH });
-    decipher.setAuthTag(authTag);
-
-    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
-    return decrypted.toString('utf-8');
+    const decrypted = await aesGcmDecrypt(decryptionKey, iv, encrypted, authTag);
+    return Buffer.from(decrypted).toString('utf-8');
   }
 
   static isEncrypted(data: string): boolean {
@@ -211,7 +271,7 @@ export class StorageEncryption {
   }
 
   getSalt(): Buffer {
-    return this.salt;
+    return Buffer.from(this.salt);
   }
 }
 
@@ -315,11 +375,11 @@ export const getPasswordFromProvider = async (provider: PrivateStoragePasswordPr
   return password;
 };
 
-export const decryptValue = (
+export const decryptValue = async (
   encryptedValue: string,
   encryption: StorageEncryption,
   password: string
-): string => {
+): Promise<string> => {
   if (!StorageEncryption.isEncrypted(encryptedValue)) {
     console.debug('MIDNIGHT: Encountered unencrypted data during decryption - passing through as-is');
     return encryptedValue;

--- a/packages/level-private-state-provider/src/test/crypto-backend-compat.test.ts
+++ b/packages/level-private-state-provider/src/test/crypto-backend-compat.test.ts
@@ -1,0 +1,53 @@
+import { NobleCryptoBackend } from '../crypto-backend-noble';
+import { WebCryptoCryptoBackend } from '../crypto-backend-webcrypto';
+
+describe('CryptoBackend cross-compatibility', () => {
+  const webcrypto = new WebCryptoCryptoBackend();
+  const noble = new NobleCryptoBackend();
+
+  const key = new Uint8Array(32);
+  key.fill(42);
+  const iv = new Uint8Array(12);
+  iv.fill(7);
+  const plaintext = new TextEncoder().encode('cross-backend test data');
+
+  describe('sha256 produces identical output', () => {
+    test('same input hashes match', async () => {
+      const input = new TextEncoder().encode('test input for sha256');
+      const webcryptoHash = await webcrypto.sha256(input);
+      const nobleHash = await noble.sha256(input);
+      expect(Buffer.from(webcryptoHash).toString('hex')).toBe(Buffer.from(nobleHash).toString('hex'));
+    });
+  });
+
+  describe('pbkdf2 produces identical output', () => {
+    test('same inputs derive same key', async () => {
+      const password = new TextEncoder().encode('Test-Password-123!');
+      const salt = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+      const webcryptoKey = await webcrypto.pbkdf2(password, salt, 1000, 32);
+      const nobleKey = await noble.pbkdf2(password, salt, 1000, 32);
+      expect(Buffer.from(webcryptoKey).toString('hex')).toBe(Buffer.from(nobleKey).toString('hex'));
+    });
+  });
+
+  describe('AES-GCM encrypt/decrypt interop', () => {
+    test('webcrypto encrypts, noble decrypts', async () => {
+      const { ciphertext, authTag } = await webcrypto.aesGcmEncrypt(key, iv, plaintext);
+      const decrypted = await noble.aesGcmDecrypt(key, iv, ciphertext, authTag);
+      expect(new TextDecoder().decode(decrypted)).toBe('cross-backend test data');
+    });
+
+    test('noble encrypts, webcrypto decrypts', async () => {
+      const { ciphertext, authTag } = await noble.aesGcmEncrypt(key, iv, plaintext);
+      const decrypted = await webcrypto.aesGcmDecrypt(key, iv, ciphertext, authTag);
+      expect(new TextDecoder().decode(decrypted)).toBe('cross-backend test data');
+    });
+
+    test('same inputs produce identical ciphertext', async () => {
+      const { ciphertext: wc, authTag: wcTag } = await webcrypto.aesGcmEncrypt(key, iv, plaintext);
+      const { ciphertext: nb, authTag: nbTag } = await noble.aesGcmEncrypt(key, iv, plaintext);
+      expect(Buffer.from(wc).toString('hex')).toBe(Buffer.from(nb).toString('hex'));
+      expect(Buffer.from(wcTag).toString('hex')).toBe(Buffer.from(nbTag).toString('hex'));
+    });
+  });
+});

--- a/packages/level-private-state-provider/src/test/crypto-backend-noble.test.ts
+++ b/packages/level-private-state-provider/src/test/crypto-backend-noble.test.ts
@@ -1,0 +1,99 @@
+import { NobleCryptoBackend } from '../crypto-backend-noble';
+
+describe('NobleCryptoBackend', () => {
+  const backend = new NobleCryptoBackend();
+
+  describe('randomBytes', () => {
+    test('returns Uint8Array of requested length', () => {
+      const result = backend.randomBytes(32);
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.length).toBe(32);
+    });
+
+    test('produces non-deterministic output', () => {
+      const a = backend.randomBytes(32);
+      const b = backend.randomBytes(32);
+      expect(Buffer.from(a).toString('hex')).not.toBe(Buffer.from(b).toString('hex'));
+    });
+  });
+
+  describe('sha256', () => {
+    test('produces correct hash for known input', async () => {
+      const input = new TextEncoder().encode('hello');
+      const result = await backend.sha256(input);
+      const hex = Buffer.from(result).toString('hex');
+      expect(hex).toBe('2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824');
+    });
+
+    test('produces 32-byte output', async () => {
+      const input = new TextEncoder().encode('test');
+      const result = await backend.sha256(input);
+      expect(result.length).toBe(32);
+    });
+  });
+
+  describe('pbkdf2', () => {
+    test('derives key of requested length', async () => {
+      const password = new TextEncoder().encode('password');
+      const salt = new Uint8Array(32);
+      const result = await backend.pbkdf2(password, salt, 1000, 32);
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.length).toBe(32);
+    });
+
+    test('same inputs produce same output', async () => {
+      const password = new TextEncoder().encode('password');
+      const salt = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+      const a = await backend.pbkdf2(password, salt, 1000, 32);
+      const b = await backend.pbkdf2(password, salt, 1000, 32);
+      expect(Buffer.from(a).toString('hex')).toBe(Buffer.from(b).toString('hex'));
+    });
+
+    test('different passwords produce different keys', async () => {
+      const salt = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+      const a = await backend.pbkdf2(new TextEncoder().encode('password1'), salt, 1000, 32);
+      const b = await backend.pbkdf2(new TextEncoder().encode('password2'), salt, 1000, 32);
+      expect(Buffer.from(a).toString('hex')).not.toBe(Buffer.from(b).toString('hex'));
+    });
+  });
+
+  describe('aesGcmEncrypt and aesGcmDecrypt', () => {
+    test('encrypt then decrypt roundtrip', async () => {
+      const key = new Uint8Array(32);
+      key.fill(1);
+      const iv = new Uint8Array(12);
+      iv.fill(2);
+      const plaintext = new TextEncoder().encode('secret message');
+
+      const { ciphertext, authTag } = await backend.aesGcmEncrypt(key, iv, plaintext);
+      expect(ciphertext.length).toBeGreaterThan(0);
+      expect(authTag.length).toBe(16);
+
+      const decrypted = await backend.aesGcmDecrypt(key, iv, ciphertext, authTag);
+      expect(new TextDecoder().decode(decrypted)).toBe('secret message');
+    });
+
+    test('decrypt fails with wrong key', async () => {
+      const key = new Uint8Array(32);
+      key.fill(1);
+      const wrongKey = new Uint8Array(32);
+      wrongKey.fill(9);
+      const iv = new Uint8Array(12);
+      const plaintext = new TextEncoder().encode('secret');
+
+      const { ciphertext, authTag } = await backend.aesGcmEncrypt(key, iv, plaintext);
+      await expect(backend.aesGcmDecrypt(wrongKey, iv, ciphertext, authTag)).rejects.toThrow();
+    });
+
+    test('decrypt fails with tampered ciphertext', async () => {
+      const key = new Uint8Array(32);
+      key.fill(1);
+      const iv = new Uint8Array(12);
+      const plaintext = new TextEncoder().encode('secret');
+
+      const { ciphertext, authTag } = await backend.aesGcmEncrypt(key, iv, plaintext);
+      ciphertext[0] ^= 0xff;
+      await expect(backend.aesGcmDecrypt(key, iv, ciphertext, authTag)).rejects.toThrow();
+    });
+  });
+});

--- a/packages/level-private-state-provider/src/test/crypto-backend-webcrypto.test.ts
+++ b/packages/level-private-state-provider/src/test/crypto-backend-webcrypto.test.ts
@@ -1,0 +1,99 @@
+import { WebCryptoCryptoBackend } from '../crypto-backend-webcrypto';
+
+describe('WebCryptoCryptoBackend', () => {
+  const backend = new WebCryptoCryptoBackend();
+
+  describe('randomBytes', () => {
+    test('returns Uint8Array of requested length', () => {
+      const result = backend.randomBytes(32);
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.length).toBe(32);
+    });
+
+    test('produces non-deterministic output', () => {
+      const a = backend.randomBytes(32);
+      const b = backend.randomBytes(32);
+      expect(Buffer.from(a).toString('hex')).not.toBe(Buffer.from(b).toString('hex'));
+    });
+  });
+
+  describe('sha256', () => {
+    test('produces correct hash for known input', async () => {
+      const input = new TextEncoder().encode('hello');
+      const result = await backend.sha256(input);
+      const hex = Buffer.from(result).toString('hex');
+      expect(hex).toBe('2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824');
+    });
+
+    test('produces 32-byte output', async () => {
+      const input = new TextEncoder().encode('test');
+      const result = await backend.sha256(input);
+      expect(result.length).toBe(32);
+    });
+  });
+
+  describe('pbkdf2', () => {
+    test('derives key of requested length', async () => {
+      const password = new TextEncoder().encode('password');
+      const salt = new Uint8Array(32);
+      const result = await backend.pbkdf2(password, salt, 1000, 32);
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.length).toBe(32);
+    });
+
+    test('same inputs produce same output', async () => {
+      const password = new TextEncoder().encode('password');
+      const salt = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+      const a = await backend.pbkdf2(password, salt, 1000, 32);
+      const b = await backend.pbkdf2(password, salt, 1000, 32);
+      expect(Buffer.from(a).toString('hex')).toBe(Buffer.from(b).toString('hex'));
+    });
+
+    test('different passwords produce different keys', async () => {
+      const salt = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+      const a = await backend.pbkdf2(new TextEncoder().encode('password1'), salt, 1000, 32);
+      const b = await backend.pbkdf2(new TextEncoder().encode('password2'), salt, 1000, 32);
+      expect(Buffer.from(a).toString('hex')).not.toBe(Buffer.from(b).toString('hex'));
+    });
+  });
+
+  describe('aesGcmEncrypt and aesGcmDecrypt', () => {
+    test('encrypt then decrypt roundtrip', async () => {
+      const key = new Uint8Array(32);
+      key.fill(1);
+      const iv = new Uint8Array(12);
+      iv.fill(2);
+      const plaintext = new TextEncoder().encode('secret message');
+
+      const { ciphertext, authTag } = await backend.aesGcmEncrypt(key, iv, plaintext);
+      expect(ciphertext.length).toBeGreaterThan(0);
+      expect(authTag.length).toBe(16);
+
+      const decrypted = await backend.aesGcmDecrypt(key, iv, ciphertext, authTag);
+      expect(new TextDecoder().decode(decrypted)).toBe('secret message');
+    });
+
+    test('decrypt fails with wrong key', async () => {
+      const key = new Uint8Array(32);
+      key.fill(1);
+      const wrongKey = new Uint8Array(32);
+      wrongKey.fill(9);
+      const iv = new Uint8Array(12);
+      const plaintext = new TextEncoder().encode('secret');
+
+      const { ciphertext, authTag } = await backend.aesGcmEncrypt(key, iv, plaintext);
+      await expect(backend.aesGcmDecrypt(wrongKey, iv, ciphertext, authTag)).rejects.toThrow();
+    });
+
+    test('decrypt fails with tampered ciphertext', async () => {
+      const key = new Uint8Array(32);
+      key.fill(1);
+      const iv = new Uint8Array(12);
+      const plaintext = new TextEncoder().encode('secret');
+
+      const { ciphertext, authTag } = await backend.aesGcmEncrypt(key, iv, plaintext);
+      ciphertext[0] ^= 0xff;
+      await expect(backend.aesGcmDecrypt(key, iv, ciphertext, authTag)).rejects.toThrow();
+    });
+  });
+});

--- a/packages/level-private-state-provider/src/test/crypto-backend.test.ts
+++ b/packages/level-private-state-provider/src/test/crypto-backend.test.ts
@@ -1,0 +1,43 @@
+import { resolveCryptoBackend } from '../crypto-backend';
+import { NobleCryptoBackend } from '../crypto-backend-noble';
+import { WebCryptoCryptoBackend } from '../crypto-backend-webcrypto';
+
+describe('resolveCryptoBackend', () => {
+  test('returns NobleCryptoBackend when noble is requested', () => {
+    const backend = resolveCryptoBackend('noble');
+    expect(backend).toBeInstanceOf(NobleCryptoBackend);
+  });
+
+  test('returns WebCryptoCryptoBackend when webcrypto is requested', () => {
+    const backend = resolveCryptoBackend('webcrypto');
+    expect(backend).toBeInstanceOf(WebCryptoCryptoBackend);
+  });
+
+  test('auto-detects WebCrypto when available (default in Node.js)', () => {
+    const backend = resolveCryptoBackend();
+    expect(backend).toBeInstanceOf(WebCryptoCryptoBackend);
+  });
+
+  test('throws when webcrypto requested but unavailable', () => {
+    const originalCrypto = globalThis.crypto;
+    Object.defineProperty(globalThis, 'crypto', { value: undefined, configurable: true });
+    try {
+      expect(() => resolveCryptoBackend('webcrypto')).toThrow(
+        'Web Crypto API is not available',
+      );
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', { value: originalCrypto, configurable: true });
+    }
+  });
+
+  test('falls back to noble when WebCrypto unavailable and no preference', () => {
+    const originalCrypto = globalThis.crypto;
+    Object.defineProperty(globalThis, 'crypto', { value: undefined, configurable: true });
+    try {
+      const backend = resolveCryptoBackend();
+      expect(backend).toBeInstanceOf(NobleCryptoBackend);
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', { value: originalCrypto, configurable: true });
+    }
+  });
+});

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -701,8 +701,8 @@ describe('Level Private State Provider', (): void => {
 
         // Create encryption with a known salt and encrypt non-JSON data
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const notJson = encryption.encrypt('this is not JSON');
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const notJson = await encryption.encrypt('this is not JSON');
 
         const badExport: PrivateStateExport = {
           format: 'midnight-private-state-export',
@@ -720,9 +720,9 @@ describe('Level Private State Provider', (): void => {
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
         // Valid JSON but missing required 'states' field
-        const invalidPayload = encryption.encrypt(JSON.stringify({
+        const invalidPayload = await encryption.encrypt(JSON.stringify({
           version: 1,
           exportedAt: new Date().toISOString(),
           stateCount: 0
@@ -745,9 +745,9 @@ describe('Level Private State Provider', (): void => {
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
         // Valid JSON but missing required 'version' field
-        const invalidPayload = encryption.encrypt(JSON.stringify({
+        const invalidPayload = await encryption.encrypt(JSON.stringify({
           exportedAt: new Date().toISOString(),
           stateCount: 0,
           states: {}
@@ -769,9 +769,9 @@ describe('Level Private State Provider', (): void => {
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
         // stateCount says 5 but only 1 state present
-        const mismatchedPayload = encryption.encrypt(JSON.stringify({
+        const mismatchedPayload = await encryption.encrypt(JSON.stringify({
           version: 1,
           exportedAt: new Date().toISOString(),
           stateCount: 5,
@@ -796,8 +796,8 @@ describe('Level Private State Provider', (): void => {
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const unsupportedVersionPayload = encryption.encrypt(JSON.stringify({
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const unsupportedVersionPayload = await encryption.encrypt(JSON.stringify({
           version: 999,
           exportedAt: new Date().toISOString(),
           stateCount: 0,
@@ -820,9 +820,9 @@ describe('Level Private State Provider', (): void => {
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
         // State value is not valid superjson
-        const invalidStatePayload = encryption.encrypt(JSON.stringify({
+        const invalidStatePayload = await encryption.encrypt(JSON.stringify({
           version: 1,
           exportedAt: new Date().toISOString(),
           stateCount: 1,
@@ -884,8 +884,8 @@ describe('Level Private State Provider', (): void => {
         // Uppercase hex should still be valid (the regex allows both cases)
         const uppercaseSalt = 'A'.repeat(64);
         const salt = Buffer.from(uppercaseSalt, 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const validPayload = encryption.encrypt(JSON.stringify({
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const validPayload = await encryption.encrypt(JSON.stringify({
           version: 1,
           exportedAt: new Date().toISOString(),
           stateCount: 0,
@@ -1188,8 +1188,8 @@ describe('Level Private State Provider', (): void => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const notJson = encryption.encrypt('this is not JSON');
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const notJson = await encryption.encrypt('this is not JSON');
 
         const badExport: SigningKeyExport = {
           format: 'midnight-signing-key-export',
@@ -1206,8 +1206,8 @@ describe('Level Private State Provider', (): void => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const invalidPayload = encryption.encrypt(JSON.stringify({
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const invalidPayload = await encryption.encrypt(JSON.stringify({
           version: 1,
           exportedAt: new Date().toISOString(),
           keyCount: 0
@@ -1228,8 +1228,8 @@ describe('Level Private State Provider', (): void => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const invalidPayload = encryption.encrypt(JSON.stringify({
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const invalidPayload = await encryption.encrypt(JSON.stringify({
           exportedAt: new Date().toISOString(),
           keyCount: 0,
           keys: {}
@@ -1250,8 +1250,8 @@ describe('Level Private State Provider', (): void => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const mismatchedPayload = encryption.encrypt(JSON.stringify({
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const mismatchedPayload = await encryption.encrypt(JSON.stringify({
           version: 1,
           exportedAt: new Date().toISOString(),
           keyCount: 5,
@@ -1275,8 +1275,8 @@ describe('Level Private State Provider', (): void => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = new StorageEncryption(VALID_PASSWORD, salt);
-        const unsupportedVersionPayload = encryption.encrypt(JSON.stringify({
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const unsupportedVersionPayload = await encryption.encrypt(JSON.stringify({
           version: 999,
           exportedAt: new Date().toISOString(),
           keyCount: 0,
@@ -1574,11 +1574,11 @@ describe('Level Private State Provider', (): void => {
 
       await db.set('key-1', 'value-1');
       expect(verifyPasswordSpy).toHaveBeenCalledTimes(1);
-      expect(verifyPasswordSpy).toHaveLastReturnedWith(true);
+      await expect(verifyPasswordSpy).toHaveLastResolvedWith(true);
 
       await db.set('key-2', 'value-2');
       expect(verifyPasswordSpy).toHaveBeenCalledTimes(2);
-      expect(verifyPasswordSpy).toHaveLastReturnedWith(true);
+      await expect(verifyPasswordSpy).toHaveLastResolvedWith(true);
 
       verifyPasswordSpy.mockRestore();
     });
@@ -2528,9 +2528,9 @@ describe('Level Private State Provider', (): void => {
         await level.open();
         await unscopedSubLevel.open();
 
-        const encryption = new StorageEncryption(TEST_PASSWORD);
-        await unscopedSubLevel.put('contract1:state1', encryption.encrypt(superjson.stringify('value1')));
-        await unscopedSubLevel.put('contract1:state2', encryption.encrypt(superjson.stringify('value2')));
+        const encryption = await StorageEncryption.create(TEST_PASSWORD);
+        await unscopedSubLevel.put('contract1:state1', await encryption.encrypt(superjson.stringify('value1')));
+        await unscopedSubLevel.put('contract1:state2', await encryption.encrypt(superjson.stringify('value2')));
       } finally {
         await unscopedSubLevel.close();
         await level.close();
@@ -2555,8 +2555,8 @@ describe('Level Private State Provider', (): void => {
         await level.open();
         await unscopedSubLevel.open();
 
-        const encryption = new StorageEncryption(TEST_PASSWORD);
-        await unscopedSubLevel.put('contract1', encryption.encrypt(superjson.stringify({ key: 'data' })));
+        const encryption = await StorageEncryption.create(TEST_PASSWORD);
+        await unscopedSubLevel.put('contract1', await encryption.encrypt(superjson.stringify({ key: 'data' })));
       } finally {
         await unscopedSubLevel.close();
         await level.close();
@@ -2605,7 +2605,7 @@ describe('Level Private State Provider', (): void => {
         valueEncoding: 'utf-8'
       });
 
-      const encryption = new StorageEncryption(TEST_PASSWORD);
+      const encryption = await StorageEncryption.create(TEST_PASSWORD);
       const CONTRACT_ADDR = 'test-contract' as ContractAddress;
       const METADATA_KEY = '__midnight_encryption_metadata__';
 
@@ -2617,7 +2617,7 @@ describe('Level Private State Provider', (): void => {
         await unscopedSubLevel.put(METADATA_KEY, JSON.stringify(metadata));
         await unscopedSubLevel.put(
           `${CONTRACT_ADDR}:migrated-key`,
-          encryption.encrypt(superjson.stringify('migrated-value'))
+          await encryption.encrypt(superjson.stringify('migrated-value'))
         );
       } finally {
         await unscopedSubLevel.close();
@@ -2646,7 +2646,7 @@ describe('Level Private State Provider', (): void => {
         valueEncoding: 'utf-8'
       });
 
-      const encryption = new StorageEncryption(TEST_PASSWORD);
+      const encryption = await StorageEncryption.create(TEST_PASSWORD);
       const CONTRACT_ADDR = 'test-contract' as ContractAddress;
       const METADATA_KEY = '__midnight_encryption_metadata__';
 
@@ -2658,7 +2658,7 @@ describe('Level Private State Provider', (): void => {
         await unscopedSubLevel.put(METADATA_KEY, JSON.stringify(metadata));
         await unscopedSubLevel.put(
           `${CONTRACT_ADDR}:idempotent-key`,
-          encryption.encrypt(superjson.stringify('idempotent-value'))
+          await encryption.encrypt(superjson.stringify('idempotent-value'))
         );
       } finally {
         await unscopedSubLevel.close();
@@ -2695,8 +2695,8 @@ describe('Level Private State Provider', (): void => {
         valueEncoding: 'utf-8'
       });
 
-      const encryption = new StorageEncryption(TEST_PASSWORD);
-      const originalEncryptedValue = encryption.encrypt(superjson.stringify('original-value'));
+      const encryption = await StorageEncryption.create(TEST_PASSWORD);
+      const originalEncryptedValue = await encryption.encrypt(superjson.stringify('original-value'));
 
       try {
         await level.open();

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -701,7 +701,7 @@ describe('Level Private State Provider', (): void => {
 
         // Create encryption with a known salt and encrypt non-JSON data
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, { existingSalt: salt });
         const notJson = await encryption.encrypt('this is not JSON');
 
         const badExport: PrivateStateExport = {
@@ -720,7 +720,7 @@ describe('Level Private State Provider', (): void => {
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, { existingSalt: salt });
         // Valid JSON but missing required 'states' field
         const invalidPayload = await encryption.encrypt(JSON.stringify({
           version: 1,
@@ -745,7 +745,7 @@ describe('Level Private State Provider', (): void => {
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, { existingSalt: salt });
         // Valid JSON but missing required 'version' field
         const invalidPayload = await encryption.encrypt(JSON.stringify({
           exportedAt: new Date().toISOString(),
@@ -769,7 +769,7 @@ describe('Level Private State Provider', (): void => {
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, { existingSalt: salt });
         // stateCount says 5 but only 1 state present
         const mismatchedPayload = await encryption.encrypt(JSON.stringify({
           version: 1,
@@ -796,7 +796,7 @@ describe('Level Private State Provider', (): void => {
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, { existingSalt: salt });
         const unsupportedVersionPayload = await encryption.encrypt(JSON.stringify({
           version: 999,
           exportedAt: new Date().toISOString(),
@@ -820,7 +820,7 @@ describe('Level Private State Provider', (): void => {
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, { existingSalt: salt });
         // State value is not valid superjson
         const invalidStatePayload = await encryption.encrypt(JSON.stringify({
           version: 1,
@@ -884,7 +884,7 @@ describe('Level Private State Provider', (): void => {
         // Uppercase hex should still be valid (the regex allows both cases)
         const uppercaseSalt = 'A'.repeat(64);
         const salt = Buffer.from(uppercaseSalt, 'hex');
-        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, { existingSalt: salt });
         const validPayload = await encryption.encrypt(JSON.stringify({
           version: 1,
           exportedAt: new Date().toISOString(),
@@ -1188,7 +1188,7 @@ describe('Level Private State Provider', (): void => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, { existingSalt: salt });
         const notJson = await encryption.encrypt('this is not JSON');
 
         const badExport: SigningKeyExport = {
@@ -1206,7 +1206,7 @@ describe('Level Private State Provider', (): void => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, { existingSalt: salt });
         const invalidPayload = await encryption.encrypt(JSON.stringify({
           version: 1,
           exportedAt: new Date().toISOString(),
@@ -1228,7 +1228,7 @@ describe('Level Private State Provider', (): void => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, { existingSalt: salt });
         const invalidPayload = await encryption.encrypt(JSON.stringify({
           exportedAt: new Date().toISOString(),
           keyCount: 0,
@@ -1250,7 +1250,7 @@ describe('Level Private State Provider', (): void => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, { existingSalt: salt });
         const mismatchedPayload = await encryption.encrypt(JSON.stringify({
           version: 1,
           exportedAt: new Date().toISOString(),
@@ -1275,7 +1275,7 @@ describe('Level Private State Provider', (): void => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
 
         const salt = Buffer.from('0'.repeat(64), 'hex');
-        const encryption = await StorageEncryption.create(VALID_PASSWORD, salt);
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, { existingSalt: salt });
         const unsupportedVersionPayload = await encryption.encrypt(JSON.stringify({
           version: 999,
           exportedAt: new Date().toISOString(),

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -1614,7 +1614,7 @@ describe('Level Private State Provider', (): void => {
       db.setContractAddress(CACHE_CONTRACT_ADDRESS);
       await db.set('test-key', 'test-value');
 
-      db.invalidateEncryptionCache();
+      await db.invalidateEncryptionCache();
 
       const value = await db.get('test-key');
       expect(value).toBe('test-value');

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -31,7 +31,7 @@ import { Level } from 'level';
 import * as superjson from 'superjson';
 import { vi } from 'vitest';
 
-import { levelPrivateStateProvider, migrateToAccountScoped } from '../index';
+import { type DatabaseLevel, levelPrivateStateProvider, migrateToAccountScoped } from '../index';
 import { StorageEncryption } from '../storage-encryption';
 
 describe('Level Private State Provider', (): void => {
@@ -2725,6 +2725,64 @@ describe('Level Private State Provider', (): void => {
       } finally {
         await unscopedAfter.close();
         await levelAfter.close();
+      }
+    });
+  });
+
+  describe('levelFactory', () => {
+    const FACTORY_DB_NAME = 'test-custom-factory-db';
+
+    afterAll(async () => {
+      await fs.rm(path.join('.', FACTORY_DB_NAME), { recursive: true, force: true });
+    });
+
+    const createLevel = (dbName: string): DatabaseLevel =>
+      new Level(dbName, { createIfMissing: true }) as DatabaseLevel;
+
+    test('custom levelFactory is invoked on get/set operations', async () => {
+      const factory = vi.fn(createLevel);
+      const db = levelPrivateStateProvider<PID, PS>({
+        ...testConfig,
+        midnightDbName: FACTORY_DB_NAME,
+        levelFactory: factory,
+      });
+      db.setContractAddress(TEST_CONTRACT_ADDRESS);
+
+      await db.set('stringValue', 'value');
+      await db.get('stringValue');
+
+      expect(factory).toHaveBeenCalled();
+      expect(factory.mock.calls.every(([name]) => name === FACTORY_DB_NAME)).toBe(true);
+    });
+
+    test('set/get roundtrip works with custom levelFactory', async () => {
+      const db = levelPrivateStateProvider<PID, PS>({
+        ...testConfig,
+        midnightDbName: FACTORY_DB_NAME,
+        levelFactory: createLevel,
+      });
+      db.setContractAddress(TEST_CONTRACT_ADDRESS);
+
+      await db.set('numberValue', 42);
+      const value = await db.get('numberValue');
+      expect(value).toBe(42);
+    });
+
+    test('migrateToAccountScoped uses custom levelFactory', async () => {
+      const migrationDbName = 'test-migration-factory-db';
+      const factory = vi.fn(createLevel);
+
+      try {
+        await migrateToAccountScoped({
+          accountId: TEST_ACCOUNT_ID,
+          midnightDbName: migrationDbName,
+          levelFactory: factory,
+        });
+
+        expect(factory).toHaveBeenCalled();
+        expect(factory.mock.calls.every(([name]) => name === migrationDbName)).toBe(true);
+      } finally {
+        await fs.rm(path.join('.', migrationDbName), { recursive: true, force: true });
       }
     });
   });

--- a/packages/level-private-state-provider/src/test/storage-encryption.test.ts
+++ b/packages/level-private-state-provider/src/test/storage-encryption.test.ts
@@ -29,135 +29,135 @@ describe('StorageEncryption', () => {
   };
 
   describe('encrypt and decrypt', () => {
-    test('successfully encrypts and decrypts data', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('successfully encrypts and decrypts data', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      const encrypted = encryption.encrypt(testData);
-      const decrypted = encryption.decrypt(encrypted);
+      const encrypted = await encryption.encrypt(testData);
+      const decrypted = await encryption.decrypt(encrypted);
 
       expect(decrypted).toBe(testData);
       expect(decrypted).not.toBe(encrypted);
     });
 
-    test('produces different ciphertext for same plaintext', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('produces different ciphertext for same plaintext', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      const encrypted1 = encryption.encrypt(testData);
-      const encrypted2 = encryption.encrypt(testData);
+      const encrypted1 = await encryption.encrypt(testData);
+      const encrypted2 = await encryption.encrypt(testData);
 
       expect(encrypted1).not.toBe(encrypted2);
-      expect(encryption.decrypt(encrypted1)).toBe(testData);
-      expect(encryption.decrypt(encrypted2)).toBe(testData);
+      expect(await encryption.decrypt(encrypted1)).toBe(testData);
+      expect(await encryption.decrypt(encrypted2)).toBe(testData);
     });
 
-    test('handles empty string', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('handles empty string', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      const encrypted = encryption.encrypt('');
-      const decrypted = encryption.decrypt(encrypted);
+      const encrypted = await encryption.encrypt('');
+      const decrypted = await encryption.decrypt(encrypted);
 
       expect(decrypted).toBe('');
     });
 
-    test('handles unicode characters', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('handles unicode characters', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
       const unicodeData = '🔐 Encrypted data with émojis and spëcial çhars 中文';
 
-      const encrypted = encryption.encrypt(unicodeData);
-      const decrypted = encryption.decrypt(encrypted);
+      const encrypted = await encryption.encrypt(unicodeData);
+      const decrypted = await encryption.decrypt(encrypted);
 
       expect(decrypted).toBe(unicodeData);
     });
   });
 
   describe('error handling', () => {
-    test('throws on wrong password', () => {
-      const encryption1 = new StorageEncryption('Correct-Pass-123!');
-      const encrypted = encryption1.encrypt(testData);
+    test('throws on wrong password', async () => {
+      const encryption1 = await StorageEncryption.create('Correct-Pass-123!');
+      const encrypted = await encryption1.encrypt(testData);
 
-      const encryption2 = new StorageEncryption('Wrong-Password-1!', encryption1.getSalt());
+      const encryption2 = await StorageEncryption.create('Wrong-Password-1!', encryption1.getSalt());
 
-      expect(() => encryption2.decrypt(encrypted)).toThrow();
+      await expect(encryption2.decrypt(encrypted)).rejects.toThrow();
     });
   });
 
   describe('version migration', () => {
-    test('decrypts v1 encrypted data with 100k iterations using decryptWithPassword', () => {
+    test('decrypts v1 encrypted data with 100k iterations using decryptWithPassword', async () => {
       const salt = Buffer.from(V1_FIXTURES.salt, 'hex');
-      const encryption = new StorageEncryption(V1_FIXTURES.password, salt);
+      const encryption = await StorageEncryption.create(V1_FIXTURES.password, salt);
 
-      const decrypted = encryption.decryptWithPassword(V1_FIXTURES.encrypted, V1_FIXTURES.password);
+      const decrypted = await encryption.decryptWithPassword(V1_FIXTURES.encrypted, V1_FIXTURES.password);
 
       expect(decrypted).toBe(V1_FIXTURES.plaintext);
     });
 
-    test('new encryption uses version 2', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('new encryption uses version 2', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      const encrypted = encryption.encrypt(testData);
+      const encrypted = await encryption.encrypt(testData);
       const buffer = Buffer.from(encrypted, 'base64');
 
       expect(buffer[0]).toBe(2);
     });
 
-    test('v2 encrypted data can be decrypted', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('v2 encrypted data can be decrypted', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      const encrypted = encryption.encrypt(testData);
-      const decrypted = encryption.decrypt(encrypted);
+      const encrypted = await encryption.encrypt(testData);
+      const decrypted = await encryption.decrypt(encrypted);
 
       expect(decrypted).toBe(testData);
     });
 
-    test('detects encryption version correctly', () => {
+    test('detects encryption version correctly', async () => {
       expect(StorageEncryption.getVersion(V1_FIXTURES.encrypted)).toBe(1);
 
-      const encryption = new StorageEncryption(testPassword);
-      const v2Encrypted = encryption.encrypt(testData);
+      const encryption = await StorageEncryption.create(testPassword);
+      const v2Encrypted = await encryption.encrypt(testData);
       expect(StorageEncryption.getVersion(v2Encrypted)).toBe(2);
     });
 
-    test('decrypt throws when V1 data is encountered without password', () => {
+    test('decrypt throws when V1 data is encountered without password', async () => {
       const salt = Buffer.from(V1_FIXTURES.salt, 'hex');
-      const encryption = new StorageEncryption(V1_FIXTURES.password, salt);
+      const encryption = await StorageEncryption.create(V1_FIXTURES.password, salt);
 
-      expect(() => encryption.decrypt(V1_FIXTURES.encrypted)).toThrow(
+      await expect(encryption.decrypt(V1_FIXTURES.encrypted)).rejects.toThrow(
         'V1 encrypted data requires password for decryption'
       );
     });
 
-    test('decryptWithPassword works for V2 data as well', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('decryptWithPassword works for V2 data as well', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      const encrypted = encryption.encrypt(testData);
-      const decrypted = encryption.decryptWithPassword(encrypted, testPassword);
+      const encrypted = await encryption.encrypt(testData);
+      const decrypted = await encryption.decryptWithPassword(encrypted, testPassword);
 
       expect(decrypted).toBe(testData);
     });
   });
 
   describe('password verification', () => {
-    test('verifyPassword returns true for correct password', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('verifyPassword returns true for correct password', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      expect(encryption.verifyPassword(testPassword)).toBe(true);
+      expect(await encryption.verifyPassword(testPassword)).toBe(true);
     });
 
-    test('verifyPassword returns false for incorrect password', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('verifyPassword returns false for incorrect password', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      expect(encryption.verifyPassword('Wrong-Password-1!')).toBe(false);
+      expect(await encryption.verifyPassword('Wrong-Password-1!')).toBe(false);
     });
 
-    test('verifyPassword is case-sensitive', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('verifyPassword is case-sensitive', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
-      expect(encryption.verifyPassword(testPassword.toLowerCase())).toBe(false);
-      expect(encryption.verifyPassword(testPassword.toUpperCase())).toBe(false);
+      expect(await encryption.verifyPassword(testPassword.toLowerCase())).toBe(false);
+      expect(await encryption.verifyPassword(testPassword.toUpperCase())).toBe(false);
     });
 
-    test('password is not stored in plaintext', () => {
-      const encryption = new StorageEncryption(testPassword);
+    test('password is not stored in plaintext', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
 
       const encryptionAsRecord = encryption as unknown as Record<string, unknown>;
       const allValues = Object.values(encryptionAsRecord);
@@ -205,20 +205,6 @@ describe('StorageEncryption', () => {
     const a = Buffer.from([]);
     const b = Buffer.from([]);
     expect(timingSafeEqual(a, b)).toBe(true);
-  });
-
-  test('timingSafeEqual fallback is used if native is missing', () => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const crypto = require('crypto');
-    const orig = crypto.timingSafeEqual;
-    crypto.timingSafeEqual = undefined;
-    // Use dynamic import to force re-evaluation
-    return import('../storage-encryption').then(mod => {
-      const a = Buffer.from([1, 2, 3]);
-      const b = Buffer.from([1, 2, 3]);
-      expect(mod.timingSafeEqual(a, b)).toBe(true);
-      crypto.timingSafeEqual = orig;
-    });
   });
 
   describe('getPasswordFromProvider', () => {

--- a/packages/level-private-state-provider/src/test/storage-encryption.test.ts
+++ b/packages/level-private-state-provider/src/test/storage-encryption.test.ts
@@ -430,3 +430,75 @@ describe('StorageEncryption', () => {
     });
   });
 });
+
+describe('StorageEncryption with noble backend', () => {
+  const testPassword = 'Test-Password-123!';
+  const testData = 'sensitive data that needs encryption';
+
+  const V1_FIXTURES = {
+    password: 'Test-Password-123!',
+    plaintext: 'sensitive data for v1 migration test',
+    encrypted: 'AYse8BxWbiRb618I8CQKwLJoGyzx0zddBBQ3LORO2wBSgi/4kHm3CqznHcvmSNPw5Y0wW9XDhweunjM/zyq8cHVQYoS53gzsFYEae5imclcA03IJN2Rr5Gf+z1GNd5J5Vg==',
+    salt: '8b1ef01c566e245beb5f08f0240ac0b2681b2cf1d3375d0414372ce44edb0052',
+  };
+
+  describe('encrypt and decrypt', () => {
+    test('successfully encrypts and decrypts data', async () => {
+      const encryption = await StorageEncryption.create(testPassword, { cryptoBackend: 'noble' });
+
+      const encrypted = await encryption.encrypt(testData);
+      const decrypted = await encryption.decrypt(encrypted);
+
+      expect(decrypted).toBe(testData);
+    });
+
+    test('handles unicode characters', async () => {
+      const encryption = await StorageEncryption.create(testPassword, { cryptoBackend: 'noble' });
+      const unicodeData = '🔐 Encrypted data with émojis and spëcial çhars 中文';
+
+      const encrypted = await encryption.encrypt(unicodeData);
+      const decrypted = await encryption.decrypt(encrypted);
+
+      expect(decrypted).toBe(unicodeData);
+    });
+  });
+
+  describe('V1 backward compatibility', () => {
+    test('decrypts V1 encrypted data using decryptWithPassword', async () => {
+      const salt = Buffer.from(V1_FIXTURES.salt, 'hex');
+      const encryption = await StorageEncryption.create(V1_FIXTURES.password, { existingSalt: salt, cryptoBackend: 'noble' });
+
+      const decrypted = await encryption.decryptWithPassword(V1_FIXTURES.encrypted, V1_FIXTURES.password);
+
+      expect(decrypted).toBe(V1_FIXTURES.plaintext);
+    });
+  });
+
+  describe('cross-backend data interop', () => {
+    test('data encrypted with webcrypto can be decrypted with noble', async () => {
+      const webcryptoEncryption = await StorageEncryption.create(testPassword, { cryptoBackend: 'webcrypto' });
+      const encrypted = await webcryptoEncryption.encrypt(testData);
+
+      const nobleEncryption = await StorageEncryption.create(testPassword, {
+        existingSalt: webcryptoEncryption.getSalt(),
+        cryptoBackend: 'noble',
+      });
+      const decrypted = await nobleEncryption.decrypt(encrypted);
+
+      expect(decrypted).toBe(testData);
+    });
+
+    test('data encrypted with noble can be decrypted with webcrypto', async () => {
+      const nobleEncryption = await StorageEncryption.create(testPassword, { cryptoBackend: 'noble' });
+      const encrypted = await nobleEncryption.encrypt(testData);
+
+      const webcryptoEncryption = await StorageEncryption.create(testPassword, {
+        existingSalt: nobleEncryption.getSalt(),
+        cryptoBackend: 'webcrypto',
+      });
+      const decrypted = await webcryptoEncryption.decrypt(encrypted);
+
+      expect(decrypted).toBe(testData);
+    });
+  });
+});

--- a/packages/level-private-state-provider/src/test/storage-encryption.test.ts
+++ b/packages/level-private-state-provider/src/test/storage-encryption.test.ts
@@ -75,7 +75,7 @@ describe('StorageEncryption', () => {
       const encryption1 = await StorageEncryption.create('Correct-Pass-123!');
       const encrypted = await encryption1.encrypt(testData);
 
-      const encryption2 = await StorageEncryption.create('Wrong-Password-1!', encryption1.getSalt());
+      const encryption2 = await StorageEncryption.create('Wrong-Password-1!', { existingSalt: encryption1.getSalt() });
 
       await expect(encryption2.decrypt(encrypted)).rejects.toThrow();
     });
@@ -97,7 +97,7 @@ describe('StorageEncryption', () => {
       const salt = new Uint8Array(32);
       globalThis.crypto.getRandomValues(salt);
 
-      const encryption = await StorageEncryption.create(testPassword, salt);
+      const encryption = await StorageEncryption.create(testPassword, { existingSalt: salt });
       const encrypted = await encryption.encrypt(testData);
       const decrypted = await encryption.decrypt(encrypted);
 
@@ -108,8 +108,8 @@ describe('StorageEncryption', () => {
       const rawBytes = new Uint8Array(32);
       globalThis.crypto.getRandomValues(rawBytes);
 
-      const encryptionFromUint8 = await StorageEncryption.create(testPassword, rawBytes);
-      const encryptionFromBuffer = await StorageEncryption.create(testPassword, Buffer.from(rawBytes));
+      const encryptionFromUint8 = await StorageEncryption.create(testPassword, { existingSalt: rawBytes });
+      const encryptionFromBuffer = await StorageEncryption.create(testPassword, { existingSalt: Buffer.from(rawBytes) });
 
       expect(encryptionFromUint8.getSalt()).toEqual(encryptionFromBuffer.getSalt());
     });
@@ -136,7 +136,7 @@ describe('StorageEncryption', () => {
 
     test('decrypts V1 encrypted data with password', async () => {
       const salt = Buffer.from(V1_FIXTURES.salt, 'hex');
-      const encryption = await StorageEncryption.create(V1_FIXTURES.password, salt);
+      const encryption = await StorageEncryption.create(V1_FIXTURES.password, { existingSalt: salt });
 
       const result = await decryptValue(V1_FIXTURES.encrypted, encryption, V1_FIXTURES.password);
 
@@ -147,7 +147,7 @@ describe('StorageEncryption', () => {
   describe('version migration', () => {
     test('decrypts v1 encrypted data with 100k iterations using decryptWithPassword', async () => {
       const salt = Buffer.from(V1_FIXTURES.salt, 'hex');
-      const encryption = await StorageEncryption.create(V1_FIXTURES.password, salt);
+      const encryption = await StorageEncryption.create(V1_FIXTURES.password, { existingSalt: salt });
 
       const decrypted = await encryption.decryptWithPassword(V1_FIXTURES.encrypted, V1_FIXTURES.password);
 
@@ -182,7 +182,7 @@ describe('StorageEncryption', () => {
 
     test('decrypt throws when V1 data is encountered without password', async () => {
       const salt = Buffer.from(V1_FIXTURES.salt, 'hex');
-      const encryption = await StorageEncryption.create(V1_FIXTURES.password, salt);
+      const encryption = await StorageEncryption.create(V1_FIXTURES.password, { existingSalt: salt });
 
       await expect(encryption.decrypt(V1_FIXTURES.encrypted)).rejects.toThrow(
         'V1 encrypted data requires password for decryption'

--- a/packages/level-private-state-provider/src/test/storage-encryption.test.ts
+++ b/packages/level-private-state-provider/src/test/storage-encryption.test.ts
@@ -442,22 +442,25 @@ describe('StorageEncryption with noble backend', () => {
     salt: '8b1ef01c566e245beb5f08f0240ac0b2681b2cf1d3375d0414372ce44edb0052',
   };
 
+  let nobleEncryption: StorageEncryption;
+
+  beforeAll(async () => {
+    nobleEncryption = await StorageEncryption.create(testPassword, { cryptoBackend: 'noble' });
+  }, 30_000);
+
   describe('encrypt and decrypt', () => {
     test('successfully encrypts and decrypts data', async () => {
-      const encryption = await StorageEncryption.create(testPassword, { cryptoBackend: 'noble' });
-
-      const encrypted = await encryption.encrypt(testData);
-      const decrypted = await encryption.decrypt(encrypted);
+      const encrypted = await nobleEncryption.encrypt(testData);
+      const decrypted = await nobleEncryption.decrypt(encrypted);
 
       expect(decrypted).toBe(testData);
     });
 
     test('handles unicode characters', async () => {
-      const encryption = await StorageEncryption.create(testPassword, { cryptoBackend: 'noble' });
       const unicodeData = '🔐 Encrypted data with émojis and spëcial çhars 中文';
 
-      const encrypted = await encryption.encrypt(unicodeData);
-      const decrypted = await encryption.decrypt(encrypted);
+      const encrypted = await nobleEncryption.encrypt(unicodeData);
+      const decrypted = await nobleEncryption.decrypt(encrypted);
 
       expect(decrypted).toBe(unicodeData);
     });
@@ -471,7 +474,7 @@ describe('StorageEncryption with noble backend', () => {
       const decrypted = await encryption.decryptWithPassword(V1_FIXTURES.encrypted, V1_FIXTURES.password);
 
       expect(decrypted).toBe(V1_FIXTURES.plaintext);
-    });
+    }, 30_000);
   });
 
   describe('cross-backend data interop', () => {
@@ -479,17 +482,16 @@ describe('StorageEncryption with noble backend', () => {
       const webcryptoEncryption = await StorageEncryption.create(testPassword, { cryptoBackend: 'webcrypto' });
       const encrypted = await webcryptoEncryption.encrypt(testData);
 
-      const nobleEncryption = await StorageEncryption.create(testPassword, {
+      const interopNoble = await StorageEncryption.create(testPassword, {
         existingSalt: webcryptoEncryption.getSalt(),
         cryptoBackend: 'noble',
       });
-      const decrypted = await nobleEncryption.decrypt(encrypted);
+      const decrypted = await interopNoble.decrypt(encrypted);
 
       expect(decrypted).toBe(testData);
-    });
+    }, 30_000);
 
     test('data encrypted with noble can be decrypted with webcrypto', async () => {
-      const nobleEncryption = await StorageEncryption.create(testPassword, { cryptoBackend: 'noble' });
       const encrypted = await nobleEncryption.encrypt(testData);
 
       const webcryptoEncryption = await StorageEncryption.create(testPassword, {

--- a/packages/level-private-state-provider/src/test/storage-encryption.test.ts
+++ b/packages/level-private-state-provider/src/test/storage-encryption.test.ts
@@ -15,7 +15,7 @@
 
 import { Buffer } from 'buffer';
 
-import { getPasswordFromProvider, StorageEncryption, timingSafeEqual } from '../storage-encryption';
+import { decryptValue, getPasswordFromProvider, StorageEncryption, timingSafeEqual } from '../storage-encryption';
 
 describe('StorageEncryption', () => {
   const testPassword = 'Test-Password-123!';
@@ -78,6 +78,69 @@ describe('StorageEncryption', () => {
       const encryption2 = await StorageEncryption.create('Wrong-Password-1!', encryption1.getSalt());
 
       await expect(encryption2.decrypt(encrypted)).rejects.toThrow();
+    });
+
+    test('rejects tampered ciphertext', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
+      const encrypted = await encryption.encrypt(testData);
+
+      const buffer = Buffer.from(encrypted, 'base64');
+      buffer[buffer.length - 1] ^= 0xff;
+      const tampered = buffer.toString('base64');
+
+      await expect(encryption.decrypt(tampered)).rejects.toThrow();
+    });
+  });
+
+  describe('create with Uint8Array salt', () => {
+    test('produces working encryption with Uint8Array salt', async () => {
+      const salt = new Uint8Array(32);
+      globalThis.crypto.getRandomValues(salt);
+
+      const encryption = await StorageEncryption.create(testPassword, salt);
+      const encrypted = await encryption.encrypt(testData);
+      const decrypted = await encryption.decrypt(encrypted);
+
+      expect(decrypted).toBe(testData);
+    });
+
+    test('Uint8Array salt produces same results as Buffer salt', async () => {
+      const rawBytes = new Uint8Array(32);
+      globalThis.crypto.getRandomValues(rawBytes);
+
+      const encryptionFromUint8 = await StorageEncryption.create(testPassword, rawBytes);
+      const encryptionFromBuffer = await StorageEncryption.create(testPassword, Buffer.from(rawBytes));
+
+      expect(encryptionFromUint8.getSalt()).toEqual(encryptionFromBuffer.getSalt());
+    });
+  });
+
+  describe('decryptValue', () => {
+    test('passes through unencrypted data as-is', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
+      const plaintext = 'not-encrypted-data';
+
+      const result = await decryptValue(plaintext, encryption, testPassword);
+
+      expect(result).toBe(plaintext);
+    });
+
+    test('decrypts V2 encrypted data', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
+      const encrypted = await encryption.encrypt(testData);
+
+      const result = await decryptValue(encrypted, encryption, testPassword);
+
+      expect(result).toBe(testData);
+    });
+
+    test('decrypts V1 encrypted data with password', async () => {
+      const salt = Buffer.from(V1_FIXTURES.salt, 'hex');
+      const encryption = await StorageEncryption.create(V1_FIXTURES.password, salt);
+
+      const result = await decryptValue(V1_FIXTURES.encrypted, encryption, V1_FIXTURES.password);
+
+      expect(result).toBe(V1_FIXTURES.plaintext);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1963,6 +1963,8 @@ __metadata:
   resolution: "@midnight-ntwrk/midnight-js-level-private-state-provider@workspace:packages/level-private-state-provider"
   dependencies:
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
+    "@noble/ciphers": "npm:^2.0.0"
+    "@noble/hashes": "npm:^2.0.0"
     abstract-level: "npm:^3.0.0"
     buffer: "npm:^6.0.3"
     fp-ts: "npm:^2.16.1"
@@ -2415,6 +2417,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/ciphers@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "@noble/ciphers@npm:2.1.1"
+  checksum: 10/efca189b2719ed7309616a6824328d713bd37156e1bcead453725e51fc93311fb2f54e4d46bef0391fa17ce18bd9c2364511290774504a8600264b572f6a1db5
+  languageName: node
+  linkType: hard
+
 "@noble/curves@npm:2.0.1":
   version: 2.0.1
   resolution: "@noble/curves@npm:2.0.1"
@@ -2440,7 +2449,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:2.0.1":
+"@noble/hashes@npm:2.0.1, @noble/hashes@npm:^2.0.0":
   version: 2.0.1
   resolution: "@noble/hashes@npm:2.0.1"
   checksum: 10/f4d00e7564eb4ff4e6d16be151dd0e404aede35f91e4372b0a8a6ec888379c1dd1e02c721b480af8e7853bea9637185b5cb9533970c5b77d60c254ead0cfd8f7


### PR DESCRIPTION
## Summary

- Add optional `levelFactory` to `LevelPrivateStateProviderConfig` that lets consumers provide their own `abstract-level` implementation
- Defaults to the standard `Level` (LevelDB/IndexedDB) for backward compatibility
- Export `LevelFactory` type for consumers
- Enables React Native consumers to use `react-native-leveldb-level-adapter` or any other `abstract-level`-compatible storage backend

## Motivation

After #827 resolves the crypto compatibility layer, the remaining blocker for React Native is the storage backend. `level` uses IndexedDB in browsers, which doesn't exist in React Native. By making the level factory injectable, RN consumers can swap in a native LevelDB binding via JSI.

Closes #829

## Usage

```typescript
import { SKReactNativeLevel } from 'react-native-leveldb-level-adapter';

levelPrivateStateProvider({
  accountId,
  privateStoragePasswordProvider: () => password,
  cryptoBackend: 'noble',
  levelFactory: (dbName) => new SKReactNativeLevel(dbName),
});
```

## Dependencies

- #827 (crypto backend abstraction) — this PR stacks on top of it

## Test plan

- [ ] All 230 existing tests pass (levelFactory defaults to standard Level, no behavior change)
- [ ] Lint clean
- [ ] Full monorepo build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
