### PR TITLE
feat(testkit-js): add DAppConnectorWalletAdapter and DAppConnectorInitialAPI

### DIFF
--- a/testkit-js/testkit-js-e2e/package.json
+++ b/testkit-js/testkit-js-e2e/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@midnight-ntwrk/midnight-js-compact": "workspace:*",
     "@midnight-ntwrk/midnight-js-contracts": "workspace:*",
+    "@midnight-ntwrk/midnight-js-dapp-connector-proof-provider": "workspace:*",
     "@midnight-ntwrk/midnight-js-http-client-proof-provider": "workspace:*",
     "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "workspace:*",
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*",

--- a/testkit-js/testkit-js-e2e/test/dapp-connector-proving.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/dapp-connector-proving.it.test.ts
@@ -1,0 +1,105 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { deployContract } from '@midnight-ntwrk/midnight-js-contracts';
+import { dappConnectorProofProvider } from '@midnight-ntwrk/midnight-js-dapp-connector-proof-provider';
+import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
+import { levelPrivateStateProvider } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
+import { NodeZkConfigProvider } from '@midnight-ntwrk/midnight-js-node-zk-config-provider';
+import { CostModel } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import { type PrivateStateId } from '@midnight-ntwrk/midnight-js-types';
+import {
+  createLogger,
+  DAppConnectorWalletAdapter,
+  type EnvironmentConfiguration,
+  expectSuccessfulCallTx,
+  expectSuccessfulDeployTx,
+  getTestEnvironment,
+  type MidnightWalletProvider,
+  type TestEnvironment,
+} from '@midnight-ntwrk/testkit-js';
+import path from 'path';
+
+import * as api from '@/counter-api';
+import type { SimpleProviders } from '@/types/simple-types';
+
+const logger = createLogger(
+  path.resolve(`${process.cwd()}`, 'logs', 'tests', `dapp_connector_proving_${new Date().toISOString()}.log`),
+);
+
+describe('DApp Connector Proving', () => {
+  let testEnvironment: TestEnvironment;
+  let environmentConfiguration: EnvironmentConfiguration;
+  let wallet: MidnightWalletProvider;
+  let walletAdapter: DAppConnectorWalletAdapter;
+
+  beforeAll(async () => {
+    testEnvironment = getTestEnvironment(logger);
+    environmentConfiguration = await testEnvironment.start();
+    api.setLogger(logger);
+    wallet = await testEnvironment.getMidnightWalletProvider();
+    walletAdapter = new DAppConnectorWalletAdapter(wallet, environmentConfiguration);
+  });
+
+  afterAll(async () => {
+    await testEnvironment.shutdown();
+  });
+
+  beforeEach(() => {
+    logger.info(`Running test=${expect.getState().currentTestName}`);
+  });
+
+  /**
+   * @given A DAppConnectorWalletAdapter wrapping a started MidnightWalletProvider
+   * @and A dappConnectorProofProvider created from the adapter's getProvingProvider
+   * @when Deploying a simple contract (no private state) using wallet-delegated proving
+   * @and Calling a circuit on the deployed contract
+   * @then Deploy transaction should succeed and be confirmed on-chain
+   * @and Call transaction should succeed and be confirmed on-chain
+   * @and No proof server should be needed (proving happens locally via WASM)
+   */
+  test('should deploy and call contract using dapp-connector-proof-provider with wallet-delegated proving [@slow]', async () => {
+    const contractConfiguration = new api.SimpleConfiguration();
+    const zkConfigProvider = new NodeZkConfigProvider<string>(contractConfiguration.zkConfigPath);
+    const costModel = CostModel.initialCostModel();
+
+    const proofProvider = await dappConnectorProofProvider(walletAdapter, zkConfigProvider, costModel);
+
+    const coinPublicKey = wallet.getCoinPublicKey();
+    const accountId = Buffer.from(coinPublicKey).toString('hex');
+
+    const providers: SimpleProviders = {
+      privateStateProvider: levelPrivateStateProvider<PrivateStateId, undefined>({
+        privateStateStoreName: `dapp-connector-proving-test-${Date.now()}`,
+        signingKeyStoreName: `dapp-connector-proving-test-${Date.now()}-signing-keys`,
+        privateStoragePasswordProvider: () => 'test-password',
+        accountId,
+      }),
+      publicDataProvider: indexerPublicDataProvider(environmentConfiguration.indexer, environmentConfiguration.indexerWS),
+      zkConfigProvider,
+      proofProvider,
+      walletProvider: walletAdapter,
+      midnightProvider: walletAdapter,
+    };
+
+    const deployedContract = await deployContract(providers, {
+      compiledContract: api.CompiledSimpleContract,
+    });
+    await expectSuccessfulDeployTx(providers, deployedContract.deployTxData);
+
+    const callTxData = await deployedContract.callTx.noop();
+    await expectSuccessfulCallTx(providers, callTxData);
+  });
+});

--- a/testkit-js/testkit-js-e2e/test/dapp-connector-proving.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/dapp-connector-proving.it.test.ts
@@ -85,7 +85,7 @@ describe('DApp Connector Proving', () => {
       privateStateProvider: levelPrivateStateProvider<PrivateStateId, undefined>({
         privateStateStoreName: `dapp-connector-proving-test-${storeSuffix}`,
         signingKeyStoreName: `dapp-connector-proving-test-${storeSuffix}-signing-keys`,
-        privateStoragePasswordProvider: () => 'test-password',
+        privateStoragePasswordProvider: () => 'test-password-1234',
         accountId,
       }),
       publicDataProvider: indexerPublicDataProvider(environmentConfiguration.indexer, environmentConfiguration.indexerWS),

--- a/testkit-js/testkit-js-e2e/test/dapp-connector-proving.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/dapp-connector-proving.it.test.ts
@@ -79,19 +79,20 @@ describe('DApp Connector Proving', () => {
 
     const coinPublicKey = wallet.getCoinPublicKey();
     const accountId = Buffer.from(coinPublicKey).toString('hex');
+    const storeSuffix = Date.now();
 
     const providers: SimpleProviders = {
       privateStateProvider: levelPrivateStateProvider<PrivateStateId, undefined>({
-        privateStateStoreName: `dapp-connector-proving-test-${Date.now()}`,
-        signingKeyStoreName: `dapp-connector-proving-test-${Date.now()}-signing-keys`,
+        privateStateStoreName: `dapp-connector-proving-test-${storeSuffix}`,
+        signingKeyStoreName: `dapp-connector-proving-test-${storeSuffix}-signing-keys`,
         privateStoragePasswordProvider: () => 'test-password',
         accountId,
       }),
       publicDataProvider: indexerPublicDataProvider(environmentConfiguration.indexer, environmentConfiguration.indexerWS),
       zkConfigProvider,
       proofProvider,
-      walletProvider: walletAdapter,
-      midnightProvider: walletAdapter,
+      walletProvider: wallet,
+      midnightProvider: wallet,
     };
 
     const deployedContract = await deployContract(providers, {

--- a/testkit-js/testkit-js-e2e/test/dapp-connector-proving.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/dapp-connector-proving.it.test.ts
@@ -85,7 +85,7 @@ describe('DApp Connector Proving', () => {
       privateStateProvider: levelPrivateStateProvider<PrivateStateId, undefined>({
         privateStateStoreName: `dapp-connector-proving-test-${storeSuffix}`,
         signingKeyStoreName: `dapp-connector-proving-test-${storeSuffix}-signing-keys`,
-        privateStoragePasswordProvider: () => 'test-password-1234',
+        privateStoragePasswordProvider: () => 'Answer to the Ultimate Question of Life, the Universe, and Everything!',
         accountId,
       }),
       publicDataProvider: indexerPublicDataProvider(environmentConfiguration.indexer, environmentConfiguration.indexerWS),

--- a/testkit-js/testkit-js/package.json
+++ b/testkit-js/testkit-js/package.json
@@ -32,6 +32,7 @@
     "deploy": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
+    "@midnight-ntwrk/dapp-connector-api": "4.0.1",
     "@midnight-ntwrk/midnight-js-compact": "workspace:*",
     "@midnight-ntwrk/midnight-js-contracts": "workspace:*",
     "@midnight-ntwrk/midnight-js-http-client-proof-provider": "workspace:*",
@@ -42,7 +43,10 @@
     "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
     "@midnight-ntwrk/midnight-js-types": "workspace:*",
     "@midnight-ntwrk/midnight-js-utils": "workspace:*",
+    "@midnight-ntwrk/wallet-sdk-address-format": "3.1.0",
     "@midnight-ntwrk/wallet-sdk-hd": "3.0.1",
+    "@midnight-ntwrk/wallet-sdk-prover-client": "^1.2.0",
+    "@midnight-ntwrk/zkir-v2": "2.1.0",
     "buffer": "^6.0.3",
     "cross-fetch": "^4.0.0",
     "rxjs": "^7.8.1",

--- a/testkit-js/testkit-js/src/wallet/dapp-connector-initial-api.ts
+++ b/testkit-js/testkit-js/src/wallet/dapp-connector-initial-api.ts
@@ -1,0 +1,46 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ConnectedAPI, InitialAPI } from '@midnight-ntwrk/dapp-connector-api';
+
+export class DAppConnectorInitialAPI implements InitialAPI {
+  readonly rdns: string;
+  readonly name: string;
+  readonly icon: string;
+  readonly apiVersion: string;
+
+  private readonly connectedWallet: ConnectedAPI;
+  private readonly expectedNetworkId: string;
+
+  constructor(
+    connectedWallet: ConnectedAPI,
+    networkId: string,
+    options?: { rdns?: string; name?: string; icon?: string; apiVersion?: string },
+  ) {
+    this.connectedWallet = connectedWallet;
+    this.expectedNetworkId = networkId;
+    this.rdns = options?.rdns ?? 'com.midnight.test-wallet';
+    this.name = options?.name ?? 'Test Wallet';
+    this.icon = options?.icon ?? 'data:image/svg+xml,<svg/>';
+    this.apiVersion = options?.apiVersion ?? '4.0.1';
+  }
+
+  async connect(networkId: string): Promise<ConnectedAPI> {
+    if (networkId !== this.expectedNetworkId) {
+      throw new Error(`Network ID mismatch: expected '${this.expectedNetworkId}', got '${networkId}'`);
+    }
+    return this.connectedWallet;
+  }
+}

--- a/testkit-js/testkit-js/src/wallet/dapp-connector-wallet-adapter.ts
+++ b/testkit-js/testkit-js/src/wallet/dapp-connector-wallet-adapter.ts
@@ -30,6 +30,7 @@ import type {
 import { Transaction as LedgerTransaction } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { fromHex, toHex, ttlOneHour } from '@midnight-ntwrk/midnight-js-utils';
 import { DustAddress, MidnightBech32m } from '@midnight-ntwrk/wallet-sdk-address-format';
+import type { BalancingRecipe } from '@midnight-ntwrk/wallet-sdk-facade';
 import { makeDefaultKeyMaterialProvider } from '@midnight-ntwrk/wallet-sdk-prover-client/effect';
 import {
   type KeyMaterialProvider as ZkirKeyMaterialProvider,
@@ -42,15 +43,12 @@ import type { EnvironmentConfiguration } from '@/test-environment/environment-co
 import type { MidnightWalletProvider } from './midnight-wallet-provider';
 
 export class DAppConnectorWalletAdapter implements ConnectedAPI {
-  private readonly walletFacade: WalletFacade;
-  private readonly unshieldedKeystore: UnshieldedKeystore;
   private readonly walletProvider: MidnightWalletProvider;
   private readonly environmentConfiguration: EnvironmentConfiguration;
+  private cachedDefaultKeyMaterialProvider?: ZkirKeyMaterialProvider;
 
   constructor(walletProvider: MidnightWalletProvider, environmentConfiguration: EnvironmentConfiguration) {
     this.walletProvider = walletProvider;
-    this.walletFacade = walletProvider.wallet;
-    this.unshieldedKeystore = walletProvider.unshieldedKeystore;
     this.environmentConfiguration = environmentConfiguration;
   }
 
@@ -59,7 +57,7 @@ export class DAppConnectorWalletAdapter implements ConnectedAPI {
     shieldedCoinPublicKey: string;
     shieldedEncryptionPublicKey: string;
   }> {
-    const state = await firstValueFrom(this.walletFacade.shielded.state);
+    const state = await firstValueFrom(this.walletProvider.wallet.shielded.state);
     return {
       shieldedAddress: MidnightBech32m.encode(this.environmentConfiguration.networkId, state.address).asString(),
       shieldedCoinPublicKey: state.address.coinPublicKeyString(),
@@ -69,7 +67,7 @@ export class DAppConnectorWalletAdapter implements ConnectedAPI {
 
   async getUnshieldedAddress(): Promise<{ unshieldedAddress: string }> {
     return {
-      unshieldedAddress: this.unshieldedKeystore.getBech32Address().asString(),
+      unshieldedAddress: this.walletProvider.unshieldedKeystore.getBech32Address().asString(),
     };
   }
 
@@ -83,17 +81,17 @@ export class DAppConnectorWalletAdapter implements ConnectedAPI {
   }
 
   async getShieldedBalances(): Promise<Record<TokenType, bigint>> {
-    const state = await firstValueFrom(this.walletFacade.shielded.state);
+    const state = await firstValueFrom(this.walletProvider.wallet.shielded.state);
     return state.balances;
   }
 
   async getUnshieldedBalances(): Promise<Record<TokenType, bigint>> {
-    const state = await firstValueFrom(this.walletFacade.unshielded.state);
+    const state = await firstValueFrom(this.walletProvider.wallet.unshielded.state);
     return state.balances;
   }
 
   async getDustBalance(): Promise<{ cap: bigint; balance: bigint }> {
-    const state = await firstValueFrom(this.walletFacade.dust.state);
+    const state = await firstValueFrom(this.walletProvider.wallet.dust.state);
     return {
       balance: state.balance(new Date()),
       cap: 0n,
@@ -103,42 +101,28 @@ export class DAppConnectorWalletAdapter implements ConnectedAPI {
   async balanceUnsealedTransaction(tx: string, options?: { payFees?: boolean }): Promise<{ tx: string }> {
     const unboundTx = LedgerTransaction.deserialize('signature', 'proof', 'preBinding', fromHex(tx));
     const tokenKindsToBalance = options?.payFees === false ? (['shielded', 'unshielded'] as const) : ('all' as const);
-    const recipe = await this.walletFacade.balanceUnboundTransaction(
+    const recipe = await this.walletProvider.wallet.balanceUnboundTransaction(
       unboundTx,
-      {
-        shieldedSecretKeys: this.walletProvider.zswapSecretKeys,
-        dustSecretKey: this.walletProvider.dustSecretKey,
-      },
+      this.secretKeys(),
       { ttl: ttlOneHour(), tokenKindsToBalance },
     );
-    const signed = await this.walletFacade.signRecipe(recipe, (payload) =>
-      this.unshieldedKeystore.signData(payload),
-    );
-    const finalized = await this.walletFacade.finalizeRecipe(signed);
-    return { tx: toHex(finalized.serialize()) };
+    return this.signAndFinalize(recipe);
   }
 
   async balanceSealedTransaction(tx: string, options?: { payFees?: boolean }): Promise<{ tx: string }> {
     const finalizedTx = LedgerTransaction.deserialize('signature', 'proof', 'binding', fromHex(tx));
     const tokenKindsToBalance = options?.payFees === false ? (['shielded', 'unshielded'] as const) : ('all' as const);
-    const recipe = await this.walletFacade.balanceFinalizedTransaction(
+    const recipe = await this.walletProvider.wallet.balanceFinalizedTransaction(
       finalizedTx,
-      {
-        shieldedSecretKeys: this.walletProvider.zswapSecretKeys,
-        dustSecretKey: this.walletProvider.dustSecretKey,
-      },
+      this.secretKeys(),
       { ttl: ttlOneHour(), tokenKindsToBalance },
     );
-    const signed = await this.walletFacade.signRecipe(recipe, (payload) =>
-      this.unshieldedKeystore.signData(payload),
-    );
-    const finalized = await this.walletFacade.finalizeRecipe(signed);
-    return { tx: toHex(finalized.serialize()) };
+    return this.signAndFinalize(recipe);
   }
 
   async submitTransaction(tx: string): Promise<void> {
     const finalizedTx = LedgerTransaction.deserialize('signature', 'proof', 'binding', fromHex(tx));
-    await this.walletFacade.submitTransaction(finalizedTx);
+    await this.walletProvider.wallet.submitTransaction(finalizedTx);
   }
 
   async signData(data: string, options: SignDataOptions): Promise<Signature> {
@@ -154,16 +138,16 @@ export class DAppConnectorWalletAdapter implements ConnectedAPI {
         bytes = Buffer.from(data, 'utf-8');
         break;
     }
-    const signature = this.unshieldedKeystore.signData(bytes);
+    const signature = this.walletProvider.unshieldedKeystore.signData(bytes);
     return {
       data,
       signature: String(signature),
-      verifyingKey: String(this.unshieldedKeystore.getPublicKey()),
+      verifyingKey: String(this.walletProvider.unshieldedKeystore.getPublicKey()),
     };
   }
 
   async getProvingProvider(keyMaterialProvider: DAppKeyMaterialProvider): Promise<ProvingProvider> {
-    const defaultProvider = makeDefaultKeyMaterialProvider();
+    const defaultProvider = this.getDefaultKeyMaterialProvider();
     const zkirProvider: ZkirKeyMaterialProvider = {
       async lookupKey(keyLocation: string) {
         try {
@@ -219,5 +203,25 @@ export class DAppConnectorWalletAdapter implements ConnectedAPI {
 
   async getTxHistory(_pageNumber: number, _pageSize: number): Promise<HistoryEntry[]> {
     throw new Error('Not implemented in DAppConnectorWalletAdapter');
+  }
+
+  private secretKeys() {
+    return {
+      shieldedSecretKeys: this.walletProvider.zswapSecretKeys,
+      dustSecretKey: this.walletProvider.dustSecretKey,
+    };
+  }
+
+  private async signAndFinalize(recipe: BalancingRecipe): Promise<{ tx: string }> {
+    const signed = await this.walletProvider.wallet.signRecipe(recipe, (payload) =>
+      this.walletProvider.unshieldedKeystore.signData(payload),
+    );
+    const finalized = await this.walletProvider.wallet.finalizeRecipe(signed);
+    return { tx: toHex(finalized.serialize()) };
+  }
+
+  private getDefaultKeyMaterialProvider(): ZkirKeyMaterialProvider {
+    this.cachedDefaultKeyMaterialProvider ??= makeDefaultKeyMaterialProvider();
+    return this.cachedDefaultKeyMaterialProvider;
   }
 }

--- a/testkit-js/testkit-js/src/wallet/dapp-connector-wallet-adapter.ts
+++ b/testkit-js/testkit-js/src/wallet/dapp-connector-wallet-adapter.ts
@@ -1,0 +1,223 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  Configuration,
+  ConnectedAPI,
+  ConnectionStatus,
+  DesiredInput,
+  DesiredOutput,
+  HistoryEntry,
+  KeyMaterialProvider as DAppKeyMaterialProvider,
+  ProvingProvider,
+  Signature,
+  SignDataOptions,
+  TokenType,
+  WalletConnectedAPI,
+} from '@midnight-ntwrk/dapp-connector-api';
+import { Transaction as LedgerTransaction } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import { fromHex, toHex, ttlOneHour } from '@midnight-ntwrk/midnight-js-utils';
+import { DustAddress, MidnightBech32m } from '@midnight-ntwrk/wallet-sdk-address-format';
+import { makeDefaultKeyMaterialProvider } from '@midnight-ntwrk/wallet-sdk-prover-client/effect';
+import {
+  type KeyMaterialProvider as ZkirKeyMaterialProvider,
+  provingProvider as createLocalProvingProvider,
+} from '@midnight-ntwrk/zkir-v2';
+import { firstValueFrom } from 'rxjs';
+
+import type { EnvironmentConfiguration } from '@/test-environment/environment-configuration';
+
+import type { MidnightWalletProvider } from './midnight-wallet-provider';
+
+export class DAppConnectorWalletAdapter implements ConnectedAPI {
+  private readonly walletFacade: WalletFacade;
+  private readonly unshieldedKeystore: UnshieldedKeystore;
+  private readonly walletProvider: MidnightWalletProvider;
+  private readonly environmentConfiguration: EnvironmentConfiguration;
+
+  constructor(walletProvider: MidnightWalletProvider, environmentConfiguration: EnvironmentConfiguration) {
+    this.walletProvider = walletProvider;
+    this.walletFacade = walletProvider.wallet;
+    this.unshieldedKeystore = walletProvider.unshieldedKeystore;
+    this.environmentConfiguration = environmentConfiguration;
+  }
+
+  async getShieldedAddresses(): Promise<{
+    shieldedAddress: string;
+    shieldedCoinPublicKey: string;
+    shieldedEncryptionPublicKey: string;
+  }> {
+    const state = await firstValueFrom(this.walletFacade.shielded.state);
+    return {
+      shieldedAddress: MidnightBech32m.encode(this.environmentConfiguration.networkId, state.address).asString(),
+      shieldedCoinPublicKey: state.address.coinPublicKeyString(),
+      shieldedEncryptionPublicKey: state.address.encryptionPublicKeyString(),
+    };
+  }
+
+  async getUnshieldedAddress(): Promise<{ unshieldedAddress: string }> {
+    return {
+      unshieldedAddress: this.unshieldedKeystore.getBech32Address().asString(),
+    };
+  }
+
+  async getDustAddress(): Promise<{ dustAddress: string }> {
+    return {
+      dustAddress: DustAddress.encodePublicKey(
+        this.environmentConfiguration.networkId,
+        this.walletProvider.dustSecretKey.publicKey,
+      ),
+    };
+  }
+
+  async getShieldedBalances(): Promise<Record<TokenType, bigint>> {
+    const state = await firstValueFrom(this.walletFacade.shielded.state);
+    return state.balances;
+  }
+
+  async getUnshieldedBalances(): Promise<Record<TokenType, bigint>> {
+    const state = await firstValueFrom(this.walletFacade.unshielded.state);
+    return state.balances;
+  }
+
+  async getDustBalance(): Promise<{ cap: bigint; balance: bigint }> {
+    const state = await firstValueFrom(this.walletFacade.dust.state);
+    return {
+      balance: state.balance(new Date()),
+      cap: 0n,
+    };
+  }
+
+  async balanceUnsealedTransaction(tx: string, options?: { payFees?: boolean }): Promise<{ tx: string }> {
+    const unboundTx = LedgerTransaction.deserialize('signature', 'proof', 'preBinding', fromHex(tx));
+    const tokenKindsToBalance = options?.payFees === false ? (['shielded', 'unshielded'] as const) : ('all' as const);
+    const recipe = await this.walletFacade.balanceUnboundTransaction(
+      unboundTx,
+      {
+        shieldedSecretKeys: this.walletProvider.zswapSecretKeys,
+        dustSecretKey: this.walletProvider.dustSecretKey,
+      },
+      { ttl: ttlOneHour(), tokenKindsToBalance },
+    );
+    const signed = await this.walletFacade.signRecipe(recipe, (payload) =>
+      this.unshieldedKeystore.signData(payload),
+    );
+    const finalized = await this.walletFacade.finalizeRecipe(signed);
+    return { tx: toHex(finalized.serialize()) };
+  }
+
+  async balanceSealedTransaction(tx: string, options?: { payFees?: boolean }): Promise<{ tx: string }> {
+    const finalizedTx = LedgerTransaction.deserialize('signature', 'proof', 'binding', fromHex(tx));
+    const tokenKindsToBalance = options?.payFees === false ? (['shielded', 'unshielded'] as const) : ('all' as const);
+    const recipe = await this.walletFacade.balanceFinalizedTransaction(
+      finalizedTx,
+      {
+        shieldedSecretKeys: this.walletProvider.zswapSecretKeys,
+        dustSecretKey: this.walletProvider.dustSecretKey,
+      },
+      { ttl: ttlOneHour(), tokenKindsToBalance },
+    );
+    const signed = await this.walletFacade.signRecipe(recipe, (payload) =>
+      this.unshieldedKeystore.signData(payload),
+    );
+    const finalized = await this.walletFacade.finalizeRecipe(signed);
+    return { tx: toHex(finalized.serialize()) };
+  }
+
+  async submitTransaction(tx: string): Promise<void> {
+    const finalizedTx = LedgerTransaction.deserialize('signature', 'proof', 'binding', fromHex(tx));
+    await this.walletFacade.submitTransaction(finalizedTx);
+  }
+
+  async signData(data: string, options: SignDataOptions): Promise<Signature> {
+    let bytes: Uint8Array;
+    switch (options.encoding) {
+      case 'hex':
+        bytes = fromHex(data);
+        break;
+      case 'base64':
+        bytes = Buffer.from(data, 'base64');
+        break;
+      case 'text':
+        bytes = Buffer.from(data, 'utf-8');
+        break;
+    }
+    const signature = this.unshieldedKeystore.signData(bytes);
+    return {
+      data,
+      signature: String(signature),
+      verifyingKey: String(this.unshieldedKeystore.getPublicKey()),
+    };
+  }
+
+  async getProvingProvider(keyMaterialProvider: DAppKeyMaterialProvider): Promise<ProvingProvider> {
+    const defaultProvider = makeDefaultKeyMaterialProvider();
+    const zkirProvider: ZkirKeyMaterialProvider = {
+      async lookupKey(keyLocation: string) {
+        try {
+          const [ir, proverKey, verifierKey] = await Promise.all([
+            keyMaterialProvider.getZKIR(keyLocation),
+            keyMaterialProvider.getProverKey(keyLocation),
+            keyMaterialProvider.getVerifierKey(keyLocation),
+          ]);
+          return { ir, proverKey, verifierKey };
+        } catch {
+          return defaultProvider.lookupKey(keyLocation);
+        }
+      },
+      async getParams(k: number) {
+        return defaultProvider.getParams(k);
+      },
+    };
+    return createLocalProvingProvider(zkirProvider);
+  }
+
+  async getConfiguration(): Promise<Configuration> {
+    return {
+      indexerUri: this.environmentConfiguration.indexer,
+      indexerWsUri: this.environmentConfiguration.indexerWS,
+      proverServerUri: this.environmentConfiguration.proofServer,
+      substrateNodeUri: this.environmentConfiguration.node,
+      networkId: this.environmentConfiguration.networkId,
+    };
+  }
+
+  async getConnectionStatus(): Promise<ConnectionStatus> {
+    return { status: 'connected', networkId: this.environmentConfiguration.networkId };
+  }
+
+  async hintUsage(_methodNames: (keyof WalletConnectedAPI)[]): Promise<void> {
+    // No-op for test wallet
+  }
+
+  async makeTransfer(
+    _desiredOutputs: DesiredOutput[],
+    _options?: { payFees?: boolean },
+  ): Promise<{ tx: string }> {
+    throw new Error('Not implemented in DAppConnectorWalletAdapter');
+  }
+
+  async makeIntent(
+    _desiredInputs: DesiredInput[],
+    _desiredOutputs: DesiredOutput[],
+    _options: { intentId: number | 'random'; payFees: boolean },
+  ): Promise<{ tx: string }> {
+    throw new Error('Not implemented in DAppConnectorWalletAdapter');
+  }
+
+  async getTxHistory(_pageNumber: number, _pageSize: number): Promise<HistoryEntry[]> {
+    throw new Error('Not implemented in DAppConnectorWalletAdapter');
+  }
+}

--- a/testkit-js/testkit-js/src/wallet/dapp-connector-wallet-adapter.ts
+++ b/testkit-js/testkit-js/src/wallet/dapp-connector-wallet-adapter.ts
@@ -31,7 +31,7 @@ import { Transaction as LedgerTransaction } from '@midnight-ntwrk/midnight-js-pr
 import { fromHex, toHex, ttlOneHour } from '@midnight-ntwrk/midnight-js-utils';
 import { DustAddress, MidnightBech32m } from '@midnight-ntwrk/wallet-sdk-address-format';
 import type { BalancingRecipe } from '@midnight-ntwrk/wallet-sdk-facade';
-import { makeDefaultKeyMaterialProvider } from '@midnight-ntwrk/wallet-sdk-prover-client/effect';
+import { WasmProver } from '@midnight-ntwrk/wallet-sdk-prover-client/effect';
 import {
   type KeyMaterialProvider as ZkirKeyMaterialProvider,
   provingProvider as createLocalProvingProvider,
@@ -43,11 +43,14 @@ import type { EnvironmentConfiguration } from '@/test-environment/environment-co
 import type { MidnightWalletProvider } from './midnight-wallet-provider';
 
 export class DAppConnectorWalletAdapter implements ConnectedAPI {
-  private readonly walletProvider: MidnightWalletProvider;
+  private readonly walletProvider: Pick<MidnightWalletProvider, 'wallet' | 'unshieldedKeystore' | 'zswapSecretKeys' | 'dustSecretKey'>;
   private readonly environmentConfiguration: EnvironmentConfiguration;
   private cachedDefaultKeyMaterialProvider?: ZkirKeyMaterialProvider;
 
-  constructor(walletProvider: MidnightWalletProvider, environmentConfiguration: EnvironmentConfiguration) {
+  constructor(
+    walletProvider: Pick<MidnightWalletProvider, 'wallet' | 'unshieldedKeystore' | 'zswapSecretKeys' | 'dustSecretKey'>,
+    environmentConfiguration: EnvironmentConfiguration,
+  ) {
     this.walletProvider = walletProvider;
     this.environmentConfiguration = environmentConfiguration;
   }
@@ -141,8 +144,8 @@ export class DAppConnectorWalletAdapter implements ConnectedAPI {
     const signature = this.walletProvider.unshieldedKeystore.signData(bytes);
     return {
       data,
-      signature: String(signature),
-      verifyingKey: String(this.walletProvider.unshieldedKeystore.getPublicKey()),
+      signature,
+      verifyingKey: this.walletProvider.unshieldedKeystore.getPublicKey(),
     };
   }
 
@@ -157,7 +160,8 @@ export class DAppConnectorWalletAdapter implements ConnectedAPI {
             keyMaterialProvider.getVerifierKey(keyLocation),
           ]);
           return { ir, proverKey, verifierKey };
-        } catch {
+        } catch (error) {
+          console.debug(`DApp key material lookup failed for '${keyLocation}', falling back to default provider`, error);
           return defaultProvider.lookupKey(keyLocation);
         }
       },
@@ -221,7 +225,7 @@ export class DAppConnectorWalletAdapter implements ConnectedAPI {
   }
 
   private getDefaultKeyMaterialProvider(): ZkirKeyMaterialProvider {
-    this.cachedDefaultKeyMaterialProvider ??= makeDefaultKeyMaterialProvider();
+    this.cachedDefaultKeyMaterialProvider ??= WasmProver.makeDefaultKeyMaterialProvider();
     return this.cachedDefaultKeyMaterialProvider;
   }
 }

--- a/testkit-js/testkit-js/src/wallet/index.ts
+++ b/testkit-js/testkit-js/src/wallet/index.ts
@@ -15,6 +15,8 @@
 
 import './bigint-serialization';
 
+export * from './dapp-connector-initial-api';
+export * from './dapp-connector-wallet-adapter';
 export * from './fluent-wallet-builder';
 export * from './gzip-file';
 export * from './midnight-wallet-provider';

--- a/testkit-js/testkit-js/test/dapp-connector-initial-api.ut.test.ts
+++ b/testkit-js/testkit-js/test/dapp-connector-initial-api.ut.test.ts
@@ -1,0 +1,66 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ConnectedAPI } from '@midnight-ntwrk/dapp-connector-api';
+
+import { DAppConnectorInitialAPI } from '@/wallet/dapp-connector-initial-api';
+
+describe('[Unit tests] DAppConnectorInitialAPI', () => {
+  const mockConnectedWallet = {} as ConnectedAPI;
+  const networkId = 'testnet';
+
+  describe('properties', () => {
+    it('should have correct defaults when no options provided', () => {
+      const api = new DAppConnectorInitialAPI(mockConnectedWallet, networkId);
+
+      expect(api.rdns).toBe('com.midnight.test-wallet');
+      expect(api.name).toBe('Test Wallet');
+      expect(api.icon).toBe('data:image/svg+xml,<svg/>');
+      expect(api.apiVersion).toBe('4.0.1');
+    });
+
+    it('should use custom properties when provided', () => {
+      const api = new DAppConnectorInitialAPI(mockConnectedWallet, networkId, {
+        rdns: 'com.custom.wallet',
+        name: 'Custom Wallet',
+        icon: 'data:image/png;base64,abc',
+        apiVersion: '5.0.0',
+      });
+
+      expect(api.rdns).toBe('com.custom.wallet');
+      expect(api.name).toBe('Custom Wallet');
+      expect(api.icon).toBe('data:image/png;base64,abc');
+      expect(api.apiVersion).toBe('5.0.0');
+    });
+  });
+
+  describe('connect', () => {
+    it('should return ConnectedAPI when networkId matches', async () => {
+      const api = new DAppConnectorInitialAPI(mockConnectedWallet, networkId);
+
+      const result = await api.connect(networkId);
+
+      expect(result).toBe(mockConnectedWallet);
+    });
+
+    it('should throw when networkId does not match', async () => {
+      const api = new DAppConnectorInitialAPI(mockConnectedWallet, networkId);
+
+      await expect(api.connect('wrong-network')).rejects.toThrow(
+        "Network ID mismatch: expected 'testnet', got 'wrong-network'",
+      );
+    });
+  });
+});

--- a/testkit-js/testkit-js/test/dapp-connector-wallet-adapter.ut.test.ts
+++ b/testkit-js/testkit-js/test/dapp-connector-wallet-adapter.ut.test.ts
@@ -1,0 +1,304 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ProvingProvider as ZkirProvingProvider } from '@midnight-ntwrk/zkir-v2';
+import { of } from 'rxjs';
+
+import type { EnvironmentConfiguration } from '@/test-environment/environment-configuration';
+import { DAppConnectorWalletAdapter } from '@/wallet/dapp-connector-wallet-adapter';
+import type { MidnightWalletProvider } from '@/wallet/midnight-wallet-provider';
+
+vi.mock('@midnight-ntwrk/wallet-sdk-address-format', () => ({
+  MidnightBech32m: {
+    encode: vi.fn().mockReturnValue({ asString: () => 'mn1shielded-bech32m-address' }),
+  },
+  ShieldedAddress: {
+    codec: { encode: vi.fn().mockReturnValue({ asString: () => 'mn1shielded-bech32m-address' }) },
+  },
+  DustAddress: {
+    encodePublicKey: vi.fn().mockReturnValue('mn1dust-bech32m-address'),
+  },
+}));
+
+vi.mock('@midnight-ntwrk/zkir-v2', () => ({
+  provingProvider: vi.fn().mockReturnValue({
+    check: vi.fn(),
+    prove: vi.fn(),
+  } satisfies ZkirProvingProvider),
+}));
+
+vi.mock('@midnight-ntwrk/wallet-sdk-prover-client/effect', () => ({
+  makeDefaultKeyMaterialProvider: vi.fn().mockReturnValue({
+    lookupKey: vi.fn().mockResolvedValue({ ir: new Uint8Array(), proverKey: new Uint8Array(), verifierKey: new Uint8Array() }),
+    getParams: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+  }),
+}));
+
+const mockShieldedState = {
+  address: {
+    coinPublicKeyString: () => 'coin-pub-key-hex',
+    encryptionPublicKeyString: () => 'enc-pub-key-hex',
+  },
+  balances: { '0x01': 100n, '0x02': 200n },
+};
+
+const mockUnshieldedState = {
+  balances: { '0x03': 300n },
+};
+
+const mockDustState = {
+  balance: vi.fn().mockReturnValue(500n),
+};
+
+const mockWalletFacade = {
+  shielded: { state: of(mockShieldedState) },
+  unshielded: { state: of(mockUnshieldedState) },
+  dust: { state: of(mockDustState) },
+  balanceUnboundTransaction: vi.fn(),
+  balanceFinalizedTransaction: vi.fn(),
+  signRecipe: vi.fn(),
+  finalizeRecipe: vi.fn(),
+  submitTransaction: vi.fn(),
+};
+
+const mockUnshieldedKeystore = {
+  getBech32Address: vi.fn().mockReturnValue({ asString: () => 'mn1unshielded-bech32m-address' }),
+  signData: vi.fn().mockReturnValue('mock-signature'),
+  getPublicKey: vi.fn().mockReturnValue('mock-public-key'),
+  getSecretKey: vi.fn(),
+  getAddress: vi.fn(),
+};
+
+const mockEnvironmentConfiguration: EnvironmentConfiguration = {
+  walletNetworkId: 'undeployed' as EnvironmentConfiguration['walletNetworkId'],
+  networkId: 'testnet',
+  indexer: 'http://localhost:8080/indexer',
+  indexerWS: 'ws://localhost:8080/indexer',
+  node: 'http://localhost:9944',
+  nodeWS: 'ws://localhost:9944',
+  proofServer: 'http://localhost:6300',
+  faucet: 'http://localhost:8080/faucet',
+};
+
+const mockWalletProvider = {
+  wallet: mockWalletFacade,
+  unshieldedKeystore: mockUnshieldedKeystore,
+  zswapSecretKeys: {} as MidnightWalletProvider['zswapSecretKeys'],
+  dustSecretKey: { publicKey: 12345n } as MidnightWalletProvider['dustSecretKey'],
+  env: mockEnvironmentConfiguration,
+} as unknown as MidnightWalletProvider;
+
+describe('[Unit tests] DAppConnectorWalletAdapter', () => {
+  let adapter: DAppConnectorWalletAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new DAppConnectorWalletAdapter(mockWalletProvider, mockEnvironmentConfiguration);
+  });
+
+  describe('getConfiguration', () => {
+    it('should map EnvironmentConfiguration fields to Configuration', async () => {
+      const config = await adapter.getConfiguration();
+
+      expect(config).toEqual({
+        indexerUri: 'http://localhost:8080/indexer',
+        indexerWsUri: 'ws://localhost:8080/indexer',
+        proverServerUri: 'http://localhost:6300',
+        substrateNodeUri: 'http://localhost:9944',
+        networkId: 'testnet',
+      });
+    });
+  });
+
+  describe('getConnectionStatus', () => {
+    it('should return connected status with correct networkId', async () => {
+      const status = await adapter.getConnectionStatus();
+
+      expect(status).toEqual({ status: 'connected', networkId: 'testnet' });
+    });
+  });
+
+  describe('hintUsage', () => {
+    it('should resolve without error', async () => {
+      await expect(adapter.hintUsage(['getShieldedBalances', 'submitTransaction'])).resolves.toBeUndefined();
+    });
+  });
+
+  describe('stubbed methods', () => {
+    it('makeTransfer should throw not implemented', async () => {
+      await expect(adapter.makeTransfer([])).rejects.toThrow('Not implemented in DAppConnectorWalletAdapter');
+    });
+
+    it('makeIntent should throw not implemented', async () => {
+      await expect(
+        adapter.makeIntent([], [], { intentId: 'random', payFees: true }),
+      ).rejects.toThrow('Not implemented in DAppConnectorWalletAdapter');
+    });
+
+    it('getTxHistory should throw not implemented', async () => {
+      await expect(adapter.getTxHistory(0, 10)).rejects.toThrow('Not implemented in DAppConnectorWalletAdapter');
+    });
+  });
+
+  describe('getShieldedAddresses', () => {
+    it('should return Bech32m-encoded address and key strings from wallet state', async () => {
+      const { MidnightBech32m } = await import('@midnight-ntwrk/wallet-sdk-address-format');
+
+      const result = await adapter.getShieldedAddresses();
+
+      expect(MidnightBech32m.encode).toHaveBeenCalledWith('testnet', mockShieldedState.address);
+      expect(result).toEqual({
+        shieldedAddress: 'mn1shielded-bech32m-address',
+        shieldedCoinPublicKey: 'coin-pub-key-hex',
+        shieldedEncryptionPublicKey: 'enc-pub-key-hex',
+      });
+    });
+  });
+
+  describe('getUnshieldedAddress', () => {
+    it('should return Bech32m-encoded address from keystore', async () => {
+      const result = await adapter.getUnshieldedAddress();
+
+      expect(mockUnshieldedKeystore.getBech32Address).toHaveBeenCalled();
+      expect(result).toEqual({ unshieldedAddress: 'mn1unshielded-bech32m-address' });
+    });
+  });
+
+  describe('getDustAddress', () => {
+    it('should return encoded dust address from DustSecretKey public key', async () => {
+      const { DustAddress } = await import('@midnight-ntwrk/wallet-sdk-address-format');
+
+      const result = await adapter.getDustAddress();
+
+      expect(DustAddress.encodePublicKey).toHaveBeenCalledWith('testnet', 12345n);
+      expect(result).toEqual({ dustAddress: 'mn1dust-bech32m-address' });
+    });
+  });
+
+  describe('getShieldedBalances', () => {
+    it('should return balances from shielded wallet state', async () => {
+      const result = await adapter.getShieldedBalances();
+
+      expect(result).toEqual({ '0x01': 100n, '0x02': 200n });
+    });
+  });
+
+  describe('getUnshieldedBalances', () => {
+    it('should return balances from unshielded wallet state', async () => {
+      const result = await adapter.getUnshieldedBalances();
+
+      expect(result).toEqual({ '0x03': 300n });
+    });
+  });
+
+  describe('getDustBalance', () => {
+    it('should return balance from dust wallet state', async () => {
+      const result = await adapter.getDustBalance();
+
+      expect(mockDustState.balance).toHaveBeenCalled();
+      expect(result).toEqual({ balance: 500n, cap: 0n });
+    });
+  });
+
+  describe('signData', () => {
+    it('should decode hex data and return signature', async () => {
+      const result = await adapter.signData('abcd', { encoding: 'hex', keyType: 'unshielded' });
+
+      expect(mockUnshieldedKeystore.signData).toHaveBeenCalled();
+      expect(result).toEqual({
+        data: 'abcd',
+        signature: 'mock-signature',
+        verifyingKey: 'mock-public-key',
+      });
+    });
+
+    it('should decode base64 data and return signature', async () => {
+      const result = await adapter.signData('aGVsbG8=', { encoding: 'base64', keyType: 'unshielded' });
+
+      const callArg = mockUnshieldedKeystore.signData.mock.calls[0][0] as Buffer;
+      expect(Buffer.from(callArg).toString('utf-8')).toBe('hello');
+      expect(result.data).toBe('aGVsbG8=');
+    });
+
+    it('should decode text data and return signature', async () => {
+      const result = await adapter.signData('hello world', { encoding: 'text', keyType: 'unshielded' });
+
+      const callArg = mockUnshieldedKeystore.signData.mock.calls[0][0] as Buffer;
+      expect(Buffer.from(callArg).toString('utf-8')).toBe('hello world');
+      expect(result.data).toBe('hello world');
+    });
+  });
+
+  describe('getProvingProvider', () => {
+    it('should return a ProvingProvider by adapting KeyMaterialProvider types', async () => {
+      const { provingProvider: createLocalProvingProvider } = await import('@midnight-ntwrk/zkir-v2');
+
+      const mockDAppKMP = {
+        getZKIR: vi.fn().mockResolvedValue(new Uint8Array([1])),
+        getProverKey: vi.fn().mockResolvedValue(new Uint8Array([2])),
+        getVerifierKey: vi.fn().mockResolvedValue(new Uint8Array([3])),
+      };
+
+      const result = await adapter.getProvingProvider(mockDAppKMP);
+
+      expect(createLocalProvingProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lookupKey: expect.any(Function),
+          getParams: expect.any(Function),
+        }),
+      );
+      expect(result).toBeDefined();
+      expect(result.check).toBeDefined();
+      expect(result.prove).toBeDefined();
+    });
+
+    it('should try dApp keys first in lookupKey, then fall back to default provider', async () => {
+      const { provingProvider: createLocalProvingProvider } = await import('@midnight-ntwrk/zkir-v2');
+      const { makeDefaultKeyMaterialProvider } = await import('@midnight-ntwrk/wallet-sdk-prover-client/effect');
+
+      const failingDAppKMP = {
+        getZKIR: vi.fn().mockRejectedValue(new Error('not found')),
+        getProverKey: vi.fn().mockRejectedValue(new Error('not found')),
+        getVerifierKey: vi.fn().mockRejectedValue(new Error('not found')),
+      };
+
+      await adapter.getProvingProvider(failingDAppKMP);
+
+      const zkirProviderArg = vi.mocked(createLocalProvingProvider).mock.calls[0][0];
+      const keyMaterial = await zkirProviderArg.lookupKey('midnight/zswap/spend');
+      const defaultProvider = vi.mocked(makeDefaultKeyMaterialProvider).mock.results[0].value;
+
+      expect(defaultProvider.lookupKey).toHaveBeenCalledWith('midnight/zswap/spend');
+      expect(keyMaterial).toBeDefined();
+    });
+
+    it('should delegate getParams to default provider', async () => {
+      const { provingProvider: createLocalProvingProvider } = await import('@midnight-ntwrk/zkir-v2');
+
+      const mockDAppKMP = {
+        getZKIR: vi.fn(),
+        getProverKey: vi.fn(),
+        getVerifierKey: vi.fn(),
+      };
+
+      await adapter.getProvingProvider(mockDAppKMP);
+
+      const zkirProviderArg = vi.mocked(createLocalProvingProvider).mock.calls[0][0];
+      const params = await zkirProviderArg.getParams(16);
+
+      expect(params).toEqual(new Uint8Array([1, 2, 3]));
+    });
+  });
+});

--- a/testkit-js/testkit-js/test/dapp-connector-wallet-adapter.ut.test.ts
+++ b/testkit-js/testkit-js/test/dapp-connector-wallet-adapter.ut.test.ts
@@ -40,10 +40,24 @@ vi.mock('@midnight-ntwrk/zkir-v2', () => ({
 }));
 
 vi.mock('@midnight-ntwrk/wallet-sdk-prover-client/effect', () => ({
-  makeDefaultKeyMaterialProvider: vi.fn().mockReturnValue({
-    lookupKey: vi.fn().mockResolvedValue({ ir: new Uint8Array(), proverKey: new Uint8Array(), verifierKey: new Uint8Array() }),
-    getParams: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
-  }),
+  WasmProver: {
+    makeDefaultKeyMaterialProvider: vi.fn().mockReturnValue({
+      lookupKey: vi.fn().mockResolvedValue({ ir: new Uint8Array(), proverKey: new Uint8Array(), verifierKey: new Uint8Array() }),
+      getParams: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+    }),
+  },
+}));
+
+vi.mock('@midnight-ntwrk/midnight-js-protocol/ledger', () => ({
+  Transaction: {
+    deserialize: vi.fn(),
+  },
+}));
+
+vi.mock('@midnight-ntwrk/midnight-js-utils', () => ({
+  fromHex: vi.fn().mockReturnValue(new Uint8Array()),
+  toHex: vi.fn().mockReturnValue('aabb'),
+  ttlOneHour: vi.fn().mockReturnValue(new Date('2026-01-01T00:00:00Z')),
 }));
 
 const mockShieldedState = {
@@ -93,12 +107,11 @@ const mockEnvironmentConfiguration: EnvironmentConfiguration = {
 };
 
 const mockWalletProvider = {
-  wallet: mockWalletFacade,
-  unshieldedKeystore: mockUnshieldedKeystore,
+  wallet: mockWalletFacade as MidnightWalletProvider['wallet'],
+  unshieldedKeystore: mockUnshieldedKeystore as MidnightWalletProvider['unshieldedKeystore'],
   zswapSecretKeys: {} as MidnightWalletProvider['zswapSecretKeys'],
   dustSecretKey: { publicKey: 12345n } as MidnightWalletProvider['dustSecretKey'],
-  env: mockEnvironmentConfiguration,
-} as unknown as MidnightWalletProvider;
+};
 
 describe('[Unit tests] DAppConnectorWalletAdapter', () => {
   let adapter: DAppConnectorWalletAdapter;
@@ -241,6 +254,66 @@ describe('[Unit tests] DAppConnectorWalletAdapter', () => {
     });
   });
 
+  describe('balanceUnsealedTransaction', () => {
+    it('should deserialize as preBinding, balance, sign, finalize, and return hex transaction', async () => {
+      const { Transaction } = await import('@midnight-ntwrk/midnight-js-protocol/ledger');
+      mockWalletFacade.balanceUnboundTransaction.mockResolvedValue({});
+      mockWalletFacade.signRecipe.mockResolvedValue({});
+      mockWalletFacade.finalizeRecipe.mockResolvedValue({ serialize: () => new Uint8Array() });
+
+      const result = await adapter.balanceUnsealedTransaction('abcd');
+
+      expect(Transaction.deserialize).toHaveBeenCalledWith('signature', 'proof', 'preBinding', expect.any(Uint8Array));
+      expect(mockWalletFacade.balanceUnboundTransaction).toHaveBeenCalled();
+      expect(mockWalletFacade.balanceUnboundTransaction.mock.calls[0][2]).toEqual(
+        expect.objectContaining({ tokenKindsToBalance: 'all' }),
+      );
+      expect(result).toEqual({ tx: 'aabb' });
+    });
+
+    it('should exclude fees from balancing when payFees is false', async () => {
+      mockWalletFacade.balanceUnboundTransaction.mockResolvedValue({});
+      mockWalletFacade.signRecipe.mockResolvedValue({});
+      mockWalletFacade.finalizeRecipe.mockResolvedValue({ serialize: () => new Uint8Array() });
+
+      await adapter.balanceUnsealedTransaction('abcd', { payFees: false });
+
+      expect(mockWalletFacade.balanceUnboundTransaction).toHaveBeenCalled();
+      expect(mockWalletFacade.balanceUnboundTransaction.mock.calls[0][2]).toEqual(
+        expect.objectContaining({ tokenKindsToBalance: ['shielded', 'unshielded'] }),
+      );
+    });
+  });
+
+  describe('balanceSealedTransaction', () => {
+    it('should deserialize as binding, balance finalized, sign, finalize, and return hex transaction', async () => {
+      const { Transaction } = await import('@midnight-ntwrk/midnight-js-protocol/ledger');
+      mockWalletFacade.balanceFinalizedTransaction.mockResolvedValue({});
+      mockWalletFacade.signRecipe.mockResolvedValue({});
+      mockWalletFacade.finalizeRecipe.mockResolvedValue({ serialize: () => new Uint8Array() });
+
+      const result = await adapter.balanceSealedTransaction('abcd');
+
+      expect(Transaction.deserialize).toHaveBeenCalledWith('signature', 'proof', 'binding', expect.any(Uint8Array));
+      expect(mockWalletFacade.balanceFinalizedTransaction).toHaveBeenCalled();
+      expect(mockWalletFacade.balanceFinalizedTransaction.mock.calls[0][2]).toEqual(
+        expect.objectContaining({ tokenKindsToBalance: 'all' }),
+      );
+      expect(result).toEqual({ tx: 'aabb' });
+    });
+  });
+
+  describe('submitTransaction', () => {
+    it('should deserialize as binding and submit to wallet', async () => {
+      const { Transaction } = await import('@midnight-ntwrk/midnight-js-protocol/ledger');
+
+      await adapter.submitTransaction('abcd');
+
+      expect(Transaction.deserialize).toHaveBeenCalledWith('signature', 'proof', 'binding', expect.anything());
+      expect(mockWalletFacade.submitTransaction).toHaveBeenCalled();
+    });
+  });
+
   describe('getProvingProvider', () => {
     it('should return a ProvingProvider by adapting KeyMaterialProvider types', async () => {
       const { provingProvider: createLocalProvingProvider } = await import('@midnight-ntwrk/zkir-v2');
@@ -266,7 +339,7 @@ describe('[Unit tests] DAppConnectorWalletAdapter', () => {
 
     it('should try dApp keys first in lookupKey, then fall back to default provider', async () => {
       const { provingProvider: createLocalProvingProvider } = await import('@midnight-ntwrk/zkir-v2');
-      const { makeDefaultKeyMaterialProvider } = await import('@midnight-ntwrk/wallet-sdk-prover-client/effect');
+      const { WasmProver } = await import('@midnight-ntwrk/wallet-sdk-prover-client/effect');
 
       const failingDAppKMP = {
         getZKIR: vi.fn().mockRejectedValue(new Error('not found')),
@@ -278,7 +351,7 @@ describe('[Unit tests] DAppConnectorWalletAdapter', () => {
 
       const zkirProviderArg = vi.mocked(createLocalProvingProvider).mock.calls[0][0];
       const keyMaterial = await zkirProviderArg.lookupKey('midnight/zswap/spend');
-      const defaultProvider = vi.mocked(makeDefaultKeyMaterialProvider).mock.results[0].value;
+      const defaultProvider = vi.mocked(WasmProver.makeDefaultKeyMaterialProvider).mock.results[0].value;
 
       expect(defaultProvider.lookupKey).toHaveBeenCalledWith('midnight/zswap/spend');
       expect(keyMaterial).toBeDefined();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,7 +1899,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@midnight-ntwrk/midnight-js-dapp-connector-proof-provider@workspace:packages/dapp-connector-proof-provider":
+"@midnight-ntwrk/midnight-js-dapp-connector-proof-provider@workspace:*, @midnight-ntwrk/midnight-js-dapp-connector-proof-provider@workspace:packages/dapp-connector-proof-provider":
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/midnight-js-dapp-connector-proof-provider@workspace:packages/dapp-connector-proof-provider"
   dependencies:
@@ -2123,6 +2123,7 @@ __metadata:
   dependencies:
     "@midnight-ntwrk/midnight-js-compact": "workspace:*"
     "@midnight-ntwrk/midnight-js-contracts": "workspace:*"
+    "@midnight-ntwrk/midnight-js-dapp-connector-proof-provider": "workspace:*"
     "@midnight-ntwrk/midnight-js-http-client-proof-provider": "workspace:*"
     "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "workspace:*"
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*"
@@ -2153,6 +2154,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/testkit-js@workspace:testkit-js/testkit-js"
   dependencies:
+    "@midnight-ntwrk/dapp-connector-api": "npm:4.0.1"
     "@midnight-ntwrk/midnight-js-compact": "workspace:*"
     "@midnight-ntwrk/midnight-js-contracts": "workspace:*"
     "@midnight-ntwrk/midnight-js-http-client-proof-provider": "workspace:*"
@@ -2163,7 +2165,10 @@ __metadata:
     "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
     "@midnight-ntwrk/midnight-js-utils": "workspace:*"
+    "@midnight-ntwrk/wallet-sdk-address-format": "npm:3.1.0"
     "@midnight-ntwrk/wallet-sdk-hd": "npm:3.0.1"
+    "@midnight-ntwrk/wallet-sdk-prover-client": "npm:^1.2.0"
+    "@midnight-ntwrk/zkir-v2": "npm:2.1.0"
     "@types/ws": "npm:^8.18.1"
     "@vitest/runner": "npm:^4.1.1"
     allure-commandline: "npm:^2.38.1"


### PR DESCRIPTION
## Summary
- Implement `DAppConnectorWalletAdapter` (ConnectedAPI) and `DAppConnectorInitialAPI` (InitialAPI) in testkit-js, wrapping `MidnightWalletProvider` behind the DApp Connector API
- `getProvingProvider` bridges `KeyMaterialProvider` types (midnight-js-types → zkir-v2) enabling local WASM proving without a proof server
- E2E test validates full proving chain: deploy + call a contract using `dappConnectorProofProvider` with wallet-delegated proving
- 22 unit tests covering configuration mapping, address encoding, balance access, signData encoding dispatch, KeyMaterialProvider adapter fallback logic, and stubbed methods

## Test plan
- [x] 22 unit tests pass (4 for InitialAPI, 18 for WalletAdapter)
- [x] All 58 existing unit tests pass (no regressions)
- [x] ESLint clean
- [x] Build succeeds (testkit-js + testkit-js-e2e)
- [ ] E2E test (`dapp-connector-proving.it.test.ts`) — requires Docker environment, validates deploy + call with wallet-delegated proving

🤖 Generated with [Claude Code](https://claude.com/claude-code)