### PR TITLE
feat: introduce Protocol ACL package

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -114,10 +114,46 @@ export default tseslint.config(
             {
               group: ['**/dist/**', './dist/**', '../dist/**'],
               message: 'Direct imports from dist folders are not allowed. Use source files instead.'
+            },
+            {
+              group: ['@midnight-ntwrk/ledger-v*'],
+              message: 'Import from @midnight-ntwrk/midnight-js-protocol/ledger instead. Only packages/protocol/src/ may import from ledger directly.'
+            },
+            {
+              group: ['@midnight-ntwrk/compact-runtime'],
+              message: 'Import from @midnight-ntwrk/midnight-js-protocol/compact-runtime instead. Only packages/protocol/src/ may import from compact-runtime directly.'
+            },
+            {
+              group: ['@midnight-ntwrk/compact-js', '@midnight-ntwrk/compact-js/*'],
+              message: 'Import from @midnight-ntwrk/midnight-js-protocol/compact-js instead. Only packages/protocol/src/ may import from compact-js directly.'
+            },
+            {
+              group: ['@midnight-ntwrk/onchain-runtime-v*'],
+              message: 'Import from @midnight-ntwrk/midnight-js-protocol/onchain-runtime instead. Only packages/protocol/src/ may import from onchain-runtime directly.'
+            },
+            {
+              group: ['@midnight-ntwrk/platform-js', '@midnight-ntwrk/platform-js/*'],
+              message: 'Import from @midnight-ntwrk/midnight-js-protocol/platform instead. Only packages/protocol/src/ may import from platform-js directly.'
             }
           ]
         }
       ],
+    }
+  },
+  {
+    files: ['packages/protocol/src/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/dist/**', './dist/**', '../dist/**'],
+              message: 'Direct imports from dist folders are not allowed. Use source files instead.'
+            }
+          ]
+        }
+      ]
     }
   },
   prettierConfig

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -133,7 +133,7 @@ export default tseslint.config(
             },
             {
               group: ['@midnight-ntwrk/platform-js', '@midnight-ntwrk/platform-js/*'],
-              message: 'Import from @midnight-ntwrk/midnight-js-protocol/platform instead. Only packages/protocol/src/ may import from platform-js directly.'
+              message: 'Import from @midnight-ntwrk/midnight-js-protocol/platform-js instead. Only packages/protocol/src/ may import from platform-js directly.'
             }
           ]
         }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@midnight-ntwrk/compact-js": "2.5.0",
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*",
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
     "@midnight-ntwrk/midnight-js-types": "workspace:*",
     "@midnight-ntwrk/midnight-js-utils": "workspace:*"
   },

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -27,7 +27,6 @@
     "deploy": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
-    "@midnight-ntwrk/compact-js": "2.5.0",
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*",
     "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
     "@midnight-ntwrk/midnight-js-types": "workspace:*",

--- a/packages/contracts/src/call-constructor.ts
+++ b/packages/contracts/src/call-constructor.ts
@@ -13,12 +13,12 @@
  * limitations under the License.
  */
 
-import { type CompiledContract, type Contract } from '@midnight-ntwrk/compact-js';
+import { type CompiledContract, type Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import {
   type CoinPublicKey,
   type ContractState,
   type ZswapLocalState
-} from '@midnight-ntwrk/compact-runtime';
+} from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 
 /**
  * Describes the target of a circuit invocation.

--- a/packages/contracts/src/call.ts
+++ b/packages/contracts/src/call.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import type { CompiledContract  } from '@midnight-ntwrk/compact-js';
-import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
+import type { CompiledContract  } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
 import {
   type AlignedValue,
   type CoinPublicKey,
@@ -23,13 +23,13 @@ import {
   type Op,
   type StateValue,
   type ZswapLocalState
-} from '@midnight-ntwrk/compact-runtime';
+} from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
   type EncPublicKey,
   type LedgerParameters,
   type PartitionedTranscript,
   type ZswapChainState
-} from '@midnight-ntwrk/ledger-v8';
+} from '@midnight-ntwrk/midnight-js-protocol/ledger';
 
 /**
  * Describes the target of a circuit invocation.

--- a/packages/contracts/src/contract-providers.ts
+++ b/packages/contracts/src/contract-providers.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
 import type {
   MidnightProviders,
   PrivateStateId

--- a/packages/contracts/src/deploy-contract.ts
+++ b/packages/contracts/src/deploy-contract.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
-import { sampleSigningKey, type SigningKey } from '@midnight-ntwrk/compact-runtime';
-import type { CoinPublicKey, EncPublicKey } from '@midnight-ntwrk/ledger-v8';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
+import { sampleSigningKey, type SigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import type { CoinPublicKey, EncPublicKey } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { PrivateStateId } from '@midnight-ntwrk/midnight-js-types';
 
 import type { ContractConstructorOptionsWithArguments } from './call-constructor';

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { ContractState } from '@midnight-ntwrk/compact-runtime';
+import type { ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import type { AnyProvableCircuitId, FinalizedTxData, PrivateStateId } from '@midnight-ntwrk/midnight-js-types';
 
 interface EffectContractError {

--- a/packages/contracts/src/find-deployed-contract.ts
+++ b/packages/contracts/src/find-deployed-contract.ts
@@ -13,13 +13,13 @@
  * limitations under the License.
  */
 
-import { type CompiledContract, type Contract, ContractExecutable } from '@midnight-ntwrk/compact-js';
+import { type CompiledContract, type Contract, ContractExecutable } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import {
   type ContractAddress,
   type ContractState,
   sampleSigningKey,
   type SigningKey
-} from '@midnight-ntwrk/compact-runtime';
+} from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
   type AnyProvableCircuitId,
   type PrivateStateId,

--- a/packages/contracts/src/get-states.ts
+++ b/packages/contracts/src/get-states.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import type { ContractState } from '@midnight-ntwrk/compact-runtime';
-import type { ContractAddress, LedgerParameters, ZswapChainState } from '@midnight-ntwrk/ledger-v8';
+import type { ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import type { ContractAddress, LedgerParameters, ZswapChainState } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { PrivateStateId,PrivateStateProvider, PublicDataProvider } from '@midnight-ntwrk/midnight-js-types';
 import { assertDefined, assertIsContractAddress } from '@midnight-ntwrk/midnight-js-utils';
 

--- a/packages/contracts/src/get-unshielded-balances.ts
+++ b/packages/contracts/src/get-unshielded-balances.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { ContractAddress } from '@midnight-ntwrk/ledger-v8';
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { PublicDataProvider, UnshieldedBalances } from '@midnight-ntwrk/midnight-js-types';
 import { assertDefined, assertIsContractAddress } from '@midnight-ntwrk/midnight-js-utils';
 

--- a/packages/contracts/src/internal/transaction.ts
+++ b/packages/contracts/src/internal/transaction.ts
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
-import type { CoinPublicKey, EncPublicKey } from '@midnight-ntwrk/ledger-v8';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
+import type { CoinPublicKey, EncPublicKey } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import { ChargedState } from '@midnight-ntwrk/midnight-js-protocol/onchain-runtime';
 import { type AnyProvableCircuitId, type PrivateStateId, SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
-import { ChargedState } from '@midnight-ntwrk/onchain-runtime-v3';
 
 import { type CallResult } from '../call';
 import { type ContractProviders } from '../contract-providers';

--- a/packages/contracts/src/submit-call-tx.ts
+++ b/packages/contracts/src/submit-call-tx.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import { ContractExecutable } from '@midnight-ntwrk/compact-js';
-import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
+import { ContractExecutable } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
 import { assertDefined, assertIsContractAddress } from '@midnight-ntwrk/midnight-js-utils';
 
 import { type CallResult } from './call';

--- a/packages/contracts/src/submit-deploy-tx.ts
+++ b/packages/contracts/src/submit-deploy-tx.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { type Contract } from '@midnight-ntwrk/compact-js';
+import { type Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import { SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
 
 import { type ContractProviders } from './contract-providers';

--- a/packages/contracts/src/submit-insert-vk-tx.ts
+++ b/packages/contracts/src/submit-insert-vk-tx.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import type { CompiledContract } from '@midnight-ntwrk/compact-js';
-import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
-import type { ContractAddress } from '@midnight-ntwrk/ledger-v8';
+import type { CompiledContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import {
   type FinalizedTxData,
   SucceedEntirely,

--- a/packages/contracts/src/submit-remove-vk-tx.ts
+++ b/packages/contracts/src/submit-remove-vk-tx.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import type { CompiledContract } from '@midnight-ntwrk/compact-js';
-import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
-import type { ContractAddress } from '@midnight-ntwrk/ledger-v8';
+import type { CompiledContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { type FinalizedTxData,SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
 import { assertDefined, assertIsContractAddress } from '@midnight-ntwrk/midnight-js-utils';
 

--- a/packages/contracts/src/submit-replace-authority-tx.ts
+++ b/packages/contracts/src/submit-replace-authority-tx.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import type { CompiledContract } from '@midnight-ntwrk/compact-js';
-import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
-import type { ContractAddress, SigningKey } from '@midnight-ntwrk/ledger-v8';
+import type { CompiledContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
+import type { ContractAddress, SigningKey } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { type FinalizedTxData, SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
 import { assertDefined, assertIsContractAddress } from '@midnight-ntwrk/midnight-js-utils';
 

--- a/packages/contracts/src/submit-tx.ts
+++ b/packages/contracts/src/submit-tx.ts
@@ -13,11 +13,11 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
 import {
   type Transaction,
   type UnprovenTransaction,
-} from '@midnight-ntwrk/ledger-v8';
+} from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import {
   type AnyProvableCircuitId,
   type FinalizedTxData,

--- a/packages/contracts/src/test/deploy-contract.test.ts
+++ b/packages/contracts/src/test/deploy-contract.test.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { type Contract } from '@midnight-ntwrk/compact-js';
-import { type ZswapLocalState } from '@midnight-ntwrk/compact-runtime';
-import { type UnprovenTransaction } from '@midnight-ntwrk/ledger-v8';
+import { type Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import { type ZswapLocalState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import { type UnprovenTransaction } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { AnyPrivateState } from '@midnight-ntwrk/midnight-js-types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/packages/contracts/src/test/enc-pub-key-resolver.test.ts
+++ b/packages/contracts/src/test/enc-pub-key-resolver.test.ts
@@ -15,8 +15,8 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { sampleCoinPublicKey, sampleEncryptionPublicKey } from '@midnight-ntwrk/ledger-v8';
 import { getNetworkId, setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { sampleCoinPublicKey, sampleEncryptionPublicKey } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { parseCoinPublicKeyToHex,parseEncPublicKeyToHex } from '@midnight-ntwrk/midnight-js-utils';
 
 import { deployContract } from '../deploy-contract';

--- a/packages/contracts/src/test/find-deployed-contract.test.ts
+++ b/packages/contracts/src/test/find-deployed-contract.test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { type Contract } from '@midnight-ntwrk/compact-js';
+import { type Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { findDeployedContract, type FoundContract } from '../find-deployed-contract';

--- a/packages/contracts/src/test/get-states.test.ts
+++ b/packages/contracts/src/test/get-states.test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { LedgerParameters, ZswapChainState } from '@midnight-ntwrk/ledger-v8';
+import type { LedgerParameters, ZswapChainState } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { PrivateStateId } from '@midnight-ntwrk/midnight-js-types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/packages/contracts/src/test/get-unshielded-balances.test.ts
+++ b/packages/contracts/src/test/get-unshielded-balances.test.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import type { ContractAddress } from '@midnight-ntwrk/ledger-v8';
-import { sampleContractAddress } from '@midnight-ntwrk/ledger-v8';
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import { sampleContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { PublicDataProvider } from '@midnight-ntwrk/midnight-js-types';
 import type { UnshieldedBalances } from '@midnight-ntwrk/midnight-js-types';
 import { describe, expect, it, vi } from 'vitest';

--- a/packages/contracts/src/test/submit-call-tx.test.ts
+++ b/packages/contracts/src/test/submit-call-tx.test.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { type CompiledContract, type Contract } from '@midnight-ntwrk/compact-js';
-import { StateValue } from '@midnight-ntwrk/compact-runtime';
-import { type AlignedValue, type ContractAddress, type IntentHash, type PartitionedTranscript, type RawTokenType } from '@midnight-ntwrk/ledger-v8';
+import { type CompiledContract, type Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import { StateValue } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import { type AlignedValue, type ContractAddress, type IntentHash, type PartitionedTranscript, type RawTokenType } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import {
   type AnyPrivateState,
   type AnyProvableCircuitId,

--- a/packages/contracts/src/test/submit-deploy-tx.test.ts
+++ b/packages/contracts/src/test/submit-deploy-tx.test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { type CompiledContract } from '@midnight-ntwrk/compact-js';
+import { type CompiledContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import { FailEntirely, FailFallible, type PrivateStateId } from '@midnight-ntwrk/midnight-js-types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -35,8 +35,8 @@ import {
 
 vi.mock('../unproven-deploy-tx');
 vi.mock('../submit-tx');
-vi.mock('@midnight-ntwrk/compact-runtime');
-vi.mock('@midnight-ntwrk/ledger-v8');
+vi.mock('@midnight-ntwrk/midnight-js-protocol/compact-runtime');
+vi.mock('@midnight-ntwrk/midnight-js-protocol/ledger');
 
 describe('submit-deploy-tx', () => {
   let mockCompiledContract: CompiledContract.CompiledContract<any, any>; // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/packages/contracts/src/test/test-mocks.ts
+++ b/packages/contracts/src/test/test-mocks.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import { CompiledContract } from '@midnight-ntwrk/compact-js';
-import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
+import { CompiledContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
 import {
   assert as compactAssert,
   ChargedState,
@@ -24,7 +24,7 @@ import {
   sampleSigningKey,
   type SigningKey,
   StateValue,
-  type ZswapLocalState} from '@midnight-ntwrk/compact-runtime';
+  type ZswapLocalState} from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
   type AlignedValue,
   type Binding,
@@ -49,7 +49,7 @@ import {
   type UnprovenTransaction,
   type ZswapChainState,
   type ZswapSecretKeys,
-} from '@midnight-ntwrk/ledger-v8';
+} from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import {
   type AnyPrivateState,
   type AnyProvableCircuitId,

--- a/packages/contracts/src/test/transaction-identity.test.ts
+++ b/packages/contracts/src/test/transaction-identity.test.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
-import { LedgerParameters } from '@midnight-ntwrk/ledger-v8';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
+import { LedgerParameters } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { AnyPrivateState, AnyProvableCircuitId, PrivateStateId } from '@midnight-ntwrk/midnight-js-types';
 import { beforeEach, describe, expect, it } from 'vitest';
 

--- a/packages/contracts/src/test/unproven-call-tx.test.ts
+++ b/packages/contracts/src/test/unproven-call-tx.test.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { type ContractState, StateValue } from '@midnight-ntwrk/compact-runtime';
-import { LedgerParameters } from '@midnight-ntwrk/ledger-v8';
 import { setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { type ContractState, StateValue } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import { LedgerParameters } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { createUnprovenCallTx, createUnprovenCallTxFromInitialStates } from '../unproven-call-tx';

--- a/packages/contracts/src/test/utils/ledger-utils.test.ts
+++ b/packages/contracts/src/test/utils/ledger-utils.test.ts
@@ -13,13 +13,14 @@
  * limitations under the License.
  */
 
+import { setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 import {
   type AlignedValue,
   ContractOperation,
   ContractState as CompactContractState,
   createCircuitContext,
   QueryContext
-} from '@midnight-ntwrk/compact-runtime';
+} from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
   feeToken,
   Intent,
@@ -39,8 +40,7 @@ import {
   unshieldedToken,
   type UtxoOutput,
   ZswapChainState
-} from '@midnight-ntwrk/ledger-v8';
-import { setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+} from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { toHex } from '@midnight-ntwrk/midnight-js-utils';
 import { randomBytes } from 'crypto';
 import { beforeAll } from 'vitest';

--- a/packages/contracts/src/test/utils/zswap-utils.test.ts
+++ b/packages/contracts/src/test/utils/zswap-utils.test.ts
@@ -14,7 +14,8 @@
  */
 
 import { fc } from '@fast-check/vitest';
-import { type Recipient } from '@midnight-ntwrk/compact-runtime';
+import { getNetworkId, setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { type Recipient } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
   type CoinPublicKey,
   createShieldedCoinInfo,
@@ -28,8 +29,7 @@ import {
   shieldedToken,
   Transaction,
   ZswapChainState,
-  ZswapOffer} from '@midnight-ntwrk/ledger-v8';
-import { getNetworkId, setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+  ZswapOffer} from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { toHex } from '@midnight-ntwrk/midnight-js-utils';
 import { randomBytes } from 'crypto';
 import { beforeAll, expect } from 'vitest';

--- a/packages/contracts/src/transaction.ts
+++ b/packages/contracts/src/transaction.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
-import type { CoinPublicKey, EncPublicKey } from '@midnight-ntwrk/ledger-v8';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
+import type { CoinPublicKey, EncPublicKey } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { type PrivateStateId } from '@midnight-ntwrk/midnight-js-types';
 
 import { type ContractProviders } from './contract-providers';

--- a/packages/contracts/src/tx-interfaces.ts
+++ b/packages/contracts/src/tx-interfaces.ts
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
-import { type CompiledContract, ContractExecutable } from '@midnight-ntwrk/compact-js';
-import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
-import type { SigningKey } from '@midnight-ntwrk/compact-runtime';
-import type { CoinPublicKey, ContractAddress, EncPublicKey } from '@midnight-ntwrk/ledger-v8';
+import { type CompiledContract, ContractExecutable } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
+import type { SigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import type { CoinPublicKey, ContractAddress, EncPublicKey } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import {
   type FinalizedTxData,
   type PrivateStateId,

--- a/packages/contracts/src/tx-model.ts
+++ b/packages/contracts/src/tx-model.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { type Contract } from '@midnight-ntwrk/compact-js';
-import type { ContractAddress, ContractState, SigningKey,ZswapLocalState } from '@midnight-ntwrk/compact-runtime';
-import { type ShieldedCoinInfo, type UnprovenTransaction } from '@midnight-ntwrk/ledger-v8';
+import { type Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import type { ContractAddress, ContractState, SigningKey,ZswapLocalState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import { type ShieldedCoinInfo, type UnprovenTransaction } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type {
   FinalizedTxData
 } from '@midnight-ntwrk/midnight-js-types';

--- a/packages/contracts/src/unproven-call-tx.ts
+++ b/packages/contracts/src/unproven-call-tx.ts
@@ -13,14 +13,14 @@
  * limitations under the License.
  */
 
-import { ContractExecutable } from '@midnight-ntwrk/compact-js';
-import { type Contract, ProvableCircuitId } from '@midnight-ntwrk/compact-js/effect/Contract';
-import { type CoinPublicKey, type ContractState } from '@midnight-ntwrk/compact-runtime';
-import { type EncPublicKey, type LedgerParameters, type ZswapChainState } from '@midnight-ntwrk/ledger-v8';
 import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { ContractExecutable } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import { type Contract, ProvableCircuitId } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
+import { type CoinPublicKey, type ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import { type EncPublicKey, type LedgerParameters, type ZswapChainState } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/platform/effect/ContractAddress';
 import { exitResultOrError, makeContractExecutableRuntime, type PrivateStateId, type ZKConfigProvider } from '@midnight-ntwrk/midnight-js-types';
 import { assertDefined, assertIsContractAddress, parseCoinPublicKeyToHex } from '@midnight-ntwrk/midnight-js-utils';
-import { ContractAddress } from '@midnight-ntwrk/platform-js/effect/ContractAddress';
 
 import type {
   CallOptions,

--- a/packages/contracts/src/unproven-call-tx.ts
+++ b/packages/contracts/src/unproven-call-tx.ts
@@ -18,7 +18,7 @@ import { ContractExecutable } from '@midnight-ntwrk/midnight-js-protocol/compact
 import { type Contract, ProvableCircuitId } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
 import { type CoinPublicKey, type ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import { type EncPublicKey, type LedgerParameters, type ZswapChainState } from '@midnight-ntwrk/midnight-js-protocol/ledger';
-import { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/platform/effect/ContractAddress';
+import { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/platform-js/effect/ContractAddress';
 import { exitResultOrError, makeContractExecutableRuntime, type PrivateStateId, type ZKConfigProvider } from '@midnight-ntwrk/midnight-js-types';
 import { assertDefined, assertIsContractAddress, parseCoinPublicKeyToHex } from '@midnight-ntwrk/midnight-js-utils';
 

--- a/packages/contracts/src/unproven-deploy-tx.ts
+++ b/packages/contracts/src/unproven-deploy-tx.ts
@@ -13,11 +13,11 @@
  * limitations under the License.
  */
 
-import { ContractExecutable } from '@midnight-ntwrk/compact-js';
-import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
-import type { CoinPublicKey,SigningKey } from '@midnight-ntwrk/compact-runtime';
-import type { EncPublicKey } from '@midnight-ntwrk/ledger-v8';
 import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { ContractExecutable } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
+import type { CoinPublicKey,SigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import type { EncPublicKey } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import {
   exitResultOrError,
   makeContractExecutableRuntime,

--- a/packages/contracts/src/utils/ledger-utils.ts
+++ b/packages/contracts/src/utils/ledger-utils.ts
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
-import { type CompiledContract, ContractExecutable } from '@midnight-ntwrk/compact-js';
-import { type Contract, ProvableCircuitId, VerifierKey as ContractVerifierKey } from '@midnight-ntwrk/compact-js/effect/Contract';
+import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { type CompiledContract, ContractExecutable } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import { type Contract, ProvableCircuitId, VerifierKey as ContractVerifierKey } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
 import {
   type AlignedValue,
   type CoinPublicKey,
@@ -22,7 +23,7 @@ import {
   ContractState,
   type QueryContext,
   type SigningKey,
-  type ZswapLocalState} from '@midnight-ntwrk/compact-runtime';
+  type ZswapLocalState} from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
   ChargedState,
   communicationCommitmentRandomness,
@@ -40,8 +41,7 @@ import {
   UnshieldedOffer,
   type UtxoOutput,
   type ZswapChainState
-} from '@midnight-ntwrk/ledger-v8';
-import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+} from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import {
   type AnyProvableCircuitId,
   asContractAddress,

--- a/packages/contracts/src/utils/zswap-utils.ts
+++ b/packages/contracts/src/utils/zswap-utils.ts
@@ -13,7 +13,8 @@
  * limitations under the License.
  */
 
-import { type Recipient, type ZswapLocalState } from '@midnight-ntwrk/compact-runtime';
+import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { type Recipient, type ZswapLocalState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
   type CoinPublicKey,
   type ContractAddress,
@@ -28,8 +29,7 @@ import {
   ZswapInput,
   ZswapOffer,
   ZswapOutput,
-  ZswapTransient} from '@midnight-ntwrk/ledger-v8';
-import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+  ZswapTransient} from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import {
   assertDefined,
   assertIsContractAddress,

--- a/packages/dapp-connector-proof-provider/package.json
+++ b/packages/dapp-connector-proof-provider/package.json
@@ -30,6 +30,7 @@
   ],
   "dependencies": {
     "@midnight-ntwrk/dapp-connector-api": "4.0.1",
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
   },
   "devDependencies": {

--- a/packages/dapp-connector-proof-provider/package.json
+++ b/packages/dapp-connector-proof-provider/package.json
@@ -32,8 +32,5 @@
     "@midnight-ntwrk/dapp-connector-api": "4.0.1",
     "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
-  },
-  "devDependencies": {
-    "@midnight-ntwrk/ledger-v8": "8.0.3"
   }
 }

--- a/packages/dapp-connector-proof-provider/src/dapp-connector-proof-provider.ts
+++ b/packages/dapp-connector-proof-provider/src/dapp-connector-proof-provider.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { CostModel } from '@midnight-ntwrk/ledger-v8';
+import type { CostModel } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { createProofProvider, type ProofProvider, type ZKConfigProvider } from '@midnight-ntwrk/midnight-js-types';
 
 import { type DAppConnectorProvingAPI, dappConnectorProvingProvider } from './dapp-connector-proving-provider';

--- a/packages/dapp-connector-proof-provider/src/test/dapp-connector-proof-provider.test.ts
+++ b/packages/dapp-connector-proof-provider/src/test/dapp-connector-proof-provider.test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { CostModel, ProvingProvider, UnprovenTransaction } from '@midnight-ntwrk/ledger-v8';
+import type { CostModel, ProvingProvider, UnprovenTransaction } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { KeyMaterialProvider, UnboundTransaction, ZKConfigProvider } from '@midnight-ntwrk/midnight-js-types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/packages/dapp-connector-proof-provider/src/test/dapp-connector-proving-provider.test.ts
+++ b/packages/dapp-connector-proof-provider/src/test/dapp-connector-proving-provider.test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { ProvingProvider } from '@midnight-ntwrk/ledger-v8';
+import type { ProvingProvider } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { KeyMaterialProvider, ZKConfigProvider } from '@midnight-ntwrk/midnight-js-types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/packages/http-client-proof-provider/package.json
+++ b/packages/http-client-proof-provider/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@midnight-ntwrk/midnight-js-contracts": "workspace:*",
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*",
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
     "@midnight-ntwrk/midnight-js-types": "workspace:*",
     "@midnight-ntwrk/midnight-js-utils": "workspace:*",
     "cross-fetch": "^4.1.0",

--- a/packages/http-client-proof-provider/src/http-client-proof-provider.ts
+++ b/packages/http-client-proof-provider/src/http-client-proof-provider.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { CostModel, type ProvingProvider, type UnprovenTransaction } from '@midnight-ntwrk/ledger-v8';
+import { CostModel, type ProvingProvider, type UnprovenTransaction } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type {
   ProofProvider,
   ProveTxConfig,

--- a/packages/http-client-proof-provider/src/http-client-proving-provider.ts
+++ b/packages/http-client-proof-provider/src/http-client-proving-provider.ts
@@ -18,7 +18,7 @@ import {
   createProvingPayload,
   parseCheckResult,
   type ProvingKeyMaterial,
-  type ProvingProvider} from '@midnight-ntwrk/ledger-v8';
+  type ProvingProvider} from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { InvalidProtocolSchemeError, type ZKConfigProvider, zkConfigToProvingKeyMaterial } from '@midnight-ntwrk/midnight-js-types';
 import fetch from 'cross-fetch';
 import fetchBuilder from 'fetch-retry';

--- a/packages/http-client-proof-provider/src/test/commons.ts
+++ b/packages/http-client-proof-provider/src/test/commons.ts
@@ -16,13 +16,15 @@
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { CompiledContract } from '@midnight-ntwrk/compact-js';
-import type { Contract } from '@midnight-ntwrk/compact-js/effect/Contract';
+import { createUnprovenCallTxFromInitialStates, createUnprovenDeployTxFromVerifierKeys } from '@midnight-ntwrk/midnight-js-contracts';
+import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { CompiledContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
 import {
   type CoinPublicKey,
   createConstructorContext,
   emptyZswapLocalState,
-  sampleSigningKey} from '@midnight-ntwrk/compact-runtime';
+  sampleSigningKey} from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
   LedgerParameters,
   sampleCoinPublicKey,
@@ -30,9 +32,7 @@ import {
   sampleEncryptionPublicKey,
   type UnprovenTransaction,
   ZswapChainState
-} from '@midnight-ntwrk/ledger-v8';
-import { createUnprovenCallTxFromInitialStates, createUnprovenDeployTxFromVerifierKeys } from '@midnight-ntwrk/midnight-js-contracts';
-import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+} from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { createProverKey,
   createVerifierKey,
   createZKIR,

--- a/packages/http-client-proof-provider/src/test/http-client-proving-provider.test.ts
+++ b/packages/http-client-proof-provider/src/test/http-client-proving-provider.test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import * as ledger from '@midnight-ntwrk/ledger-v8';
+import * as ledger from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import {
   InvalidProtocolSchemeError,
   type ProverKey,
@@ -38,8 +38,8 @@ vi.mock('fetch-retry', () => ({
   default: () => mockFetchRetry
 }));
 
-vi.mock('@midnight-ntwrk/ledger-v8', async () => {
-  const actual = await vi.importActual('@midnight-ntwrk/ledger-v8');
+vi.mock('@midnight-ntwrk/midnight-js-protocol/ledger', async () => {
+  const actual = await vi.importActual('@midnight-ntwrk/midnight-js-protocol/ledger');
   return {
     ...actual,
     createCheckPayload: vi.fn(),

--- a/packages/indexer-public-data-provider/package.json
+++ b/packages/indexer-public-data-provider/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@apollo/client": "^4.1.6",
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*",
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
     "@midnight-ntwrk/midnight-js-types": "workspace:*",
     "@midnight-ntwrk/midnight-js-utils": "workspace:*",
     "buffer": "^6.0.3",

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -19,7 +19,7 @@ import { HttpLink } from '@apollo/client/link/http';
 import { RetryLink } from '@apollo/client/link/retry';
 import { GraphQLWsLink } from '@apollo/client/link/subscriptions';
 import { getMainDefinition } from '@apollo/client/utilities';
-import { ContractState } from '@midnight-ntwrk/compact-runtime';
+import { ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
   type Binding,
   type ContractAddress,
@@ -28,8 +28,8 @@ import {
   type RawTokenType,
   type SignatureEnabled,
   type TransactionId
-} from '@midnight-ntwrk/ledger-v8';
-import { LedgerParameters,Transaction as LedgerTransaction, ZswapChainState } from '@midnight-ntwrk/ledger-v8';
+} from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import { LedgerParameters,Transaction as LedgerTransaction, ZswapChainState } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type {
   BlockHashConfig,
   BlockHeightConfig,

--- a/packages/indexer-public-data-provider/src/test/indexer-public-data-provider-unshielded-balances.test.ts
+++ b/packages/indexer-public-data-provider/src/test/indexer-public-data-provider-unshielded-balances.test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { ContractAddress } from '@midnight-ntwrk/ledger-v8';
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { ContractStateObservableConfig } from '@midnight-ntwrk/midnight-js-types';
 import { describe, expect, test } from 'vitest';
 

--- a/packages/level-private-state-provider/package.json
+++ b/packages/level-private-state-provider/package.json
@@ -26,6 +26,7 @@
     "deploy": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
     "@midnight-ntwrk/midnight-js-types": "workspace:*",
     "abstract-level": "^3.0.0",
     "buffer": "^6.0.3",

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { ContractAddress, SigningKey } from '@midnight-ntwrk/compact-runtime';
+import type { ContractAddress, SigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
   ExportDecryptionError,
   type ExportPrivateStatesOptions,

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -16,7 +16,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/compact-runtime';
+import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
   ExportDecryptionError,
   ImportConflictError,

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,0 +1,119 @@
+{
+  "name": "@midnight-ntwrk/midnight-js-protocol",
+  "version": "4.0.4",
+  "description": "Protocol type re-exports for midnight-js framework",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.cts"
+      },
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./ledger": {
+      "types": {
+        "import": "./dist/ledger.d.mts",
+        "require": "./dist/ledger.d.cts"
+      },
+      "import": "./dist/ledger.mjs",
+      "require": "./dist/ledger.cjs"
+    },
+    "./compact-runtime": {
+      "types": {
+        "import": "./dist/compact-runtime.d.mts",
+        "require": "./dist/compact-runtime.d.cts"
+      },
+      "import": "./dist/compact-runtime.mjs",
+      "require": "./dist/compact-runtime.cjs"
+    },
+    "./compact-js": {
+      "types": {
+        "import": "./dist/compact-js.d.mts",
+        "require": "./dist/compact-js.d.cts"
+      },
+      "import": "./dist/compact-js.mjs",
+      "require": "./dist/compact-js.cjs"
+    },
+    "./compact-js/effect": {
+      "types": {
+        "import": "./dist/compact-js-effect.d.mts",
+        "require": "./dist/compact-js-effect.d.cts"
+      },
+      "import": "./dist/compact-js-effect.mjs",
+      "require": "./dist/compact-js-effect.cjs"
+    },
+    "./compact-js/effect/Contract": {
+      "types": {
+        "import": "./dist/compact-js-effect-contract.d.mts",
+        "require": "./dist/compact-js-effect-contract.d.cts"
+      },
+      "import": "./dist/compact-js-effect-contract.mjs",
+      "require": "./dist/compact-js-effect-contract.cjs"
+    },
+    "./onchain-runtime": {
+      "types": {
+        "import": "./dist/onchain-runtime.d.mts",
+        "require": "./dist/onchain-runtime.d.cts"
+      },
+      "import": "./dist/onchain-runtime.mjs",
+      "require": "./dist/onchain-runtime.cjs"
+    },
+    "./platform": {
+      "types": {
+        "import": "./dist/platform.d.mts",
+        "require": "./dist/platform.d.cts"
+      },
+      "import": "./dist/platform.mjs",
+      "require": "./dist/platform.cjs"
+    },
+    "./platform/effect/Configuration": {
+      "types": {
+        "import": "./dist/platform-effect-configuration.d.mts",
+        "require": "./dist/platform-effect-configuration.d.cts"
+      },
+      "import": "./dist/platform-effect-configuration.mjs",
+      "require": "./dist/platform-effect-configuration.cjs"
+    },
+    "./platform/effect/ContractAddress": {
+      "types": {
+        "import": "./dist/platform-effect-contract-address.d.mts",
+        "require": "./dist/platform-effect-contract-address.d.cts"
+      },
+      "import": "./dist/platform-effect-contract-address.mjs",
+      "require": "./dist/platform-effect-contract-address.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "repository": "git@github.com:midnight-ntwrk/artifacts",
+  "packageManager": "yarn@4.12.0",
+  "author": "IOHK",
+  "license": "Apache-2.0",
+  "scripts": {
+    "clean": "rm -rf dist tsconfig.build.tsbuildinfo .rollup.cache reports coverage",
+    "build": "rollup -c rollup.config.mjs",
+    "lint": "eslint src/",
+    "deploy": "yarn npm publish --tolerate-republish"
+  },
+  "files": [
+    "dist/"
+  ],
+  "dependencies": {
+    "@midnight-ntwrk/compact-js": "2.5.0",
+    "@midnight-ntwrk/compact-runtime": "0.15.0",
+    "@midnight-ntwrk/ledger-v8": "8.0.3",
+    "@midnight-ntwrk/onchain-runtime-v3": "3.0.0",
+    "@midnight-ntwrk/platform-js": "2.2.4"
+  },
+  "devDependencies": {
+    "@rollup/plugin-typescript": "^12.3.0",
+    "rollup": "^4.60.0",
+    "rollup-plugin-dts": "^6.4.1",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -62,7 +62,7 @@
       "import": "./dist/onchain-runtime.mjs",
       "require": "./dist/onchain-runtime.cjs"
     },
-    "./platform": {
+    "./platform-js": {
       "types": {
         "import": "./dist/platform.d.mts",
         "require": "./dist/platform.d.cts"
@@ -70,7 +70,7 @@
       "import": "./dist/platform.mjs",
       "require": "./dist/platform.cjs"
     },
-    "./platform/effect/Configuration": {
+    "./platform-js/effect/Configuration": {
       "types": {
         "import": "./dist/platform-effect-configuration.d.mts",
         "require": "./dist/platform-effect-configuration.d.cts"
@@ -78,7 +78,7 @@
       "import": "./dist/platform-effect-configuration.mjs",
       "require": "./dist/platform-effect-configuration.cjs"
     },
-    "./platform/effect/ContractAddress": {
+    "./platform-js/effect/ContractAddress": {
       "types": {
         "import": "./dist/platform-effect-contract-address.d.mts",
         "require": "./dist/platform-effect-contract-address.d.cts"

--- a/packages/protocol/rollup.config.mjs
+++ b/packages/protocol/rollup.config.mjs
@@ -1,0 +1,56 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import typescript from '@rollup/plugin-typescript';
+import dts from 'rollup-plugin-dts';
+
+const external = [/node_modules/, /^@midnight-ntwrk\//];
+
+const entries = [
+  { input: 'src/index.ts', name: 'index' },
+  { input: 'src/ledger.ts', name: 'ledger' },
+  { input: 'src/compact-runtime.ts', name: 'compact-runtime' },
+  { input: 'src/compact-js.ts', name: 'compact-js' },
+  { input: 'src/compact-js-effect.ts', name: 'compact-js-effect' },
+  { input: 'src/compact-js-effect-contract.ts', name: 'compact-js-effect-contract' },
+  { input: 'src/onchain-runtime.ts', name: 'onchain-runtime' },
+  { input: 'src/platform.ts', name: 'platform' },
+  { input: 'src/platform-effect-configuration.ts', name: 'platform-effect-configuration' },
+  { input: 'src/platform-effect-contract-address.ts', name: 'platform-effect-contract-address' },
+];
+
+export default entries.flatMap(({ input, name }) => [
+  {
+    input,
+    output: [
+      { file: `dist/${name}.mjs`, format: 'esm', sourcemap: true },
+      { file: `dist/${name}.cjs`, format: 'cjs', sourcemap: true },
+    ],
+    plugins: [
+      typescript({ tsconfig: './tsconfig.build.json', composite: false }),
+    ],
+    external,
+  },
+  {
+    input,
+    output: [
+      { file: `dist/${name}.d.mts`, format: 'esm' },
+      { file: `dist/${name}.d.cts`, format: 'cjs' },
+      { file: `dist/${name}.d.ts`, format: 'esm' },
+    ],
+    plugins: [dts()],
+    external,
+  },
+]);

--- a/packages/protocol/src/compact-js-effect-contract.ts
+++ b/packages/protocol/src/compact-js-effect-contract.ts
@@ -1,0 +1,16 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from '@midnight-ntwrk/compact-js/effect/Contract';

--- a/packages/protocol/src/compact-js-effect.ts
+++ b/packages/protocol/src/compact-js-effect.ts
@@ -1,0 +1,16 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from '@midnight-ntwrk/compact-js/effect';

--- a/packages/protocol/src/compact-js.ts
+++ b/packages/protocol/src/compact-js.ts
@@ -1,0 +1,16 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from '@midnight-ntwrk/compact-js';

--- a/packages/protocol/src/compact-runtime.ts
+++ b/packages/protocol/src/compact-runtime.ts
@@ -1,0 +1,16 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from '@midnight-ntwrk/compact-runtime';

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,0 +1,20 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * as compactJs from '@midnight-ntwrk/compact-js';
+export * as compactRuntime from '@midnight-ntwrk/compact-runtime';
+export * as ledger from '@midnight-ntwrk/ledger-v8';
+export * as onchainRuntime from '@midnight-ntwrk/onchain-runtime-v3';
+export * as platform from '@midnight-ntwrk/platform-js';

--- a/packages/protocol/src/ledger.ts
+++ b/packages/protocol/src/ledger.ts
@@ -1,0 +1,16 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from '@midnight-ntwrk/ledger-v8';

--- a/packages/protocol/src/onchain-runtime.ts
+++ b/packages/protocol/src/onchain-runtime.ts
@@ -1,0 +1,16 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from '@midnight-ntwrk/onchain-runtime-v3';

--- a/packages/protocol/src/platform-effect-configuration.ts
+++ b/packages/protocol/src/platform-effect-configuration.ts
@@ -1,0 +1,16 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from '@midnight-ntwrk/platform-js/effect/Configuration';

--- a/packages/protocol/src/platform-effect-contract-address.ts
+++ b/packages/protocol/src/platform-effect-contract-address.ts
@@ -1,0 +1,16 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from '@midnight-ntwrk/platform-js/effect/ContractAddress';

--- a/packages/protocol/src/platform.ts
+++ b/packages/protocol/src/platform.ts
@@ -1,0 +1,16 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from '@midnight-ntwrk/platform-js';

--- a/packages/protocol/tsconfig.build.json
+++ b/packages/protocol/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "./src/test/**/*.ts"
+  ]
+}

--- a/packages/protocol/tsconfig.json
+++ b/packages/protocol/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": [
+    "./src/**/*.ts"
+  ]
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -30,6 +30,7 @@
   ],
   "dependencies": {
     "@midnight-ntwrk/compact-js": "2.5.0",
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
     "@midnight-ntwrk/platform-js": "2.2.4",
     "rxjs": "^7.5.0"
   }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -29,9 +29,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@midnight-ntwrk/compact-js": "2.5.0",
     "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
-    "@midnight-ntwrk/platform-js": "2.2.4",
     "rxjs": "^7.5.0"
   }
 }

--- a/packages/types/src/contract.ts
+++ b/packages/types/src/contract.ts
@@ -15,8 +15,8 @@
 
 import { type CompiledContract, Contract, type ContractExecutable, ContractExecutableRuntime,
   ZKConfiguration, ZKConfigurationReadError } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect';
-import { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/platform';
-import * as Configuration from '@midnight-ntwrk/midnight-js-protocol/platform/effect/Configuration';
+import { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/platform-js';
+import * as Configuration from '@midnight-ntwrk/midnight-js-protocol/platform-js/effect/Configuration';
 import { Cause, type ConfigError, ConfigProvider, Effect, Exit,Layer, Option } from 'effect';
 import { type ManagedRuntime } from 'effect/ManagedRuntime';
 

--- a/packages/types/src/contract.ts
+++ b/packages/types/src/contract.ts
@@ -14,9 +14,9 @@
  */
 
 import { type CompiledContract, Contract, type ContractExecutable, ContractExecutableRuntime,
-  ZKConfiguration, ZKConfigurationReadError } from '@midnight-ntwrk/compact-js/effect';
-import { ContractAddress } from '@midnight-ntwrk/platform-js';
-import * as Configuration from '@midnight-ntwrk/platform-js/effect/Configuration';
+  ZKConfiguration, ZKConfigurationReadError } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect';
+import { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/platform';
+import * as Configuration from '@midnight-ntwrk/midnight-js-protocol/platform/effect/Configuration';
 import { Cause, type ConfigError, ConfigProvider, Effect, Exit,Layer, Option } from 'effect';
 import { type ManagedRuntime } from 'effect/ManagedRuntime';
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -24,4 +24,4 @@ export * from './providers';
 export * from './public-data-provider';
 export * from './wallet-provider';
 export * from './zk-config-provider';
-export { Transaction } from '@midnight-ntwrk/ledger-v8';
+export { Transaction } from '@midnight-ntwrk/midnight-js-protocol/ledger';

--- a/packages/types/src/midnight-provider.ts
+++ b/packages/types/src/midnight-provider.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { FinalizedTransaction, TransactionId } from '@midnight-ntwrk/ledger-v8';
+import type { FinalizedTransaction, TransactionId } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 
 /**
  * Interface for Midnight transaction submission logic. It could be implemented, e.g., by a wallet,

--- a/packages/types/src/midnight-types.ts
+++ b/packages/types/src/midnight-types.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import {
   type Binding,
   type ContractAddress,
@@ -24,7 +24,7 @@ import {
   type Transaction,
   type TransactionHash,
   type TransactionId,
-} from '@midnight-ntwrk/ledger-v8';
+} from '@midnight-ntwrk/midnight-js-protocol/ledger';
 
 export type AnyProvableCircuitId = Contract.ProvableCircuitId<Contract.Any>;
 

--- a/packages/types/src/private-state-provider.ts
+++ b/packages/types/src/private-state-provider.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { ContractAddress,SigningKey } from '@midnight-ntwrk/compact-runtime';
+import type { ContractAddress,SigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 
 /**
  * A type representing an ID used to store a contract's private state.

--- a/packages/types/src/proof-provider.ts
+++ b/packages/types/src/proof-provider.ts
@@ -21,7 +21,7 @@ import {
   type SignatureEnabled,
   type Transaction,
   type UnprovenTransaction
-} from '@midnight-ntwrk/ledger-v8';
+} from '@midnight-ntwrk/midnight-js-protocol/ledger';
 
 export type UnboundTransaction = Transaction<SignatureEnabled, Proof, PreBinding>;
 

--- a/packages/types/src/public-data-provider.ts
+++ b/packages/types/src/public-data-provider.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import type { ContractState } from '@midnight-ntwrk/compact-runtime';
-import type { ContractAddress, LedgerParameters, TransactionId, ZswapChainState } from '@midnight-ntwrk/ledger-v8';
+import type { ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import type { ContractAddress, LedgerParameters, TransactionId, ZswapChainState } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { Observable } from 'rxjs';
 
 import type { FinalizedTxData, UnshieldedBalances } from './midnight-types';

--- a/packages/types/src/wallet-provider.ts
+++ b/packages/types/src/wallet-provider.ts
@@ -17,7 +17,7 @@ import {
   type CoinPublicKey,
   type EncPublicKey,
   type FinalizedTransaction,
-} from '@midnight-ntwrk/ledger-v8';
+} from '@midnight-ntwrk/midnight-js-protocol/ledger';
 
 import { type UnboundTransaction } from './proof-provider';
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -30,6 +30,7 @@
   ],
   "dependencies": {
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*",
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
     "@scure/base": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/utils/src/type-utils.ts
+++ b/packages/utils/src/type-utils.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { ContractAddress } from '@midnight-ntwrk/compact-runtime';
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 
 import { assertIsHex, parseHex } from './hex-utils';
 

--- a/testkit-js/testkit-js-e2e/package.json
+++ b/testkit-js/testkit-js-e2e/package.json
@@ -43,7 +43,6 @@
     "deploy": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
-    "@midnight-ntwrk/compact-js": "2.5.0",
     "@midnight-ntwrk/midnight-js-compact": "workspace:*",
     "@midnight-ntwrk/midnight-js-contracts": "workspace:*",
     "@midnight-ntwrk/midnight-js-http-client-proof-provider": "workspace:*",

--- a/testkit-js/testkit-js-e2e/package.json
+++ b/testkit-js/testkit-js-e2e/package.json
@@ -50,6 +50,7 @@
     "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "workspace:*",
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*",
     "@midnight-ntwrk/midnight-js-node-zk-config-provider": "workspace:*",
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
     "@midnight-ntwrk/midnight-js-types": "workspace:*",
     "@midnight-ntwrk/midnight-js-utils": "workspace:*",
     "@midnight-ntwrk/testkit-js": "workspace:*",

--- a/testkit-js/testkit-js-e2e/src/constants.ts
+++ b/testkit-js/testkit-js-e2e/src/constants.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { sampleContractAddress } from '@midnight-ntwrk/compact-runtime';
+import { sampleContractAddress } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 
 export const MINUTE = 60_000;
 export const SLOW_TEST_TIMEOUT = 6 * MINUTE;

--- a/testkit-js/testkit-js-e2e/src/contract/double-counter-witnesses.ts
+++ b/testkit-js/testkit-js-e2e/src/contract/double-counter-witnesses.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
+import type { WitnessContext } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 
 import type { Ledger } from './compiled/double-counter/contract/index.js';
 

--- a/testkit-js/testkit-js-e2e/src/contract/index.ts
+++ b/testkit-js/testkit-js-e2e/src/contract/index.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { CompiledContract } from '@midnight-ntwrk/compact-js';
+import { CompiledContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 
 import * as CompiledBlockTime from './compiled/block-time/contract/index.js';
 import * as CompiledCounter from './compiled/counter/contract/index.js';

--- a/testkit-js/testkit-js-e2e/src/contract/witnesses.ts
+++ b/testkit-js/testkit-js-e2e/src/contract/witnesses.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
+import type { WitnessContext } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 
 import type { Ledger } from './compiled/counter/contract/index.js';
 

--- a/testkit-js/testkit-js-e2e/src/counter-api.ts
+++ b/testkit-js/testkit-js-e2e/src/counter-api.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import type { ContractAddress } from '@midnight-ntwrk/ledger-v8';
 import { deployContract } from '@midnight-ntwrk/midnight-js-contracts';
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { FinalizedTxData } from '@midnight-ntwrk/midnight-js-types';
 import { assertIsContractAddress } from '@midnight-ntwrk/midnight-js-utils';
 import {

--- a/testkit-js/testkit-js-e2e/src/double-counter-api.ts
+++ b/testkit-js/testkit-js-e2e/src/double-counter-api.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import type { ContractAddress } from '@midnight-ntwrk/ledger-v8';
 import { deployContract } from '@midnight-ntwrk/midnight-js-contracts';
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { FinalizedTxData } from '@midnight-ntwrk/midnight-js-types';
 import { assertIsContractAddress } from '@midnight-ntwrk/midnight-js-utils';
 import {

--- a/testkit-js/testkit-js-e2e/src/types/block-time-types.ts
+++ b/testkit-js/testkit-js-e2e/src/types/block-time-types.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js';
 import type { DeployedContract } from '@midnight-ntwrk/midnight-js-contracts';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import type { MidnightProviders } from '@midnight-ntwrk/midnight-js-types';
 
 import type { CompiledBlockTime } from '../contract';

--- a/testkit-js/testkit-js-e2e/src/types/counter-clone-types.ts
+++ b/testkit-js/testkit-js-e2e/src/types/counter-clone-types.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 
 import { CompiledCounterClone } from '../contract';
 import { type CounterPrivateState, witnesses } from '../contract/witnesses';

--- a/testkit-js/testkit-js-e2e/src/types/counter-types.ts
+++ b/testkit-js/testkit-js-e2e/src/types/counter-types.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js';
 import type { DeployedContract } from '@midnight-ntwrk/midnight-js-contracts';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import type { MidnightProviders } from '@midnight-ntwrk/midnight-js-types';
 
 import { CompiledCounter } from '../contract';

--- a/testkit-js/testkit-js-e2e/src/types/double-counter-types.ts
+++ b/testkit-js/testkit-js-e2e/src/types/double-counter-types.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js';
 import type { DeployedContract } from '@midnight-ntwrk/midnight-js-contracts';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import type { MidnightProviders } from '@midnight-ntwrk/midnight-js-types';
 
 import { CompiledDoubleCounter } from '../contract';

--- a/testkit-js/testkit-js-e2e/src/types/shielded-types.ts
+++ b/testkit-js/testkit-js-e2e/src/types/shielded-types.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import type { MidnightProviders } from '@midnight-ntwrk/midnight-js-types';
 
 import { type CompiledShielded } from '../contract';

--- a/testkit-js/testkit-js-e2e/src/types/simple-types.ts
+++ b/testkit-js/testkit-js-e2e/src/types/simple-types.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import type { MidnightProviders } from '@midnight-ntwrk/midnight-js-types';
 
 import { CompiledSimple } from '../contract';

--- a/testkit-js/testkit-js-e2e/src/types/unshielded-types.ts
+++ b/testkit-js/testkit-js-e2e/src/types/unshielded-types.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import type { MidnightProviders } from '@midnight-ntwrk/midnight-js-types';
 
 import { CompiledUnshielded } from '../contract';

--- a/testkit-js/testkit-js-e2e/test/contracts.blocktime.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/contracts.blocktime.it.test.ts
@@ -13,12 +13,12 @@
  * limitations under the License.
  */
 
-import { type ContractAddress } from '@midnight-ntwrk/ledger-v8';
 import {
   createUnprovenCallTx,
   type FinalizedDeployTxData,
   submitTx
 } from '@midnight-ntwrk/midnight-js-contracts';
+import { type ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { FailEntirely, SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
 import type {
   EnvironmentConfiguration,

--- a/testkit-js/testkit-js-e2e/test/contracts.blocktime2.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/contracts.blocktime2.it.test.ts
@@ -13,12 +13,12 @@
  * limitations under the License.
  */
 
-import { type ContractAddress } from '@midnight-ntwrk/ledger-v8';
 import {
   createUnprovenCallTx,
   type FinalizedDeployTxData,
   submitTx
 } from '@midnight-ntwrk/midnight-js-contracts';
+import { type ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { FailEntirely, SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
 import {
   type EnvironmentConfiguration,

--- a/testkit-js/testkit-js-e2e/test/contracts.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/contracts.it.test.ts
@@ -14,13 +14,6 @@
  */
 
 import {
-  ContractState,
-  decodeZswapLocalState,
-  emptyZswapLocalState,
-  sampleSigningKey
-} from '@midnight-ntwrk/compact-runtime';
-import { type ContractAddress, LedgerParameters, ZswapChainState } from '@midnight-ntwrk/ledger-v8';
-import {
   ContractTypeError,
   createCircuitCallTxInterface,
   createUnprovenCallTxFromInitialStates,
@@ -31,6 +24,13 @@ import {
   submitCallTx,
   submitDeployTx} from '@midnight-ntwrk/midnight-js-contracts';
 import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import {
+  ContractState,
+  decodeZswapLocalState,
+  emptyZswapLocalState,
+  sampleSigningKey
+} from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import { type ContractAddress, LedgerParameters, ZswapChainState } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
 import { parseCoinPublicKeyToHex } from '@midnight-ntwrk/midnight-js-utils';
 import type {

--- a/testkit-js/testkit-js-e2e/test/contracts.scopedtx.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/contracts.scopedtx.it.test.ts
@@ -13,13 +13,13 @@
  * limitations under the License.
  */
 
-import { type ContractAddress } from '@midnight-ntwrk/ledger-v8';
 import {
   type CallTxOptionsWithPrivateStateId,
   type FinalizedDeployTxData,
   submitCallTx,
   withContractScopedTransaction
 } from '@midnight-ntwrk/midnight-js-contracts';
+import { type ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { EnvironmentConfiguration, MidnightWalletProvider, TestEnvironment } from '@midnight-ntwrk/testkit-js';
 import { createLogger, getTestEnvironment, initializeMidnightProviders } from '@midnight-ntwrk/testkit-js';
 import path from 'path';

--- a/testkit-js/testkit-js-e2e/test/contracts.singlecontract.nostate.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/contracts.singlecontract.nostate.it.test.ts
@@ -14,14 +14,6 @@
  */
 
 import {
-  type CoinPublicKey,
-  decodeZswapLocalState,
-  emptyZswapLocalState,
-  sampleSigningKey,
-  type SigningKey
-} from '@midnight-ntwrk/compact-runtime';
-import { LedgerParameters, ZswapChainState } from '@midnight-ntwrk/ledger-v8';
-import {
   type CallResult,
   createUnprovenCallTx,
   createUnprovenCallTxFromInitialStates,
@@ -34,6 +26,14 @@ import {
   type UnsubmittedDeployTxData
 } from '@midnight-ntwrk/midnight-js-contracts';
 import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import {
+  type CoinPublicKey,
+  decodeZswapLocalState,
+  emptyZswapLocalState,
+  sampleSigningKey,
+  type SigningKey
+} from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import { LedgerParameters, ZswapChainState } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { parseCoinPublicKeyToHex } from '@midnight-ntwrk/midnight-js-utils';
 import {
   createLogger,

--- a/testkit-js/testkit-js-e2e/test/contracts.snarkupgrade.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/contracts.snarkupgrade.it.test.ts
@@ -13,13 +13,13 @@
  * limitations under the License.
  */
 
-import type { ContractAddress } from '@midnight-ntwrk/ledger-v8';
 import {
   createCircuitCallTxInterface,
   createCircuitMaintenanceTxInterface,
   createCircuitMaintenanceTxInterfaces,
   submitRemoveVerifierKeyTx
 } from '@midnight-ntwrk/midnight-js-contracts';
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
 import type {
   EnvironmentConfiguration,

--- a/testkit-js/testkit-js-e2e/test/contracts.snarkupgrade.singlecontract.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/contracts.snarkupgrade.singlecontract.it.test.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { sampleSigningKey } from '@midnight-ntwrk/compact-runtime';
-import type { ContractAddress } from '@midnight-ntwrk/ledger-v8';
 import {
   createCircuitMaintenanceTxInterface,
   createCircuitMaintenanceTxInterfaces,
@@ -23,6 +21,8 @@ import {
   submitRemoveVerifierKeyTx,
   submitReplaceAuthorityTx
 } from '@midnight-ntwrk/midnight-js-contracts';
+import { sampleSigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { SucceedEntirely, type VerifierKey } from '@midnight-ntwrk/midnight-js-types';
 import {
   createLogger,

--- a/testkit-js/testkit-js-e2e/test/contracts.snarkupgrade.smoke.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/contracts.snarkupgrade.smoke.it.test.ts
@@ -13,14 +13,14 @@
  * limitations under the License.
  */
 
-import { sampleSigningKey } from '@midnight-ntwrk/compact-runtime';
-import type { ContractAddress } from '@midnight-ntwrk/ledger-v8';
 import {
   createCircuitMaintenanceTxInterfaces,
   findDeployedContract,
   submitRemoveVerifierKeyTx,
   submitReplaceAuthorityTx
 } from '@midnight-ntwrk/midnight-js-contracts';
+import { sampleSigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
 import {
   createLogger,

--- a/testkit-js/testkit-js-e2e/test/indexer-public-data-provider.observable1.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/indexer-public-data-provider.observable1.it.test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { type ContractState } from '@midnight-ntwrk/compact-runtime';
+import { type ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import { type FinalizedTxData, type PublicDataProvider } from '@midnight-ntwrk/midnight-js-types';
 import {
   createLogger,

--- a/testkit-js/testkit-js-e2e/test/indexer-public-data-provider.observable2.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/indexer-public-data-provider.observable2.it.test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { type ContractState } from '@midnight-ntwrk/compact-runtime';
+import { type ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
   type All,
   type FinalizedTxData,

--- a/testkit-js/testkit-js-e2e/test/level-private-state-provider.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/level-private-state-provider.it.test.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import type { ContractAddress } from '@midnight-ntwrk/ledger-v8';
 import { createCircuitCallTxInterface, deployContract } from '@midnight-ntwrk/midnight-js-contracts';
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { PrivateStateExport, SigningKeyExport } from '@midnight-ntwrk/midnight-js-types';
 import type { EnvironmentConfiguration, MidnightWalletProvider, TestEnvironment } from '@midnight-ntwrk/testkit-js';
 import { createLogger, getTestEnvironment, initializeMidnightProviders } from '@midnight-ntwrk/testkit-js';

--- a/testkit-js/testkit-js-e2e/test/proof-server.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/proof-server.it.test.ts
@@ -13,7 +13,14 @@
  * limitations under the License.
  */
 
-import { sampleSigningKey } from '@midnight-ntwrk/compact-runtime';
+import {
+  createUnprovenCallTxFromInitialStates,
+  createUnprovenDeployTxFromVerifierKeys
+} from '@midnight-ntwrk/midnight-js-contracts';
+import { DEFAULT_CONFIG, httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client-proof-provider';
+import { getNetworkId, setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { NodeZkConfigProvider } from '@midnight-ntwrk/midnight-js-node-zk-config-provider';
+import { sampleSigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
   ContractCall,
   ContractDeploy,
@@ -25,14 +32,7 @@ import {
   type UnprovenTransaction,
   WellFormedStrictness,
   ZswapChainState
-} from '@midnight-ntwrk/ledger-v8';
-import {
-  createUnprovenCallTxFromInitialStates,
-  createUnprovenDeployTxFromVerifierKeys
-} from '@midnight-ntwrk/midnight-js-contracts';
-import { DEFAULT_CONFIG, httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client-proof-provider';
-import { getNetworkId, setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
-import { NodeZkConfigProvider } from '@midnight-ntwrk/midnight-js-node-zk-config-provider';
+} from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { ProofProvider } from '@midnight-ntwrk/midnight-js-types';
 import {
   createLogger,

--- a/testkit-js/testkit-js-e2e/test/shielded.advanced.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/shielded.advanced.it.test.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/compact-runtime';
 import { deployContract, submitCallTx } from '@midnight-ntwrk/midnight-js-contracts';
+import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import { SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
 import {
   type ContractConfiguration,

--- a/testkit-js/testkit-js-e2e/test/shielded.transfer.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/shielded.transfer.it.test.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/compact-runtime';
 import { deployContract, submitCallTx } from '@midnight-ntwrk/midnight-js-contracts';
+import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import { SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
 import {
   type ContractConfiguration,

--- a/testkit-js/testkit-js-e2e/test/unshielded.balance.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/unshielded.balance.it.test.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/compact-runtime';
 import { deployContract, submitCallTx } from '@midnight-ntwrk/midnight-js-contracts';
+import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import { SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
 import {
   type ContractConfiguration,

--- a/testkit-js/testkit-js-e2e/test/unshielded.cross-wallet-transfer.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/unshielded.cross-wallet-transfer.it.test.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/compact-runtime';
 import { deployContract, submitCallTx } from '@midnight-ntwrk/midnight-js-contracts';
+import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import { SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
 import {
   type ContractConfiguration,

--- a/testkit-js/testkit-js-e2e/test/unshielded.mint-and-send.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/unshielded.mint-and-send.it.test.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/compact-runtime';
 import { deployContract, submitCallTx } from '@midnight-ntwrk/midnight-js-contracts';
+import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import { SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
 import {
   type ContractConfiguration,

--- a/testkit-js/testkit-js-e2e/test/unshielded.transfer.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/unshielded.transfer.it.test.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/compact-runtime';
 import { deployContract, submitCallTx } from '@midnight-ntwrk/midnight-js-contracts';
+import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import { SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
 import {
   type ContractConfiguration,

--- a/testkit-js/testkit-js/package.json
+++ b/testkit-js/testkit-js/package.json
@@ -32,8 +32,6 @@
     "deploy": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
-    "@midnight-ntwrk/compact-js": "2.5.0",
-    "@midnight-ntwrk/ledger-v8": "8.0.3",
     "@midnight-ntwrk/midnight-js-compact": "workspace:*",
     "@midnight-ntwrk/midnight-js-contracts": "workspace:*",
     "@midnight-ntwrk/midnight-js-http-client-proof-provider": "workspace:*",

--- a/testkit-js/testkit-js/package.json
+++ b/testkit-js/testkit-js/package.json
@@ -41,6 +41,7 @@
     "@midnight-ntwrk/midnight-js-level-private-state-provider": "workspace:*",
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*",
     "@midnight-ntwrk/midnight-js-node-zk-config-provider": "workspace:*",
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
     "@midnight-ntwrk/midnight-js-types": "workspace:*",
     "@midnight-ntwrk/midnight-js-utils": "workspace:*",
     "@midnight-ntwrk/wallet-sdk-hd": "3.0.1",

--- a/testkit-js/testkit-js/src/assertions.ts
+++ b/testkit-js/testkit-js/src/assertions.ts
@@ -13,9 +13,6 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js';
-import type { StateValue } from '@midnight-ntwrk/compact-runtime';
-import type { Bindingish, Proofish, Signaturish, Transaction } from '@midnight-ntwrk/ledger-v8';
 import type {
   CallTxOptions,
   DeployContractOptions,
@@ -24,6 +21,9 @@ import type {
   FinalizedDeployTxData,
   FinalizedDeployTxDataBase
 } from '@midnight-ntwrk/midnight-js-contracts';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import type { StateValue } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import type { Bindingish, Proofish, Signaturish, Transaction } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import {
   type FinalizedTxData,
   type MidnightProviders,

--- a/testkit-js/testkit-js/src/client/node-client.ts
+++ b/testkit-js/testkit-js/src/client/node-client.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import type { ContractAddress } from '@midnight-ntwrk/compact-runtime';
-import { ContractState, LedgerState } from '@midnight-ntwrk/ledger-v8';
 import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import { ContractState, LedgerState } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { BlockHash } from '@midnight-ntwrk/midnight-js-types';
 import axios, { type AxiosResponse } from 'axios';
 import type { Logger } from 'pino';

--- a/testkit-js/testkit-js/src/contract/in-memory-private-state-provider.ts
+++ b/testkit-js/testkit-js/src/contract/in-memory-private-state-provider.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import type { Contract } from '@midnight-ntwrk/compact-js';
-import type { SigningKey } from '@midnight-ntwrk/compact-runtime';
-import type { ContractAddress } from '@midnight-ntwrk/ledger-v8';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import type { SigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import {
   ExportDecryptionError,
   type ExportPrivateStatesOptions,

--- a/testkit-js/testkit-js/src/wallet/midnight-wallet-provider.ts
+++ b/testkit-js/testkit-js/src/wallet/midnight-wallet-provider.ts
@@ -21,7 +21,7 @@ import {
   shieldedToken,
   type TokenType,
   ZswapSecretKeys
-} from '@midnight-ntwrk/ledger-v8';
+} from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { type MidnightProvider, type UnboundTransaction, type WalletProvider } from '@midnight-ntwrk/midnight-js-types';
 import { ttlOneHour } from '@midnight-ntwrk/midnight-js-utils';
 import { type WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';

--- a/testkit-js/testkit-js/src/wallet/wallet-configuration-mapper.ts
+++ b/testkit-js/testkit-js/src/wallet/wallet-configuration-mapper.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { type LedgerParameters } from '@midnight-ntwrk/ledger-v8';
+import { type LedgerParameters } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { type DefaultConfiguration } from '@midnight-ntwrk/wallet-sdk-facade';
 import { InMemoryTransactionHistoryStorage } from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
 

--- a/testkit-js/testkit-js/src/wallet/wallet-factory.ts
+++ b/testkit-js/testkit-js/src/wallet/wallet-factory.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { DustSecretKey, LedgerParameters, ZswapSecretKeys } from '@midnight-ntwrk/ledger-v8';
+import { DustSecretKey, LedgerParameters, ZswapSecretKeys } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { DustWallet, type DustWalletAPI } from '@midnight-ntwrk/wallet-sdk-dust-wallet';
 import { type DefaultConfiguration, WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';
 import { ShieldedWallet, type ShieldedWalletAPI } from '@midnight-ntwrk/wallet-sdk-shielded';

--- a/testkit-js/testkit-js/src/wallet/wallet-utils.ts
+++ b/testkit-js/testkit-js/src/wallet/wallet-utils.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { shieldedToken, type TokenType } from '@midnight-ntwrk/ledger-v8';
+import { shieldedToken, type TokenType } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { type WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';
 import { type ShieldedWalletAPI, type ShieldedWalletState } from '@midnight-ntwrk/wallet-sdk-shielded';
 import { type UnshieldedWalletAPI, type UnshieldedWalletState } from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';

--- a/testkit-js/testkit-js/test/assertions.ut.test.ts
+++ b/testkit-js/testkit-js/test/assertions.ut.test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { StateValue } from '@midnight-ntwrk/compact-runtime';
+import type { StateValue } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 
 import { stateValueEqual } from '@/assertions';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1892,6 +1892,7 @@ __metadata:
     "@fast-check/vitest": "npm:^0.3.0"
     "@midnight-ntwrk/compact-js": "npm:2.5.0"
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*"
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
     "@midnight-ntwrk/midnight-js-utils": "workspace:*"
     vitest: "npm:^4.1.2"
@@ -1904,6 +1905,7 @@ __metadata:
   dependencies:
     "@midnight-ntwrk/dapp-connector-api": "npm:4.0.1"
     "@midnight-ntwrk/ledger-v8": "npm:8.0.3"
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
   languageName: unknown
   linkType: soft
@@ -1926,6 +1928,7 @@ __metadata:
     "@midnight-ntwrk/midnight-js-compact": "workspace:*"
     "@midnight-ntwrk/midnight-js-contracts": "workspace:*"
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*"
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
     "@midnight-ntwrk/midnight-js-utils": "workspace:*"
     "@types/lodash": "npm:^4.17.19"
@@ -1945,6 +1948,7 @@ __metadata:
     "@graphql-codegen/typescript": "npm:^5.0.0"
     "@graphql-codegen/typescript-operations": "npm:^5.0.8"
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*"
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
     "@midnight-ntwrk/midnight-js-utils": "workspace:*"
     "@types/ws": "npm:^8.18.0"
@@ -1962,6 +1966,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/midnight-js-level-private-state-provider@workspace:packages/level-private-state-provider"
   dependencies:
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
     abstract-level: "npm:^3.0.0"
     buffer: "npm:^6.0.3"
@@ -2042,11 +2047,29 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@midnight-ntwrk/midnight-js-protocol@workspace:*, @midnight-ntwrk/midnight-js-protocol@workspace:packages/protocol":
+  version: 0.0.0-use.local
+  resolution: "@midnight-ntwrk/midnight-js-protocol@workspace:packages/protocol"
+  dependencies:
+    "@midnight-ntwrk/compact-js": "npm:2.5.0"
+    "@midnight-ntwrk/compact-runtime": "npm:0.15.0"
+    "@midnight-ntwrk/ledger-v8": "npm:8.0.3"
+    "@midnight-ntwrk/onchain-runtime-v3": "npm:3.0.0"
+    "@midnight-ntwrk/platform-js": "npm:2.2.4"
+    "@rollup/plugin-typescript": "npm:^12.3.0"
+    rollup: "npm:^4.60.0"
+    rollup-plugin-dts: "npm:^6.4.1"
+    typescript: "npm:^6.0.2"
+    vitest: "npm:^4.1.2"
+  languageName: unknown
+  linkType: soft
+
 "@midnight-ntwrk/midnight-js-types@workspace:*, @midnight-ntwrk/midnight-js-types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/midnight-js-types@workspace:packages/types"
   dependencies:
     "@midnight-ntwrk/compact-js": "npm:2.5.0"
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@midnight-ntwrk/platform-js": "npm:2.2.4"
     rxjs: "npm:^7.5.0"
   languageName: unknown
@@ -2057,6 +2080,7 @@ __metadata:
   resolution: "@midnight-ntwrk/midnight-js-utils@workspace:packages/utils"
   dependencies:
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*"
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@scure/base": "npm:^2.0.0"
     "@types/node": "npm:^24.0.0"
   languageName: unknown
@@ -2107,6 +2131,7 @@ __metadata:
     "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "workspace:*"
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*"
     "@midnight-ntwrk/midnight-js-node-zk-config-provider": "workspace:*"
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
     "@midnight-ntwrk/midnight-js-utils": "workspace:*"
     "@midnight-ntwrk/testkit-js": "workspace:*"
@@ -2141,6 +2166,7 @@ __metadata:
     "@midnight-ntwrk/midnight-js-level-private-state-provider": "workspace:*"
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*"
     "@midnight-ntwrk/midnight-js-node-zk-config-provider": "workspace:*"
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
     "@midnight-ntwrk/midnight-js-utils": "workspace:*"
     "@midnight-ntwrk/wallet-sdk-hd": "npm:3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,7 +1890,6 @@ __metadata:
   resolution: "@midnight-ntwrk/midnight-js-contracts@workspace:packages/contracts"
   dependencies:
     "@fast-check/vitest": "npm:^0.3.0"
-    "@midnight-ntwrk/compact-js": "npm:2.5.0"
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*"
     "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
@@ -1904,7 +1903,6 @@ __metadata:
   resolution: "@midnight-ntwrk/midnight-js-dapp-connector-proof-provider@workspace:packages/dapp-connector-proof-provider"
   dependencies:
     "@midnight-ntwrk/dapp-connector-api": "npm:4.0.1"
-    "@midnight-ntwrk/ledger-v8": "npm:8.0.3"
     "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
   languageName: unknown
@@ -2068,9 +2066,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/midnight-js-types@workspace:packages/types"
   dependencies:
-    "@midnight-ntwrk/compact-js": "npm:2.5.0"
     "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
-    "@midnight-ntwrk/platform-js": "npm:2.2.4"
     rxjs: "npm:^7.5.0"
   languageName: unknown
   linkType: soft
@@ -2124,7 +2120,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/testkit-js-e2e@workspace:testkit-js/testkit-js-e2e"
   dependencies:
-    "@midnight-ntwrk/compact-js": "npm:2.5.0"
     "@midnight-ntwrk/midnight-js-compact": "workspace:*"
     "@midnight-ntwrk/midnight-js-contracts": "workspace:*"
     "@midnight-ntwrk/midnight-js-http-client-proof-provider": "workspace:*"
@@ -2157,8 +2152,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/testkit-js@workspace:testkit-js/testkit-js"
   dependencies:
-    "@midnight-ntwrk/compact-js": "npm:2.5.0"
-    "@midnight-ntwrk/ledger-v8": "npm:8.0.3"
     "@midnight-ntwrk/midnight-js-compact": "workspace:*"
     "@midnight-ntwrk/midnight-js-contracts": "workspace:*"
     "@midnight-ntwrk/midnight-js-http-client-proof-provider": "workspace:*"


### PR DESCRIPTION
## Summary

- Introduces `@midnight-ntwrk/midnight-js-protocol` — a thin re-export barrel with subpath exports wrapping 5 external protocol packages (`ledger-v8`, `compact-runtime`, `compact-js`, `onchain-runtime-v3`, `platform-js`) behind version-agnostic paths
- Migrates all ~93 source files across 9 packages to import from `@midnight-ntwrk/midnight-js-protocol/<subpath>` instead of directly from protocol packages
- Adds ESLint `no-restricted-imports` rule to enforce the ACL boundary going forward

## Motivation

These 5 external packages are tightly coupled and upgrade together on every Midnight network release. Currently a protocol upgrade requires mechanical changes across ~94 files in 9 packages. With this ACL, future upgrades only touch `packages/protocol/` — no consumer files change.

## Changes

| Commit | Scope |
|--------|-------|
| Scaffold protocol package | `packages/protocol/` — package.json, rollup, tsconfig, 10 re-export source files |
| Add dependency | 9 consumer `package.json` files |
| Migrate imports | 93 source files — pure import path find-and-replace |
| Remove old deps | 5 consumer `package.json` files — remove now-transitive protocol deps |
| ESLint guard | `eslint.config.mjs` — ban direct protocol imports outside `packages/protocol/` |

## What this does NOT change

- Zero logic changes — pure import path refactoring
- Zero runtime behavior changes
- No public API changes
- Auto-generated Compact compiler output (`**/compiled/**`) is excluded

## Test plan

- [x] Full monorepo build passes (`yarn build --force` — 16/16)
- [x] Full test suite passes (`yarn test` — 24/24)
- [x] Lint clean (`yarn lint`)
- [x] Grep confirms zero remaining direct protocol imports outside `packages/protocol/`
- [x] ESLint rule catches any future direct protocol imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)