### PR TITLE
Augment interface of unproven-call-tx.ts to allow cross-contract calls

### DIFF
--- a/packages/contracts/src/call.ts
+++ b/packages/contracts/src/call.ts
@@ -25,6 +25,7 @@ import {
   type ZswapLocalState
 } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
+  type CommunicationCommitmentRand,
   type EncPublicKey,
   type LedgerParameters,
   type PartitionedTranscript,
@@ -54,6 +55,10 @@ export type CallOptionsBase<C extends Contract.Any, PCK extends Contract.Provabl
    * The address of the contract being executed.
    */
   readonly contractAddress: ContractAddress;
+  /**
+   * Optional override for the call communication commitment randomness.
+   */
+  readonly communicationCommitmentRand?: CommunicationCommitmentRand;
 };
 
 /**

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -95,8 +95,10 @@ export {
   CallTxOptionsWithPrivateStateId,
   createUnprovenCallTx,
   createUnprovenCallTxFromInitialStates,
+  createUnprovenCallTxFromInitialStatesWithZswapLocalState,
   UnprovenCallTxProvidersBase,
-  UnprovenCallTxProvidersWithPrivateState
+  UnprovenCallTxProvidersWithPrivateState,
+  UnsubmittedCallTxDataWithZswapLocalState
 } from './unproven-call-tx';
 export {
   createUnprovenDeployTx,

--- a/packages/contracts/src/submit-tx.ts
+++ b/packages/contracts/src/submit-tx.ts
@@ -22,8 +22,6 @@ import {
   type AnyProvableCircuitId,
   type FinalizedTxData,
 } from '@midnight-ntwrk/midnight-js-types';
-import fs from 'fs';
-import path from 'path';
 
 import { type ContractProviders } from './contract-providers';
 
@@ -72,23 +70,9 @@ function logTransaction(circuitId: string | string[] | undefined, tx: Transactio
 
   try {
     console.log(`Submit tx: ${circuitIds} : ${tx}`);
-    const serialized = tx.serialize();
-    const logsDir = path.join(process.cwd(), 'logs', 'transactions');
-
-    if (!fs.existsSync(logsDir)) {
-      fs.mkdirSync(logsDir, { recursive: true });
-    }
-
-    const filename = `tx-${Date.now()}-${circuitIds}`;
-    const filepath = path.join(logsDir, filename + '.bin');
-    const filepathString = path.join(logsDir, filename + '.txt');
-
-    fs.writeFileSync(filepath, serialized);
-    fs.writeFileSync(filepathString, tx.toString());
-
-    console.log(`Transaction serialized and written to: ${filepath}`);
+    console.log(`Serialized tx bytes: ${tx.serialize().length}`);
   } catch (error) {
-    console.error('Failed to write debug transaction logs:', error instanceof Error ? error.message : String(error));
+    console.error('Failed to serialize debug transaction:', error instanceof Error ? error.message : String(error));
   }
 }
 

--- a/packages/contracts/src/submit-tx.ts
+++ b/packages/contracts/src/submit-tx.ts
@@ -22,6 +22,8 @@ import {
   type AnyProvableCircuitId,
   type FinalizedTxData,
 } from '@midnight-ntwrk/midnight-js-types';
+import fs from 'fs';
+import path from 'path';
 
 import { type ContractProviders } from './contract-providers';
 
@@ -70,9 +72,23 @@ function logTransaction(circuitId: string | string[] | undefined, tx: Transactio
 
   try {
     console.log(`Submit tx: ${circuitIds} : ${tx}`);
-    console.log(`Serialized tx bytes: ${tx.serialize().length}`);
+    const serialized = tx.serialize();
+    const logsDir = path.join(process.cwd(), 'logs', 'transactions');
+
+    if (!fs.existsSync(logsDir)) {
+      fs.mkdirSync(logsDir, { recursive: true });
+    }
+
+    const filename = `tx-${Date.now()}-${circuitIds}`;
+    const filepath = path.join(logsDir, filename + '.bin');
+    const filepathString = path.join(logsDir, filename + '.txt');
+
+    fs.writeFileSync(filepath, serialized);
+    fs.writeFileSync(filepathString, tx.toString());
+
+    console.log(`Transaction serialized and written to: ${filepath}`);
   } catch (error) {
-    console.error('Failed to serialize debug transaction:', error instanceof Error ? error.message : String(error));
+    console.error('Failed to write debug transaction logs:', error instanceof Error ? error.message : String(error));
   }
 }
 

--- a/packages/contracts/src/unproven-call-tx.ts
+++ b/packages/contracts/src/unproven-call-tx.ts
@@ -16,8 +16,8 @@
 import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 import { ContractExecutable } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import { type Contract, ProvableCircuitId } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
-import { type CoinPublicKey, type ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
-import { type EncPublicKey, type LedgerParameters, type ZswapChainState } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import { type CoinPublicKey, type ContractState, type ZswapLocalState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import { type EncPublicKey, type LedgerParameters, type QualifiedShieldedCoinInfo, type ZswapChainState } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/platform-js/effect/ContractAddress';
 import { exitResultOrError, makeContractExecutableRuntime, type PrivateStateId, type ZKConfigProvider } from '@midnight-ntwrk/midnight-js-types';
 import { assertDefined, assertIsContractAddress, parseCoinPublicKeyToHex } from '@midnight-ntwrk/midnight-js-utils';
@@ -34,7 +34,57 @@ import { type ContractStates, getPublicStates, getStates, type PublicContractSta
 import * as Transaction from './internal/transaction';
 import { type TransactionContext } from './transaction';
 import type { UnsubmittedCallTxData } from './tx-model';
-import { createUnprovenLedgerCallTx, encryptionPublicKeyResolverForZswapState, zswapStateToNewCoins } from './utils';
+import {
+  createUnprovenLedgerCallTx,
+  createZswapOutput,
+  encryptionPublicKeyForZswapState,
+  encryptionPublicKeyResolverForZswapState,
+  zswapStateToNewCoins
+} from './utils';
+
+type MergeMetadataPayload = {
+  readonly contractOwnedOutputCoinsByCommitment: ReadonlyMap<string, QualifiedShieldedCoinInfo>;
+};
+
+const MergeMetadata = Symbol.for('@midnight-ntwrk/midnight-js-contracts#MergeMetadata');
+
+const contractOwnedOutputCoinsByCommitment = (
+  zswapLocalState: ZswapLocalState,
+  walletEncryptionPublicKey: EncPublicKey
+): ReadonlyMap<string, QualifiedShieldedCoinInfo> => {
+  const commitments = new Map<string, QualifiedShieldedCoinInfo>();
+  const encryptionPublicKeyResolver = () => walletEncryptionPublicKey;
+
+  zswapLocalState.outputs.forEach((output) => {
+    if (output.recipient.is_left) {
+      return;
+    }
+
+    const unprovenOutput = createZswapOutput(output, encryptionPublicKeyResolver);
+    commitments.set(unprovenOutput.commitment, {
+      ...output.coinInfo,
+      // Placeholder only: merge metadata is keyed by commitment, not by a real Merkle position.
+      mt_index: 0n
+    });
+  });
+
+  return commitments;
+};
+
+const attachMergeMetadata = <C extends Contract.Any, PCK extends Contract.ProvableCircuitId<C>>(
+  callTxData: UnsubmittedCallTxData<C, PCK>,
+  zswapLocalState: ZswapLocalState,
+  walletEncryptionPublicKey: EncPublicKey
+): UnsubmittedCallTxData<C, PCK> => {
+  const privateData = callTxData.private as typeof callTxData.private & Record<symbol, MergeMetadataPayload>;
+  privateData[MergeMetadata] = {
+    contractOwnedOutputCoinsByCommitment: contractOwnedOutputCoinsByCommitment(
+      zswapLocalState,
+      walletEncryptionPublicKey
+    )
+  };
+  return callTxData;
+};
 
 export function createUnprovenCallTxFromInitialStates<C extends Contract<undefined>, PCK extends Contract.ProvableCircuitId<C>>(
   zkConfigProvider: ZKConfigProvider<string>,
@@ -105,7 +155,19 @@ export async function createUnprovenCallTxFromInitialStates<C extends Contract.A
       }
     } = exitResultOrError(exitResult)
 
-    return {
+    const encryptionPublicKeyResolver = encryptionPublicKeyResolverForZswapState(
+      zswapLocalState,
+      options.coinPublicKey,
+      walletEncryptionPublicKey,
+      options.additionalCoinEncPublicKeyMappings
+    );
+    const walletEncryptionPublicKeyLocal = encryptionPublicKeyForZswapState(
+      zswapLocalState,
+      options.coinPublicKey,
+      walletEncryptionPublicKey
+    );
+
+    const callTxData = {
       public: {
         nextContractState: contractState,
         partitionedTranscript,
@@ -128,12 +190,8 @@ export async function createUnprovenCallTxFromInitialStates<C extends Contract.A
           input,
           output,
           zswapLocalState,
-          encryptionPublicKeyResolverForZswapState(
-            zswapLocalState,
-            options.coinPublicKey,
-            walletEncryptionPublicKey,
-            options.additionalCoinEncPublicKeyMappings
-          )
+          encryptionPublicKeyResolver,
+          options.communicationCommitmentRand
         ),
         newCoins: zswapStateToNewCoins(
           parseCoinPublicKeyToHex(coinPublicKey, getNetworkId()),
@@ -141,6 +199,8 @@ export async function createUnprovenCallTxFromInitialStates<C extends Contract.A
         )
       }
     };
+
+    return attachMergeMetadata(callTxData, zswapLocalState, walletEncryptionPublicKeyLocal);
   } catch (error: unknown) {
     if (!isEffectContractError(error) || error._tag !== 'ContractRuntimeError') throw error;
     if (error.cause.name !== 'CompactError') throw error;
@@ -188,7 +248,8 @@ const createCallOptions = <C extends Contract.Any, PCK extends Contract.Provable
     additionalCoinEncPublicKeyMappings: callTxOptions.additionalCoinEncPublicKeyMappings,
     compiledContract: callTxOptions.compiledContract,
     contractAddress: callTxOptions.contractAddress,
-    circuitId: callTxOptions.circuitId
+    circuitId: callTxOptions.circuitId,
+    communicationCommitmentRand: callTxOptions.communicationCommitmentRand
   };
   const callOptionsWithArguments =
     'args' in callTxOptions

--- a/packages/contracts/src/unproven-call-tx.ts
+++ b/packages/contracts/src/unproven-call-tx.ts
@@ -17,7 +17,7 @@ import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 import { ContractExecutable } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import { type Contract, ProvableCircuitId } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
 import { type CoinPublicKey, type ContractState, type ZswapLocalState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
-import { type EncPublicKey, type LedgerParameters, type QualifiedShieldedCoinInfo, type ZswapChainState } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import { type EncPublicKey, type LedgerParameters, type ZswapChainState } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/platform-js/effect/ContractAddress';
 import { exitResultOrError, makeContractExecutableRuntime, type PrivateStateId, type ZKConfigProvider } from '@midnight-ntwrk/midnight-js-types';
 import { assertDefined, assertIsContractAddress, parseCoinPublicKeyToHex } from '@midnight-ntwrk/midnight-js-utils';
@@ -34,57 +34,30 @@ import { type ContractStates, getPublicStates, getStates, type PublicContractSta
 import * as Transaction from './internal/transaction';
 import { type TransactionContext } from './transaction';
 import type { UnsubmittedCallTxData } from './tx-model';
-import {
-  createUnprovenLedgerCallTx,
-  createZswapOutput,
-  encryptionPublicKeyForZswapState,
-  encryptionPublicKeyResolverForZswapState,
-  zswapStateToNewCoins
-} from './utils';
+import { createUnprovenLedgerCallTx, encryptionPublicKeyResolverForZswapState, zswapStateToNewCoins } from './utils';
 
-type MergeMetadataPayload = {
-  readonly contractOwnedOutputCoinsByCommitment: ReadonlyMap<string, QualifiedShieldedCoinInfo>;
+export type UnsubmittedCallTxDataWithZswapLocalState<C extends Contract.Any, PCK extends Contract.ProvableCircuitId<C>> = {
+  readonly callTxData: UnsubmittedCallTxData<C, PCK>;
+  readonly zswapLocalState: ZswapLocalState;
 };
 
-const MergeMetadata = Symbol.for('@midnight-ntwrk/midnight-js-contracts#MergeMetadata');
-
-const contractOwnedOutputCoinsByCommitment = (
-  zswapLocalState: ZswapLocalState,
+export function createUnprovenCallTxFromInitialStatesWithZswapLocalState<
+  C extends Contract<undefined>,
+  PCK extends Contract.ProvableCircuitId<C>
+>(
+  zkConfigProvider: ZKConfigProvider<string>,
+  options: CallOptionsWithProviderDataDependencies<C, PCK>,
   walletEncryptionPublicKey: EncPublicKey
-): ReadonlyMap<string, QualifiedShieldedCoinInfo> => {
-  const commitments = new Map<string, QualifiedShieldedCoinInfo>();
-  const encryptionPublicKeyResolver = () => walletEncryptionPublicKey;
+): Promise<UnsubmittedCallTxDataWithZswapLocalState<C, PCK>>;
 
-  zswapLocalState.outputs.forEach((output) => {
-    if (output.recipient.is_left) {
-      return;
-    }
-
-    const unprovenOutput = createZswapOutput(output, encryptionPublicKeyResolver);
-    commitments.set(unprovenOutput.commitment, {
-      ...output.coinInfo,
-      // Placeholder only: merge metadata is keyed by commitment, not by a real Merkle position.
-      mt_index: 0n
-    });
-  });
-
-  return commitments;
-};
-
-const attachMergeMetadata = <C extends Contract.Any, PCK extends Contract.ProvableCircuitId<C>>(
-  callTxData: UnsubmittedCallTxData<C, PCK>,
-  zswapLocalState: ZswapLocalState,
+export function createUnprovenCallTxFromInitialStatesWithZswapLocalState<
+  C extends Contract.Any,
+  PCK extends Contract.ProvableCircuitId<C>
+>(
+  zkConfigProvider: ZKConfigProvider<string>,
+  options: CallOptionsWithPrivateState<C, PCK>,
   walletEncryptionPublicKey: EncPublicKey
-): UnsubmittedCallTxData<C, PCK> => {
-  const privateData = callTxData.private as typeof callTxData.private & Record<symbol, MergeMetadataPayload>;
-  privateData[MergeMetadata] = {
-    contractOwnedOutputCoinsByCommitment: contractOwnedOutputCoinsByCommitment(
-      zswapLocalState,
-      walletEncryptionPublicKey
-    )
-  };
-  return callTxData;
-};
+): Promise<UnsubmittedCallTxDataWithZswapLocalState<C, PCK>>;
 
 export function createUnprovenCallTxFromInitialStates<C extends Contract<undefined>, PCK extends Contract.ProvableCircuitId<C>>(
   zkConfigProvider: ZKConfigProvider<string>,
@@ -113,6 +86,33 @@ export async function createUnprovenCallTxFromInitialStates<C extends Contract.A
   options: CallOptions<C, PCK>,
   walletEncryptionPublicKey: EncPublicKey
 ): Promise<UnsubmittedCallTxData<C, PCK>> {
+  return (
+    await createUnprovenCallTxFromInitialStatesWithZswapLocalState(
+      zkConfigProvider,
+      options,
+      walletEncryptionPublicKey
+    )
+  ).callTxData;
+}
+
+/**
+ * Calls a circuit using the provided initial `states` and creates an unbalanced,
+ * unproven, unsubmitted, call transaction together with the resulting local Zswap state.
+ *
+ * @param zkConfigProvider
+ * @param options Configuration.
+ *
+ * @param walletEncryptionPublicKey
+ * @returns The unsubmitted call transaction data together with the resulting local Zswap state.
+ */
+export async function createUnprovenCallTxFromInitialStatesWithZswapLocalState<
+  C extends Contract.Any,
+  PCK extends Contract.ProvableCircuitId<C>
+>(
+  zkConfigProvider: ZKConfigProvider<string>,
+  options: CallOptions<C, PCK>,
+  walletEncryptionPublicKey: EncPublicKey
+): Promise<UnsubmittedCallTxDataWithZswapLocalState<C, PCK>> {
   const { compiledContract, contractAddress, coinPublicKey, initialContractState, initialZswapChainState, ledgerParameters } = options;
   assertIsContractAddress(contractAddress);
   assertDefined(
@@ -161,13 +161,8 @@ export async function createUnprovenCallTxFromInitialStates<C extends Contract.A
       walletEncryptionPublicKey,
       options.additionalCoinEncPublicKeyMappings
     );
-    const walletEncryptionPublicKeyLocal = encryptionPublicKeyForZswapState(
-      zswapLocalState,
-      options.coinPublicKey,
-      walletEncryptionPublicKey
-    );
-
-    const callTxData = {
+    return {
+      callTxData: {
       public: {
         nextContractState: contractState,
         partitionedTranscript,
@@ -198,9 +193,9 @@ export async function createUnprovenCallTxFromInitialStates<C extends Contract.A
           zswapLocalState
         )
       }
+      },
+      zswapLocalState
     };
-
-    return attachMergeMetadata(callTxData, zswapLocalState, walletEncryptionPublicKeyLocal);
   } catch (error: unknown) {
     if (!isEffectContractError(error) || error._tag !== 'ContractRuntimeError') throw error;
     if (error.cause.name !== 'CompactError') throw error;

--- a/packages/contracts/src/utils/ledger-utils.ts
+++ b/packages/contracts/src/utils/ledger-utils.ts
@@ -26,6 +26,7 @@ import {
   type ZswapLocalState} from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
   ChargedState,
+  type CommunicationCommitmentRand,
   communicationCommitmentRandomness,
   ContractCallPrototype,
   ContractDeploy,
@@ -116,7 +117,8 @@ export const createUnprovenLedgerCallTx = (
   input: AlignedValue,
   output: AlignedValue,
   nextZswapLocalState: ZswapLocalState,
-  encryptionPublicKey: EncPublicKey | EncryptionPublicKeyResolver
+  encryptionPublicKey: EncPublicKey | EncryptionPublicKeyResolver,
+  communicationCommitmentRand?: CommunicationCommitmentRand
 ): UnprovenTransaction => {
   const op = toLedgerContractState(initialContractState).operation(circuitId);
   assertDefined(op, `Operation '${circuitId}' is undefined for contract state ${initialContractState.toString(false)}`);
@@ -131,7 +133,7 @@ export const createUnprovenLedgerCallTx = (
       privateTranscriptOutputs,
       input,
       output,
-      communicationCommitmentRandomness(),
+      communicationCommitmentRand ?? communicationCommitmentRandomness(),
       circuitId
     )
   );


### PR DESCRIPTION
I've requested some changes to make it easier to do cross-contract calls 

1. `communicationCommitmentRand` is threaded all the way from call options into `ContractCallPrototype`. Default behavior is unchanged when the field is omitted, because the ledger still generates fresh randomness in that case. The difference is that callers can now provide the exact communication commitment randomness when they need the call transaction to line up with a separately-constructed opening of transientCommit of calling circuits.

2. Create a variant of `createUnprovenCallTxFromInitialStates()` called `createUnprovenCallTxFromInitialStatesWithZswapLocalState()`, which also returns the zswapLocalState. This is more convenient than rebuilding the zswapLocalState externally. We need the zswapLocalState to figure out which outputs are created by the tx, so we can merge them as transient coins in cross-contract calls.