### PR TITLE
docs: add release notes for v4.1.0

### DIFF
--- a/docs/releases/v4.1.0/README.md
+++ b/docs/releases/v4.1.0/README.md
@@ -1,0 +1,72 @@
+# midnight-js v4.1.0 Release Documentation
+
+**Release Date:** April 22, 2026
+**Previous Version:** v4.0.4
+**Migration Complexity:** Medium (breaking changes in storage encryption API and protocol imports)
+
+## Quick Links
+
+- [Release Notes](./release-notes.md) - High-level changelog
+- [Breaking Changes](./breaking-changes.md) - StorageEncryption async migration, protocol import paths
+- [New Features](./new-features.md) - Web Crypto, CryptoBackend abstraction, Protocol ACL, React Native support
+- [Migration Guide](./migration-guide.md) - Step-by-step upgrade from v4.0.4
+- [API Changes](./api-changes.md) - Complete API reference changes
+
+## Breaking Changes (2)
+
+1. **StorageEncryption migrated to async Web Crypto API** - Constructor replaced with async factory `StorageEncryption.create()`, all encrypt/decrypt methods now async (#798)
+2. **Protocol imports via ACL package** - Direct imports from `@midnight-ntwrk/ledger-v8`, `@midnight-ntwrk/compact-runtime`, etc. replaced with `@midnight-ntwrk/midnight-js-protocol` subpaths (#832)
+
+## New Features (4)
+
+1. Web Crypto API for storage encryption -- browser compatibility (#798)
+2. CryptoBackend abstraction with Noble fallback -- React Native and non-secure contexts (#827)
+3. Protocol ACL package -- version-agnostic protocol imports (#832)
+4. DAppConnectorWalletAdapter for testkit-js -- wallet-delegated proving in e2e tests (#855)
+
+## Quick Migration
+
+### StorageEncryption (v4.0.4 -> v4.1.0)
+
+```typescript
+// Before (v4.0.4)
+const encryption = new StorageEncryption(password);
+const encrypted = encryption.encrypt(data);
+
+// After (v4.1.0)
+const encryption = await StorageEncryption.create(password);
+const encrypted = await encryption.encrypt(data);
+```
+
+### Protocol Imports (v4.0.4 -> v4.1.0)
+
+```typescript
+// Before (v4.0.4)
+import { type Transaction } from '@midnight-ntwrk/ledger-v8';
+import { type ContractAddress } from '@midnight-ntwrk/compact-runtime';
+
+// After (v4.1.0)
+import { type Transaction } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import { type ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+```
+
+## Requirements
+
+- **Node.js:** 22+
+- **TypeScript:** 5.0+
+
+## Testing Checklist
+
+- [ ] `StorageEncryption.create()` replaces all `new StorageEncryption()` usages
+- [ ] All encrypt/decrypt calls use `await`
+- [ ] Protocol imports use `@midnight-ntwrk/midnight-js-protocol/*` subpaths
+- [ ] ESLint passes (new rule blocks direct protocol imports)
+- [ ] `@apollo/client` v4 compatible -- no breaking type errors
+- [ ] TypeScript compilation passes
+- [ ] Unit tests pass
+- [ ] Integration tests pass
+
+---
+
+**Last Updated:** April 22, 2026
+**License:** Apache-2.0

--- a/docs/releases/v4.1.0/api-changes.md
+++ b/docs/releases/v4.1.0/api-changes.md
@@ -1,0 +1,180 @@
+# API Changes Reference v4.1.0
+
+## Package: @midnight-ntwrk/midnight-js-level-private-state-provider
+
+### Modified Exports
+
+#### StorageEncryption
+
+**v4.0.4:**
+```typescript
+class StorageEncryption {
+  constructor(password: string, options?: { existingSalt?: Buffer });
+  encrypt(data: string): string;
+  decrypt(data: string): string;
+  decryptWithPassword(data: string, password: string): string;
+  verifyPassword(password: string): boolean;
+  get salt(): Buffer;
+}
+```
+
+**v4.1.0:**
+```typescript
+class StorageEncryption {
+  static create(password: string, options?: StorageEncryptionOptions): Promise<StorageEncryption>;
+  encrypt(data: string): Promise<string>;
+  decrypt(data: string): Promise<string>;
+  decryptWithPassword(data: string, password: string): Promise<string>;
+  verifyPassword(password: string): Promise<boolean>;
+  get salt(): Buffer;
+}
+```
+
+**Breaking:** Constructor replaced with async factory. All methods now return `Promise`.
+
+#### LevelPrivateStateProviderConfig
+
+**v4.0.4:**
+```typescript
+interface LevelPrivateStateProviderConfig {
+  readonly dbName: string;
+  // ... existing fields
+}
+```
+
+**v4.1.0:**
+```typescript
+interface LevelPrivateStateProviderConfig {
+  readonly dbName: string;
+  readonly cryptoBackend?: CryptoBackendType;
+  readonly levelFactory?: LevelFactory;
+  // ... existing fields
+}
+```
+
+**Non-breaking:** New optional fields added.
+
+#### invalidateEncryptionCache
+
+**v4.0.4:**
+```typescript
+function invalidateEncryptionCache(): void;
+```
+
+**v4.1.0:**
+```typescript
+function invalidateEncryptionCache(): Promise<void>;
+```
+
+**Breaking:** Return type changed from `void` to `Promise<void>`.
+
+### New Exports
+
+#### CryptoBackend (interface)
+
+```typescript
+interface CryptoBackend {
+  randomBytes(length: number): Uint8Array;
+  sha256(data: Uint8Array): Promise<Uint8Array>;
+  pbkdf2(password: Uint8Array, salt: Uint8Array, iterations: number, keyLength: number): Promise<Uint8Array>;
+  aesGcmEncrypt(key: Uint8Array, iv: Uint8Array, plaintext: Uint8Array): Promise<{ ciphertext: Uint8Array; authTag: Uint8Array }>;
+  aesGcmDecrypt(key: Uint8Array, iv: Uint8Array, ciphertext: Uint8Array, authTag: Uint8Array): Promise<Uint8Array>;
+}
+```
+
+#### CryptoBackendType
+
+```typescript
+type CryptoBackendType = 'webcrypto' | 'noble';
+```
+
+#### StorageEncryptionOptions
+
+```typescript
+interface StorageEncryptionOptions {
+  existingSalt?: Buffer;
+  cryptoBackend?: CryptoBackendType;
+}
+```
+
+#### LevelFactory
+
+```typescript
+type LevelFactory = (dbName: string) => DatabaseLevel;
+```
+
+#### DatabaseLevel
+
+```typescript
+type DatabaseLevel = AbstractLevel<string | Buffer | Uint8Array, string, string>;
+```
+
+---
+
+## Package: @midnight-ntwrk/midnight-js-protocol (NEW)
+
+### Barrel Export
+
+```typescript
+export * as compactJs from '@midnight-ntwrk/compact-js';
+export * as compactRuntime from '@midnight-ntwrk/compact-runtime';
+export * as ledger from '@midnight-ntwrk/ledger-v8';
+export * as onchainRuntime from '@midnight-ntwrk/onchain-runtime-v3';
+export * as platform from '@midnight-ntwrk/platform-js';
+```
+
+### Subpath Exports
+
+Each subpath re-exports `*` from the underlying protocol package:
+- `./ledger` -> `@midnight-ntwrk/ledger-v8`
+- `./compact-runtime` -> `@midnight-ntwrk/compact-runtime`
+- `./compact-js` -> `@midnight-ntwrk/compact-js`
+- `./compact-js/effect` -> `@midnight-ntwrk/compact-js/effect`
+- `./compact-js/effect-contract` -> `@midnight-ntwrk/compact-js/effect-contract`
+- `./onchain-runtime` -> `@midnight-ntwrk/onchain-runtime-v3`
+- `./platform-js` -> `@midnight-ntwrk/platform-js`
+- `./platform-js/effect-configuration` -> `@midnight-ntwrk/platform-js/effect-configuration`
+- `./platform-js/effect-contract-address` -> `@midnight-ntwrk/platform-js/effect-contract-address`
+
+---
+
+## Package: @midnight-ntwrk/testkit-js
+
+### New Exports
+
+#### DAppConnectorWalletAdapter
+
+```typescript
+class DAppConnectorWalletAdapter implements ConnectedAPI {
+  constructor(walletProvider: MidnightWalletProvider);
+  // Implements full ConnectedAPI interface from @midnight-ntwrk/dapp-connector-api
+}
+```
+
+#### DAppConnectorInitialAPI
+
+```typescript
+class DAppConnectorInitialAPI implements InitialAPI {
+  constructor(walletAdapter: DAppConnectorWalletAdapter, expectedNetworkId: string);
+}
+```
+
+---
+
+## Package: @midnight-ntwrk/midnight-js-indexer-public-data-provider
+
+### Modified Dependencies
+
+`@apollo/client` upgraded from 3.14.0 to 4.1.6 (#666). The provider API is unchanged, but consumers who interact with Apollo Client types directly (e.g., `ApolloClient`, `InMemoryCache`) may need to update for Apollo Client v4 compatibility.
+
+---
+
+## Package: @midnight-ntwrk/midnight-js-fetch-zk-config-provider
+
+### Modified Behavior
+
+#### sendRequest
+
+**v4.0.4:** Accepted any HTTP 200 response regardless of Content-Type.
+
+**v4.1.0:** Rejects responses with `Content-Type: text/html` and includes the full URL and status code in error messages for non-ok responses.

--- a/docs/releases/v4.1.0/breaking-changes.md
+++ b/docs/releases/v4.1.0/breaking-changes.md
@@ -1,0 +1,125 @@
+# Breaking Changes v4.1.0
+
+## 1. StorageEncryption migrated to async Web Crypto API (#798)
+
+### Reason
+
+The Node.js `crypto` module is not available in browser contexts. Migrating to the Web Crypto API (`globalThis.crypto.subtle`) enables `level-private-state-provider` to work in browsers and other non-Node.js environments. The Web Crypto API is inherently asynchronous, requiring the API surface to change from synchronous to async.
+
+### Impact
+
+Any code that:
+- Creates `StorageEncryption` instances via `new StorageEncryption()`
+- Calls `encrypt()`, `decrypt()`, `decryptWithPassword()`, or `verifyPassword()` synchronously
+- Calls `invalidateEncryptionCache()` without `await`
+
+### Before
+
+```typescript
+import { StorageEncryption } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
+
+const encryption = new StorageEncryption(password);
+const encrypted = encryption.encrypt(data);
+const decrypted = encryption.decrypt(encrypted);
+const isValid = encryption.verifyPassword(password);
+```
+
+### After
+
+```typescript
+import { StorageEncryption } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
+
+const encryption = await StorageEncryption.create(password);
+const encrypted = await encryption.encrypt(data);
+const decrypted = await encryption.decrypt(encrypted);
+const isValid = await encryption.verifyPassword(password);
+```
+
+### Migration Steps
+
+1. Replace all `new StorageEncryption(password)` with `await StorageEncryption.create(password)`
+2. Replace all `new StorageEncryption(password, { existingSalt })` with `await StorageEncryption.create(password, { existingSalt })`
+3. Add `await` before every `encrypt()`, `decrypt()`, `decryptWithPassword()`, and `verifyPassword()` call
+4. Add `await` before `invalidateEncryptionCache()` calls (return type changed from `void` to `Promise<void>`)
+5. Convert synchronous `.toThrow()` test assertions to `await .rejects.toThrow()`
+
+---
+
+## 2. Protocol imports via ACL package (#832)
+
+### Reason
+
+Protocol packages use version-specific names (e.g., `@midnight-ntwrk/ledger-v8`, `@midnight-ntwrk/onchain-runtime-v3`). When protocol versions are upgraded, every import across every package must be updated. The ACL package provides version-agnostic subpath exports so that future protocol upgrades only require updating the single protocol package.
+
+### Impact
+
+Any code that imports directly from:
+- `@midnight-ntwrk/ledger-v8`
+- `@midnight-ntwrk/compact-runtime`
+- `@midnight-ntwrk/compact-js` or `@midnight-ntwrk/compact-js/*`
+- `@midnight-ntwrk/onchain-runtime-v3`
+- `@midnight-ntwrk/platform-js` or `@midnight-ntwrk/platform-js/*`
+
+An ESLint rule is added that blocks direct imports from these packages.
+
+### Before
+
+```typescript
+import { type Transaction, type UnbalancedTransaction } from '@midnight-ntwrk/ledger-v8';
+import { type ContractAddress } from '@midnight-ntwrk/compact-runtime';
+import { Contract } from '@midnight-ntwrk/compact-js';
+import { createEffectContract } from '@midnight-ntwrk/compact-js/effect-contract';
+import { type Resource } from '@midnight-ntwrk/onchain-runtime-v3';
+import { type NetworkId } from '@midnight-ntwrk/platform-js';
+```
+
+### After
+
+```typescript
+import { type Transaction, type UnbalancedTransaction } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import { type ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import { createEffectContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect-contract';
+import { type Resource } from '@midnight-ntwrk/midnight-js-protocol/onchain-runtime';
+import { type NetworkId } from '@midnight-ntwrk/midnight-js-protocol/platform-js';
+```
+
+### Migration Steps
+
+1. Add `@midnight-ntwrk/midnight-js-protocol` as a dependency
+2. Replace all direct protocol imports using the mapping table:
+
+| Direct import | ACL subpath |
+|---|---|
+| `@midnight-ntwrk/ledger-v8` | `@midnight-ntwrk/midnight-js-protocol/ledger` |
+| `@midnight-ntwrk/compact-runtime` | `@midnight-ntwrk/midnight-js-protocol/compact-runtime` |
+| `@midnight-ntwrk/compact-js` | `@midnight-ntwrk/midnight-js-protocol/compact-js` |
+| `@midnight-ntwrk/compact-js/effect` | `@midnight-ntwrk/midnight-js-protocol/compact-js/effect` |
+| `@midnight-ntwrk/compact-js/effect-contract` | `@midnight-ntwrk/midnight-js-protocol/compact-js/effect-contract` |
+| `@midnight-ntwrk/onchain-runtime-v3` | `@midnight-ntwrk/midnight-js-protocol/onchain-runtime` |
+| `@midnight-ntwrk/platform-js` | `@midnight-ntwrk/midnight-js-protocol/platform-js` |
+| `@midnight-ntwrk/platform-js/effect-configuration` | `@midnight-ntwrk/midnight-js-protocol/platform-js/effect-configuration` |
+| `@midnight-ntwrk/platform-js/effect-contract-address` | `@midnight-ntwrk/midnight-js-protocol/platform-js/effect-contract-address` |
+
+3. Remove direct protocol package dependencies from your `package.json`
+4. Run `yarn lint` to verify no direct imports remain
+
+---
+
+## Common Migration Issues
+
+### Error: "StorageEncryption is not a constructor"
+
+**Solution:** Replace `new StorageEncryption(password)` with `await StorageEncryption.create(password)`. The constructor is no longer public.
+
+### Error: "Cannot find module '@midnight-ntwrk/ledger-v8'"
+
+**Solution:** Add `@midnight-ntwrk/midnight-js-protocol` as a dependency and change the import to `@midnight-ntwrk/midnight-js-protocol/ledger`.
+
+### ESLint error: "Import from @midnight-ntwrk/midnight-js-protocol/ledger instead"
+
+**Solution:** Follow the import mapping table above to replace direct protocol imports with ACL subpath imports.
+
+### Error: "encryption.encrypt is not a function" / "encrypt(...).then is not a function"
+
+**Solution:** `encrypt()`, `decrypt()`, etc. are now async. Add `await` before each call and ensure the containing function is `async`.

--- a/docs/releases/v4.1.0/migration-guide.md
+++ b/docs/releases/v4.1.0/migration-guide.md
@@ -1,0 +1,184 @@
+# Migration Guide v4.0.4 to v4.1.0
+
+## Overview
+
+This guide covers migrating from midnight-js v4.0.4 to v4.1.0. The two main breaking changes are the async StorageEncryption API and the protocol import ACL. Most consumers of the high-level `levelPrivateStateProvider` function will only need to update protocol imports.
+
+## Step 1: Update Dependencies
+
+```bash
+yarn add @midnight-ntwrk/midnight-js-protocol@^4.1.0
+yarn add @midnight-ntwrk/midnight-js-level-private-state-provider@^4.1.0
+# Update all other @midnight-ntwrk packages to ^4.1.0
+```
+
+Remove direct protocol dependencies from your `package.json`:
+
+```bash
+yarn remove @midnight-ntwrk/ledger-v8 @midnight-ntwrk/compact-runtime @midnight-ntwrk/compact-js @midnight-ntwrk/onchain-runtime-v3 @midnight-ntwrk/platform-js
+```
+
+## Step 2: Migrate Protocol Imports
+
+Replace all direct protocol imports with ACL subpath imports.
+
+### 2.1 Ledger
+
+**Before (v4.0.4):**
+```typescript
+import { type Transaction, type UnbalancedTransaction } from '@midnight-ntwrk/ledger-v8';
+```
+
+**After (v4.1.0):**
+```typescript
+import { type Transaction, type UnbalancedTransaction } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+```
+
+### 2.2 Compact Runtime
+
+**Before (v4.0.4):**
+```typescript
+import { type ContractAddress } from '@midnight-ntwrk/compact-runtime';
+```
+
+**After (v4.1.0):**
+```typescript
+import { type ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+```
+
+### 2.3 Compact JS
+
+**Before (v4.0.4):**
+```typescript
+import { Contract } from '@midnight-ntwrk/compact-js';
+import { createEffectContract } from '@midnight-ntwrk/compact-js/effect-contract';
+```
+
+**After (v4.1.0):**
+```typescript
+import { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import { createEffectContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect-contract';
+```
+
+### 2.4 Onchain Runtime
+
+**Before (v4.0.4):**
+```typescript
+import { type Resource } from '@midnight-ntwrk/onchain-runtime-v3';
+```
+
+**After (v4.1.0):**
+```typescript
+import { type Resource } from '@midnight-ntwrk/midnight-js-protocol/onchain-runtime';
+```
+
+### 2.5 Platform JS
+
+**Before (v4.0.4):**
+```typescript
+import { type NetworkId } from '@midnight-ntwrk/platform-js';
+```
+
+**After (v4.1.0):**
+```typescript
+import { type NetworkId } from '@midnight-ntwrk/midnight-js-protocol/platform-js';
+```
+
+### 2.6 Verify with ESLint
+
+Run `yarn lint` -- the new ESLint rule will flag any remaining direct protocol imports with specific instructions.
+
+## Step 3: Migrate StorageEncryption (if used directly)
+
+If you use `StorageEncryption` directly (most consumers use `levelPrivateStateProvider` which handles this internally):
+
+### 3.1 Replace Constructor
+
+**Before (v4.0.4):**
+```typescript
+const encryption = new StorageEncryption(password);
+const encryption2 = new StorageEncryption(password, { existingSalt: salt });
+```
+
+**After (v4.1.0):**
+```typescript
+const encryption = await StorageEncryption.create(password);
+const encryption2 = await StorageEncryption.create(password, { existingSalt: salt });
+```
+
+### 3.2 Add Await to Methods
+
+**Before (v4.0.4):**
+```typescript
+const encrypted = encryption.encrypt(data);
+const decrypted = encryption.decrypt(encrypted);
+const valid = encryption.verifyPassword(password);
+```
+
+**After (v4.1.0):**
+```typescript
+const encrypted = await encryption.encrypt(data);
+const decrypted = await encryption.decrypt(encrypted);
+const valid = await encryption.verifyPassword(password);
+```
+
+### 3.3 Update Error Handling in Tests
+
+**Before (v4.0.4):**
+```typescript
+expect(() => encryption.decrypt(tampered)).toThrow();
+```
+
+**After (v4.1.0):**
+```typescript
+await expect(encryption.decrypt(tampered)).rejects.toThrow();
+```
+
+## Step 4: Optional -- Configure CryptoBackend
+
+If targeting React Native or environments without `crypto.subtle`:
+
+```typescript
+const provider = await levelPrivateStateProvider({
+  ...config,
+  cryptoBackend: 'noble',           // pure-JS crypto (no Web Crypto required)
+  levelFactory: myCustomLevel,       // custom AbstractLevel implementation
+});
+```
+
+## Step 5: Verify
+
+```bash
+yarn lint       # Check protocol imports and code style
+yarn build      # TypeScript compilation
+yarn test       # Unit tests
+```
+
+## Troubleshooting
+
+### Error: "StorageEncryption is not a constructor"
+
+The constructor is now private. Use `await StorageEncryption.create(password)` instead.
+
+### Error: "Cannot find module '@midnight-ntwrk/ledger-v8'"
+
+Add `@midnight-ntwrk/midnight-js-protocol` and change the import to `@midnight-ntwrk/midnight-js-protocol/ledger`.
+
+### Error: "Web Crypto API is not available"
+
+You are running in a non-secure context (not HTTPS or localhost). Either:
+- Use `cryptoBackend: 'noble'` in your provider config
+- Serve your app over HTTPS
+
+### Apollo Client type errors
+
+`@apollo/client` was upgraded from 3.x to 4.x. If you interact with Apollo types directly, consult the [Apollo Client 4 migration guide](https://www.apollographql.com/docs/react/migrating/apollo-client-3-to-4).
+
+## Rollback Plan
+
+If rollback is needed:
+1. Revert `@midnight-ntwrk/*` packages to `^4.0.4`
+2. Restore direct protocol package dependencies
+3. Revert protocol imports to direct package names
+4. Revert `StorageEncryption.create()` to `new StorageEncryption()`
+5. Remove `await` from sync encryption methods

--- a/docs/releases/v4.1.0/new-features.md
+++ b/docs/releases/v4.1.0/new-features.md
@@ -1,0 +1,140 @@
+# New Features v4.1.0
+
+## 1. Web Crypto API for Storage Encryption (#798)
+
+`level-private-state-provider` now uses the Web Crypto API (`globalThis.crypto.subtle`) instead of the Node.js `crypto` module for all cryptographic operations: AES-256-GCM encryption/decryption, PBKDF2 key derivation, SHA-256 hashing, and random byte generation.
+
+This enables `level-private-state-provider` to run in browser environments without polyfills.
+
+### Usage
+
+The migration is transparent for `levelPrivateStateProvider` consumers -- the provider handles the async encryption internally. Only direct `StorageEncryption` users need to update (see [Breaking Changes](./breaking-changes.md)).
+
+---
+
+## 2. CryptoBackend Abstraction with Noble Fallback (#827)
+
+A pluggable `CryptoBackend` interface abstracts the cryptographic primitives used by `StorageEncryption`. Two implementations are provided:
+
+- **WebCryptoCryptoBackend** -- delegates to `globalThis.crypto.subtle` (default when available)
+- **NobleCryptoBackend** -- pure-JS implementation using `@noble/ciphers` (AES-256-GCM) and `@noble/hashes` (SHA-256, PBKDF2)
+
+Auto-resolution: WebCrypto is preferred when `crypto.subtle` is available; Noble is used as fallback (e.g., React Native without a secure context).
+
+### Usage
+
+```typescript
+import { levelPrivateStateProvider } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
+
+// Auto-resolve (default): WebCrypto if available, Noble otherwise
+const provider = await levelPrivateStateProvider({ ... });
+
+// Force Noble backend (useful for React Native)
+const provider = await levelPrivateStateProvider({
+  ...config,
+  cryptoBackend: 'noble',
+});
+
+// Force WebCrypto backend (throws if unavailable)
+const provider = await levelPrivateStateProvider({
+  ...config,
+  cryptoBackend: 'webcrypto',
+});
+```
+
+### API
+
+```typescript
+interface CryptoBackend {
+  randomBytes(length: number): Uint8Array;
+  sha256(data: Uint8Array): Promise<Uint8Array>;
+  pbkdf2(password: Uint8Array, salt: Uint8Array, iterations: number, keyLength: number): Promise<Uint8Array>;
+  aesGcmEncrypt(key: Uint8Array, iv: Uint8Array, plaintext: Uint8Array): Promise<{ ciphertext: Uint8Array; authTag: Uint8Array }>;
+  aesGcmDecrypt(key: Uint8Array, iv: Uint8Array, ciphertext: Uint8Array, authTag: Uint8Array): Promise<Uint8Array>;
+}
+
+type CryptoBackendType = 'webcrypto' | 'noble';
+```
+
+---
+
+## 3. Injectable levelFactory for React Native (#827)
+
+`LevelPrivateStateProviderConfig` now accepts an optional `levelFactory` function, enabling custom storage backends that extend `AbstractLevel`. This is required for React Native, where the default Node.js `Level` is not available.
+
+### Usage
+
+```typescript
+import { levelPrivateStateProvider, type LevelFactory } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
+
+const customLevelFactory: LevelFactory = (dbName) => new MyReactNativeLevel(dbName);
+
+const provider = await levelPrivateStateProvider({
+  ...config,
+  levelFactory: customLevelFactory,
+  cryptoBackend: 'noble', // typically paired with Noble for React Native
+});
+```
+
+### API
+
+```typescript
+type DatabaseLevel = AbstractLevel<string | Buffer | Uint8Array, string, string>;
+type LevelFactory = (dbName: string) => DatabaseLevel;
+```
+
+---
+
+## 4. Protocol ACL Package (#832)
+
+New `@midnight-ntwrk/midnight-js-protocol` package wraps all 5 external protocol packages behind version-agnostic subpath exports. Future protocol version upgrades (e.g., `ledger-v8` -> `ledger-v9`) only require updating this single package.
+
+### Subpath Exports
+
+| Subpath | Wraps |
+|---|---|
+| `./ledger` | `@midnight-ntwrk/ledger-v8` |
+| `./compact-runtime` | `@midnight-ntwrk/compact-runtime` |
+| `./compact-js` | `@midnight-ntwrk/compact-js` |
+| `./compact-js/effect` | `@midnight-ntwrk/compact-js/effect` |
+| `./compact-js/effect-contract` | `@midnight-ntwrk/compact-js/effect-contract` |
+| `./onchain-runtime` | `@midnight-ntwrk/onchain-runtime-v3` |
+| `./platform-js` | `@midnight-ntwrk/platform-js` |
+| `./platform-js/effect-configuration` | `@midnight-ntwrk/platform-js/effect-configuration` |
+| `./platform-js/effect-contract-address` | `@midnight-ntwrk/platform-js/effect-contract-address` |
+
+### Usage
+
+```typescript
+// Namespace import (barrel)
+import { ledger, compactRuntime, compactJs, onchainRuntime, platform } from '@midnight-ntwrk/midnight-js-protocol';
+
+// Subpath imports (recommended)
+import { type Transaction } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import { type ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+```
+
+An ESLint rule enforces the ACL imports -- direct protocol imports will produce lint errors.
+
+---
+
+## 5. DAppConnectorWalletAdapter for testkit-js (#855)
+
+New testing infrastructure that enables e2e testing of wallet-delegated proving through `dapp-connector-proof-provider` without a standalone proof server.
+
+### Components
+
+- **DAppConnectorWalletAdapter** -- wraps `MidnightWalletProvider` behind the `ConnectedAPI` interface from `@midnight-ntwrk/dapp-connector-api`, with local WASM proving via zkir-v2
+- **DAppConnectorInitialAPI** -- provides `InitialAPI` with networkId validation
+
+### Usage
+
+```typescript
+import { DAppConnectorWalletAdapter, DAppConnectorInitialAPI } from '@midnight-ntwrk/testkit-js';
+
+const walletAdapter = new DAppConnectorWalletAdapter(walletProvider);
+const initialAPI = new DAppConnectorInitialAPI(walletAdapter, expectedNetworkId);
+
+// Use with dapp-connector-proof-provider in e2e tests
+const proofProvider = await dappConnectorProofProvider(walletAdapter, zkConfigProvider, costModel);
+```

--- a/docs/releases/v4.1.0/release-notes.md
+++ b/docs/releases/v4.1.0/release-notes.md
@@ -1,0 +1,141 @@
+# Release Notes v4.1.0
+
+**Release Date:** April 22, 2026
+**Previous Version:** v4.0.4
+**Node.js Requirement:** >=22
+
+## Breaking Changes
+
+### 1. StorageEncryption migrated to async Web Crypto API (#798)
+
+`StorageEncryption` in `level-private-state-provider` has been migrated from Node.js `crypto` module to the Web Crypto API (`globalThis.crypto.subtle`). This enables browser compatibility but changes the API surface:
+
+- **Constructor** replaced with async factory: `new StorageEncryption(password)` -> `await StorageEncryption.create(password)`
+- **encrypt/decrypt/verifyPassword/decryptWithPassword** are now async (return `Promise`)
+- **invalidateEncryptionCache** return type changed from `void` to `Promise<void>`
+- `isDecryptionError` updated to recognize Web Crypto `DOMException` error messages
+
+Salt comparison now uses `timingSafeEqual` for constant-time comparison.
+
+### 2. Protocol imports via ACL package (#832)
+
+New `@midnight-ntwrk/midnight-js-protocol` package wraps all 5 external protocol packages behind version-agnostic subpath exports. Direct imports from protocol packages are now blocked by an ESLint rule.
+
+| Before (v4.0.4) | After (v4.1.0) |
+|---|---|
+| `@midnight-ntwrk/ledger-v8` | `@midnight-ntwrk/midnight-js-protocol/ledger` |
+| `@midnight-ntwrk/compact-runtime` | `@midnight-ntwrk/midnight-js-protocol/compact-runtime` |
+| `@midnight-ntwrk/compact-js` | `@midnight-ntwrk/midnight-js-protocol/compact-js` |
+| `@midnight-ntwrk/onchain-runtime-v3` | `@midnight-ntwrk/midnight-js-protocol/onchain-runtime` |
+| `@midnight-ntwrk/platform-js` | `@midnight-ntwrk/midnight-js-protocol/platform-js` |
+
+Additional subpaths: `./compact-js/effect`, `./compact-js/effect-contract`, `./platform-js/effect-configuration`, `./platform-js/effect-contract-address`.
+
+## Security
+
+### Update axios (#834)
+
+Security update to axios in testkit-js packages, addressing known vulnerabilities.
+
+## Features
+
+### CryptoBackend abstraction with Noble fallback (#827)
+
+Introduces a pluggable `CryptoBackend` interface for `level-private-state-provider` with two implementations:
+
+- **WebCryptoCryptoBackend** -- uses `globalThis.crypto.subtle` (default when available)
+- **NobleCryptoBackend** -- pure-JS fallback using `@noble/ciphers` and `@noble/hashes`
+
+The backend is auto-resolved: WebCrypto is preferred when available, Noble is used as fallback (e.g., React Native without secure context).
+
+```typescript
+const provider = await levelPrivateStateProvider({
+  // ...
+  cryptoBackend: 'noble', // explicit selection: 'webcrypto' | 'noble' | undefined (auto)
+});
+```
+
+New exports from `@midnight-ntwrk/midnight-js-level-private-state-provider`:
+- `CryptoBackend` (interface)
+- `CryptoBackendType` (`'webcrypto' | 'noble'`)
+- `StorageEncryptionOptions`
+
+### Injectable levelFactory for React Native support (#827)
+
+`LevelPrivateStateProviderConfig` now accepts an optional `levelFactory` function, enabling React Native adapters that extend `AbstractLevel` to be used instead of the default Node.js `Level`.
+
+```typescript
+import { levelPrivateStateProvider, type LevelFactory } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
+
+const customLevelFactory: LevelFactory = (dbName) => new MyReactNativeLevel(dbName);
+
+const provider = await levelPrivateStateProvider({
+  // ...
+  levelFactory: customLevelFactory,
+});
+```
+
+New exports: `LevelFactory`, `DatabaseLevel`.
+
+### Protocol ACL package (#832)
+
+New `@midnight-ntwrk/midnight-js-protocol` package provides version-agnostic access to 5 protocol packages via subpath exports. Decouples consumer code from protocol version numbers -- future ledger/runtime upgrades only require updating the protocol package.
+
+### DAppConnectorWalletAdapter for testkit-js (#855)
+
+New testing infrastructure for wallet-delegated proving through `dapp-connector-proof-provider`:
+
+- **DAppConnectorWalletAdapter** -- wraps `MidnightWalletProvider` behind the `ConnectedAPI` interface with local WASM proving
+- **DAppConnectorInitialAPI** -- provides `InitialAPI` with networkId validation
+
+Enables e2e testing of the dapp-connector proving flow without a standalone proof server.
+
+## Bug Fixes
+
+### Reject HTML responses in FetchZkConfigProvider (#785)
+
+SPA servers return `index.html` with HTTP 200 for non-existent artifact paths. Without Content-Type validation, HTML bytes were silently accepted as ZK key material, causing cryptic proof server failures. The fix validates the Content-Type header and rejects `text/html` responses with a descriptive error including the full URL and status code.
+
+## Dependencies
+
+### Runtime Dependencies Updated
+- `@apollo/client`: 3.14.0 -> 4.1.6 (#666)
+- `graphql`: 16.13.1 -> 16.13.2 (#778)
+- `graphql-ws`: 6.0.7 -> 6.0.8 (#796)
+- `@noble/ciphers` and `@noble/hashes`: added (#827)
+
+### Development Dependencies Updated
+- `turbo`: 2.8.21 -> 2.9.5 (#845)
+- `rollup`: 4.59.0 -> 4.60.1 (#797)
+- `typescript`, `ws`, `@vitest/runner`: bumped (#776)
+- `docker/login-action`: 4.0.0 -> 4.1.0 (#836)
+- `mikepenz/action-junit-report`: 6.3.1 -> 6.4.0 (#792)
+- `ctrf-io/github-test-reporter`: 1.0.27 -> 1.0.28 (#793)
+- `npm_and_yarn` group: 2 updates (#791)
+
+### Maintenance
+- Add protocol as dependency of barrel package (#842)
+- Remove unused deps from midnight-js (#800)
+
+## Tests
+
+- Improve indexer-public-data-provider coverage (#801)
+- Cover encryption key resolver and dapp-connector error paths (#848)
+- Add shell-injection regression suite for compact CLI
+- Guard invalidate-and-re-derive in level-private-state
+- Add ACL structural and ESLint rule tests
+- Prune low-value tests from resolver and dapp-connector suites
+
+## Documentation
+
+- Rewrite CLAUDE.md as contributor guide (#747)
+- Add protocol package README and update main README (#835)
+- API documentation updates (#846, #841, #833, #826, #784)
+
+## Links
+
+- [Breaking Changes Details](./breaking-changes.md)
+- [New Features Guide](./new-features.md)
+- [Migration Guide](./migration-guide.md)
+- [API Changes Reference](./api-changes.md)
+- [v4.0.4 Release Notes](../v4.0.4/release-notes.md)

--- a/docs/releases/v4.1.0/release-notes.md
+++ b/docs/releases/v4.1.0/release-notes.md
@@ -37,6 +37,10 @@ Additional subpaths: `./compact-js/effect`, `./compact-js/effect-contract`, `./p
 
 Security update to axios in testkit-js packages, addressing known vulnerabilities.
 
+### Fix critical protobufjs vulnerability (#854)
+
+Bumps `protobufjs` from 7.5.4 to 7.5.5, fixing CVE-2026-41242 (arbitrary code execution via `__proto__` poisoning in Message constructor and invalid characters in type names).
+
 ## Features
 
 ### CryptoBackend abstraction with Noble fallback (#827)

--- a/docs/releases/v4.1.0/release-notes.md
+++ b/docs/releases/v4.1.0/release-notes.md
@@ -62,16 +62,16 @@ New exports from `@midnight-ntwrk/midnight-js-level-private-state-provider`:
 
 ### Injectable levelFactory for React Native support (#827)
 
-`LevelPrivateStateProviderConfig` now accepts an optional `levelFactory` function, enabling React Native adapters that extend `AbstractLevel` to be used instead of the default Node.js `Level`.
+`LevelPrivateStateProviderConfig` now accepts an optional `levelFactory` function, enabling any `AbstractLevel`-compatible storage backend to be used instead of the default Node.js `Level`. This unblocks React Native consumers — for example, using [`react-native-leveldb-level-adapter`](https://www.npmjs.com/package/react-native-leveldb-level-adapter) which provides an `AbstractLevel` adapter over native LevelDB bindings via JSI.
 
 ```typescript
-import { levelPrivateStateProvider, type LevelFactory } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
-
-const customLevelFactory: LevelFactory = (dbName) => new MyReactNativeLevel(dbName);
+import { levelPrivateStateProvider } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
+import { SKReactNativeLevel } from 'react-native-leveldb-level-adapter';
 
 const provider = await levelPrivateStateProvider({
   // ...
-  levelFactory: customLevelFactory,
+  cryptoBackend: 'noble',
+  levelFactory: (dbName) => new SKReactNativeLevel(dbName),
 });
 ```
 


### PR DESCRIPTION
## Summary

- Add complete release documentation for v4.1.0 in `docs/releases/v4.1.0/`
- Covers 2 breaking changes (StorageEncryption async Web Crypto migration, protocol ACL imports), 4 new features (CryptoBackend abstraction with Noble fallback, injectable levelFactory for React Native, protocol ACL package, DAppConnector testkit adapter), 1 security fix (axios), 1 bug fix (HTML response rejection in FetchZkConfigProvider)
- Includes README, release notes, breaking changes, new features, API changes reference, and migration guide

## Test plan
- [ ] All links between release notes files are valid
- [ ] Code examples in migration guide compile
- [ ] Import mapping table in breaking-changes.md is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)