### PR TITLE
chore(midnight-js): add protocol as dependency of barrel package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ TypeScript application development framework for the Midnight blockchain. Simila
 ## Installation
 
 ```bash
-yarn add @midnight-ntwrk/midnight-js-contracts @midnight-ntwrk/midnight-js-protocol
+yarn add @midnight-ntwrk/midnight-js
 ```
 
 ## Quick Start

--- a/packages/midnight-js/README.md
+++ b/packages/midnight-js/README.md
@@ -28,6 +28,7 @@ const deployed = await contracts.deployContract(providers, {
 | ------------ | ---------------------------------------- | ---------------------------------------------- |
 | `contracts`  | `@midnight-ntwrk/midnight-js-contracts`  | Contract deployment and interaction utilities   |
 | `networkId`  | `@midnight-ntwrk/midnight-js-network-id` | Network identifier management                  |
+| `protocol`   | `@midnight-ntwrk/midnight-js-protocol`   | Version-agnostic protocol type re-exports       |
 | `types`      | `@midnight-ntwrk/midnight-js-types`      | Shared types, interfaces, and provider contracts|
 | `utils`      | `@midnight-ntwrk/midnight-js-utils`      | Hex encoding, address validation, and utilities |
 

--- a/packages/midnight-js/package.json
+++ b/packages/midnight-js/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "@midnight-ntwrk/midnight-js-contracts": "workspace:*",
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*",
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
     "@midnight-ntwrk/midnight-js-types": "workspace:*",
     "@midnight-ntwrk/midnight-js-utils": "workspace:*"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2085,6 +2085,7 @@ __metadata:
   dependencies:
     "@midnight-ntwrk/midnight-js-contracts": "workspace:*"
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*"
+    "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
     "@midnight-ntwrk/midnight-js-utils": "workspace:*"
     "@rollup/plugin-typescript": "npm:^12.3.0"


### PR DESCRIPTION
## Summary

- Add `@midnight-ntwrk/midnight-js-protocol` as a dependency of `@midnight-ntwrk/midnight-js` barrel package
- No re-exports added — protocol is consumed directly via its own subpath imports
- `yarn add @midnight-ntwrk/midnight-js` now transitively installs the protocol package
- Update barrel README to list protocol in the modules table

## Test plan

- [ ] Verify `yarn install` resolves protocol as transitive dependency
- [ ] Verify no runtime changes — protocol is not re-exported

🤖 Generated with [Claude Code](https://claude.ai/code)