### PR TITLE
feat: Add bundled transaction support

### DIFF
--- a/packages/contracts/src/bundle.ts
+++ b/packages/contracts/src/bundle.ts
@@ -1,0 +1,118 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
+import { type AnyProvableCircuitId, type FinalizedTxData } from '@midnight-ntwrk/midnight-js-types';
+
+import { type ContractProviders } from './contract-providers';
+import type { FoundContract } from './find-deployed-contract';
+import * as Internal from './internal/bundle';
+import {
+  type ScopedTransactionOptions,
+  type TransactionContext
+} from './transaction';
+
+/**
+ * The aggregate return value of {@link withMultiContractScopedTransaction}. Mirrors
+ * the shape of {@link FinalizedCallTxData} but for a transaction containing more
+ * than one contract call. The per-call records carry private data the caller may
+ * need to apply additional state updates beyond the wallet's automatic private-state
+ * persistence.
+ */
+export interface BundledFinalizedTxData {
+  /**
+   * Public on-chain data of the bundled transaction. Status is guaranteed to be
+   * `SucceedEntirely` if {@link withMultiContractScopedTransaction} returned
+   * normally; non-success statuses are reported via {@link CallTxFailedError}.
+   */
+  readonly public: FinalizedTxData;
+
+  /**
+   * Per-call records in submission order. Each record carries the contract address,
+   * private state ID (if any), circuit ID, and the {@link UnsubmittedCallTxData}
+   * the SDK produced for that call.
+   */
+  readonly calls: readonly Internal.InFlightCall[];
+}
+
+/**
+ * The contract-polymorphic transaction context handed to the
+ * {@link withMultiContractScopedTransaction} callback. Structurally a
+ * {@link TransactionContext}<{@link Contract.Any}, {@link AnyProvableCircuitId}>
+ * so that the SDK's per-call merge protocol accepts it as the outer scope; in
+ * addition exposes {@link MultiContractTransactionContext.for} for ergonomic
+ * typed widening at each `callTx` invocation.
+ */
+export interface MultiContractTransactionContext
+  extends TransactionContext<Contract.Any, AnyProvableCircuitId> {
+  /**
+   * Returns this same context typed for `contract`. Required because each
+   * `FoundContract`'s circuit-call interface is statically typed at its own
+   * `(C, PCK)`, and our context is intentionally type-erased so a single
+   * instance may be threaded through calls to heterogeneous contracts.
+   *
+   * Pure widening: no runtime work is performed; the same instance is returned.
+   *
+   * @example
+   * ```ts
+   * await withMultiContractScopedTransaction(providers, async (txCtx) => {
+   *   await sender.callTx.send(txCtx.for(sender), ...);
+   *   await recipient.callTx.receive(txCtx.for(recipient), ...);
+   * });
+   * ```
+   */
+  for<
+    C extends Contract.Any,
+    PCK extends Contract.ProvableCircuitId<C> = Contract.ProvableCircuitId<C>
+  >(contract: FoundContract<C>): TransactionContext<C, PCK>;
+}
+
+/**
+ * Executes a function within the context of a multi-contract scoped transaction.
+ * Calls to `contract.callTx.<circuit>(ctx.for(contract), ...)` made inside `fn` are
+ * collected and bundled into a single intent of a single ledger transaction segment
+ * that is proved, balanced, and submitted when `fn` resolves. Each participating
+ * contract's private state is persisted on success.
+ *
+ * @param providers The contract providers to use within the transaction.
+ * @param fn The function to execute within the transaction context.
+ * @param options Optional transaction scope options.
+ * @returns A `Promise` that resolves with the finalized public transaction data and
+ *   the per-call records produced for all circuit calls made within `fn`.
+ *
+ * @remarks
+ * Joint transcript partitioning across all bundled calls is performed at submission
+ * time via the ledger's {@link Transaction.addCalls} API. This is the property that
+ * matters for cross-contract value flows: the ledger's effects-check matches a
+ * sender's `claimed_unshielded_spends` against the recipient contract's
+ * `unshielded_inputs` only when both calls land in the same intent segment AND the
+ * same guaranteed/fallible half. Independent per-call partitioning (the alternative
+ * to joint partitioning) cannot guarantee that alignment.
+ *
+ * Where `fn` makes multiple circuit calls to the same contract, the second and
+ * subsequent calls observe the in-flight contract state produced by their
+ * predecessors. This mirrors the same-identity behaviour of
+ * {@link withContractScopedTransaction}.
+ *
+ * If `fn` throws an error, no submission is attempted and the error is re-thrown
+ * wrapped with the scope name. If submission fails, a {@link CallTxFailedError} is
+ * thrown with the finalized transaction data and the array of circuit IDs.
+ */
+export const withMultiContractScopedTransaction: (
+  providers: ContractProviders<Contract.Any, AnyProvableCircuitId>,
+  fn: (txCtx: MultiContractTransactionContext) => Promise<void>,
+  options?: ScopedTransactionOptions
+) => Promise<BundledFinalizedTxData> = (providers, fn, options) =>
+  Internal.bundleScoped(providers, fn, options);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -14,6 +14,11 @@
  */
 
 export {
+  BundledFinalizedTxData,
+  MultiContractTransactionContext,
+  withMultiContractScopedTransaction
+} from './bundle';
+export {
   CallOptions,
   CallOptionsBase,
   CallOptionsProviderDataDependencies,

--- a/packages/contracts/src/internal/bundle.ts
+++ b/packages/contracts/src/internal/bundle.ts
@@ -1,0 +1,470 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
+import { ChargedState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import {
+  type CoinPublicKey,
+  communicationCommitmentRandomness,
+  type ContractAddress,
+  ContractState as LedgerContractState,
+  type EncPublicKey,
+  LedgerParameters as LedgerLedgerParameters,
+  PrePartitionContractCall,
+  PreTranscript,
+  QueryContext as LedgerQueryContext,
+  type UnprovenTransaction
+} from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import {
+  type AnyProvableCircuitId,
+  type FinalizedTxData,
+  type PrivateStateId,
+  SucceedEntirely,
+  Transaction
+} from '@midnight-ntwrk/midnight-js-types';
+import { ttlOneHour } from '@midnight-ntwrk/midnight-js-utils';
+
+import type * as BundleApi from '../bundle';
+import { type ContractProviders } from '../contract-providers';
+import { CallTxFailedError } from '../errors';
+import { type ContractStates, type PublicContractStates } from '../get-states';
+import { submitTx } from '../submit-tx';
+import type * as TransactionApi from '../transaction';
+import type { UnsubmittedCallTxData } from '../tx-model';
+import {
+  type CachedStateIdentity,
+  CacheStates,
+  GetCurrentStatesForIdentity,
+  MergeUnsubmittedCallTxData,
+  Submit,
+  TypeId
+} from './transaction';
+
+/**
+ * @internal
+ *
+ * One contract call captured during a {@link withMultiContractScopedTransaction} scope.
+ * The scope handler records the raw inputs the SDK's per-call pipeline produced (input,
+ * output, private transcript outputs, public transcript) so the bundler can reconstruct
+ * a fresh {@link PrePartitionContractCall} and hand it to {@link Transaction.addCalls}
+ * for joint transcript partitioning.
+ *
+ * `contractStateBytes` and `ledgerParametersBytes` are serialized snapshots taken at
+ * merge time, BEFORE any subsequent same-identity state mutation in the scope. The
+ * bundler hands these bytes to {@link LedgerContractState.deserialize} and
+ * {@link LedgerLedgerParameters.deserialize} so the resulting `ContractOperation`,
+ * `ChargedState`, `QueryContext`, and `LedgerParameters` instances are ledger-v8 wasm
+ * instances; ledger-v8 APIs validate the wasm class identity of their arguments.
+ *
+ * `callData.public.publicTranscript` is the PRE-partition program. The
+ * `partitionedTranscript` and `unprovenTx` fields on `callData` are artifacts of the
+ * SDK's per-call assembly and are intentionally NOT used by the bundler — joint
+ * partitioning supersedes the per-call partition.
+ */
+export interface InFlightCall {
+  readonly identity: CachedStateIdentity;
+  readonly circuitId: AnyProvableCircuitId;
+  readonly contractStateBytes: Uint8Array;
+  readonly ledgerParametersBytes: Uint8Array;
+  readonly callData: UnsubmittedCallTxData<Contract.Any, AnyProvableCircuitId>;
+}
+
+interface CachedStatesEntry {
+  readonly identity: CachedStateIdentity;
+  states: ContractStates<unknown> | PublicContractStates;
+}
+
+/**
+ * @internal
+ *
+ * Builds an {@link UnprovenTransaction} from a list of in-flight calls. Default impl
+ * is {@link bundleIntoSingleIntent}; the seam exists so unit tests can stub it without
+ * needing to construct round-trippable wasm contract states.
+ */
+export type Bundler = (calls: readonly InFlightCall[]) => UnprovenTransaction;
+
+const identityKey = (i: CachedStateIdentity): string =>
+  `${i.contractAddress} ${i.privateStateId ?? ''}`;
+
+/**
+ * @internal
+ *
+ * Builds a single {@link UnprovenTransaction} carrying every in-flight call in one
+ * intent of one randomly-chosen segment, via the documented multi-call API
+ * `Transaction.addCalls(segment, calls, params, ttl)`.
+ *
+ * Joint partitioning (rather than per-call partitioning followed by intent-level
+ * splicing) is the property required for cross-contract value flows. With each call
+ * partitioned independently, sender's {@link ContractAction} and recipient's
+ * {@link ContractAction} can land in different guaranteed/fallible halves of the same
+ * intent, in which case the cross-call effects-check at the ledger
+ * (`real_unshielded_spends.has_subset(claimed_unshielded_spends)`, keyed at
+ * `(intent_seg, is_guaranteed_half)`) refuses to match the sender's
+ * `claimed_unshielded_spends` against the recipient's `unshielded_inputs`.
+ *
+ * For each call we build a fresh {@link ContractCallPrototype} from raw inputs and a
+ * freshly-sampled {@link communicationCommitmentRandomness}; the binding nonce can be
+ * (re-)sampled at any point before proving for independent actions.
+ */
+export const bundleIntoSingleIntent: Bundler = (calls) => {
+  if (calls.length === 0) {
+    throw new Error('Cannot bundle: in-flight call list is empty.');
+  }
+
+  // All calls in a scope are made against the same chain, so the first call's
+  // ledgerParameters are representative of the whole bundle. Round-trip through
+  // ledger-v8 to ensure the wasm-class identity matches what `addCalls` expects.
+  const ledgerParams = LedgerLedgerParameters.deserialize(calls[0].ledgerParametersBytes);
+
+  const prePartitionCalls = calls.map((call): PrePartitionContractCall => {
+    // Bridge cross-package wasm class identity by deserializing through ledger-v8.
+    // `compact-runtime` and `ledger-v8` each ship their OWN wasm class for
+    // ContractState / ContractOperation / ChargedState / QueryContext under the
+    // same TypeScript names; the ledger-v8 APIs reject non-ledger-v8 instances.
+    const ledgerState = LedgerContractState.deserialize(call.contractStateBytes);
+    const op = ledgerState.operation(call.circuitId);
+    if (!op) {
+      throw new Error(
+        `Operation '${String(call.circuitId)}' is undefined for the cached state of contract ${
+          call.identity.contractAddress
+        }.`
+      );
+    }
+    const queryContext = new LedgerQueryContext(
+      ledgerState.data,
+      call.identity.contractAddress as ContractAddress
+    );
+    const preTranscript = new PreTranscript(queryContext, call.callData.public.publicTranscript);
+
+    return new PrePartitionContractCall(
+      call.identity.contractAddress as ContractAddress,
+      call.circuitId,
+      op,
+      preTranscript,
+      call.callData.private.privateTranscriptOutputs,
+      call.callData.private.input,
+      call.callData.private.output,
+      communicationCommitmentRandomness(),
+      String(call.circuitId)
+    );
+  });
+
+  // For our contract-only bundles we never have Zswap inputs/outputs/transients; if a
+  // future caller wants those routed through the bundler the empty array arguments
+  // here are the place to thread them through.
+  const empty = Transaction.fromParts(getNetworkId());
+  return empty.addCalls(
+    { tag: 'random' },
+    prePartitionCalls,
+    ledgerParams,
+    ttlOneHour()
+  );
+};
+
+/**
+ * @internal
+ *
+ * Implementation of {@link BundleApi.MultiContractTransactionContext}. The runtime
+ * shape is structurally a {@link TransactionApi.TransactionContext}<Contract.Any>:
+ * each per-contract `callTx.<circuitId>(ctx, ...)` invocation goes through the SDK's
+ * normal `submitCallTx → Transaction.scoped → mergeUnsubmittedCallTxData` path with
+ * this object as the outer `txCtx`, then we collect the raw call data and assemble
+ * one merged transaction at submission time.
+ */
+export class BundleContextImpl
+  implements TransactionApi.TransactionContext<Contract.Any, AnyProvableCircuitId>
+{
+  readonly [TypeId]: TransactionApi.TypeId = TypeId;
+
+  private readonly providers: ContractProviders<Contract.Any, AnyProvableCircuitId>;
+  private readonly options?: TransactionApi.ScopedTransactionOptions;
+  private readonly bundler: Bundler;
+
+  private readonly cachedStatesByIdentity = new Map<string, CachedStatesEntry>();
+  private readonly inFlightCalls: InFlightCall[] = [];
+
+  private lastUnsubmittedCall:
+    | [UnsubmittedCallTxData<Contract.Any, AnyProvableCircuitId>, PrivateStateId?]
+    | undefined = undefined;
+
+  constructor(
+    providers: ContractProviders<Contract.Any, AnyProvableCircuitId>,
+    options?: TransactionApi.ScopedTransactionOptions,
+    bundler: Bundler = bundleIntoSingleIntent
+  ) {
+    this.providers = providers;
+    this.options = options;
+    this.bundler = bundler;
+  }
+
+  // ── TransactionContext protocol surface ─────────────────────────────────
+
+  getAdditionalMappings(): ReadonlyMap<CoinPublicKey, EncPublicKey> | undefined {
+    return this.options?.additionalCoinEncPublicKeyMappings;
+  }
+
+  /**
+   * @deprecated Mirrors {@link TransactionApi.TransactionContext.getCurrentStates}'s
+   * single-identity semantics by returning the most recently touched identity's states.
+   * Multi-contract callers should not rely on it; use the identity-validating reader.
+   */
+  getCurrentStates(): ContractStates<unknown> | PublicContractStates | undefined {
+    if (this.inFlightCalls.length === 0) return undefined;
+    const lastIdentity = this.inFlightCalls[this.inFlightCalls.length - 1]!.identity;
+    return this.cachedStatesByIdentity.get(identityKey(lastIdentity))?.states;
+  }
+
+  getLastUnsubmittedCallTxDataToTransact():
+    | [UnsubmittedCallTxData<Contract.Any, AnyProvableCircuitId>, PrivateStateId?]
+    | undefined {
+    return this.lastUnsubmittedCall;
+  }
+
+  [GetCurrentStatesForIdentity](
+    identity: CachedStateIdentity
+  ): ContractStates<unknown> | PublicContractStates | undefined {
+    return this.cachedStatesByIdentity.get(identityKey(identity))?.states;
+  }
+
+  [CacheStates](
+    states: ContractStates<unknown> | PublicContractStates,
+    identity: CachedStateIdentity
+  ): void {
+    this.cachedStatesByIdentity.set(identityKey(identity), { identity, states });
+  }
+
+  [MergeUnsubmittedCallTxData](
+    circuitId: AnyProvableCircuitId,
+    callData: UnsubmittedCallTxData<Contract.Any, AnyProvableCircuitId>,
+    privateStateId?: PrivateStateId
+  ): void {
+    const identity = this.identityForCall(privateStateId);
+
+    const cached = this.cachedStatesByIdentity.get(identityKey(identity));
+    if (!cached) {
+      throw new Error(
+        `No cached state for identity ${identityKey(identity)} at merge time. ` +
+          'The SDK populates the cache via [CacheStates] before [MergeUnsubmittedCallTxData]; ' +
+          'this invariant is violated.'
+      );
+    }
+    // Capture the raw bytes BEFORE the post-call mutation below. The bundler treats
+    // this snapshot as the pre-call state when constructing PreTranscript / op for
+    // the call.
+    const contractStateBytes: Uint8Array = cached.states.contractState.serialize();
+    const ledgerParametersBytes: Uint8Array = (
+      cached.states.ledgerParameters as { serialize(): Uint8Array }
+    ).serialize();
+
+    this.inFlightCalls.push({
+      identity,
+      circuitId,
+      contractStateBytes,
+      ledgerParametersBytes,
+      callData
+    });
+    this.lastUnsubmittedCall = [callData, privateStateId];
+
+    // Mirror the SDK's in-place state-update behaviour so subsequent same-identity
+    // calls in the scope read the post-call ledger state, preserving the original
+    // zswapChainState and ledgerParameters.
+    const nextContractState = cached.states.contractState;
+    nextContractState.data = new ChargedState(callData.public.nextContractState);
+    const nextStates: ContractStates<unknown> | PublicContractStates =
+      'privateState' in cached.states
+        ? {
+            contractState: nextContractState,
+            zswapChainState: cached.states.zswapChainState,
+            ledgerParameters: cached.states.ledgerParameters,
+            privateState: callData.private.nextPrivateState
+          }
+        : {
+            contractState: nextContractState,
+            zswapChainState: cached.states.zswapChainState,
+            ledgerParameters: cached.states.ledgerParameters
+          };
+    this.cachedStatesByIdentity.set(identityKey(identity), { identity, states: nextStates });
+  }
+
+  /**
+   * Provided for protocol compatibility. The SDK's root `scoped(...)` only calls
+   * `[Submit]` when no outer `txCtx` is supplied; in our usage we ARE the outer ctx,
+   * so the SDK never invokes this. We expose it so a {@link BundleContextImpl} is
+   * structurally a {@link TransactionApi.TransactionContext}.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async [Submit](): Promise<any> {
+    return this.submit();
+  }
+
+  // ── Bundler-specific surface ────────────────────────────────────────────
+
+  /**
+   * Pure widening: returns this same context typed for `_contract`. Required because
+   * each {@link BundleApi.MultiContractTransactionContext.for} caller's
+   * `FoundContract` is statically typed at its own `(C, PCK)`, while the bundle
+   * context is intentionally type-erased so it can thread through calls to
+   * heterogeneous contracts.
+   */
+  for<C extends Contract.Any, PCK extends Contract.ProvableCircuitId<C>>(
+    _contract: unknown
+  ): TransactionApi.TransactionContext<C, PCK> {
+    return this as unknown as TransactionApi.TransactionContext<C, PCK>;
+  }
+
+  /**
+   * Bundles the in-flight calls into a single-intent transaction, submits it, and
+   * persists each participating private state. Returns the finalized public tx data
+   * plus the per-call records.
+   */
+  async submit(): Promise<BundleApi.BundledFinalizedTxData> {
+    if (this.inFlightCalls.length === 0) {
+      throw new Error('No calls were submitted within the multi-contract scope.');
+    }
+
+    const mergedTx = this.bundler(this.inFlightCalls);
+    const circuitIds = this.inFlightCalls.map((c) => c.circuitId);
+
+    const finalizedTxData: FinalizedTxData = await submitTx(this.providers, {
+      unprovenTx: mergedTx,
+      circuitId: circuitIds
+    });
+
+    if (finalizedTxData.status !== SucceedEntirely) {
+      throw new CallTxFailedError(finalizedTxData, circuitIds);
+    }
+
+    // Persist the latest nextPrivateState for each participating privateStateId.
+    // Walking in insertion order means later same-PSID calls override earlier ones.
+    const latestByPsId = new Map<PrivateStateId, InFlightCall>();
+    for (const c of this.inFlightCalls) {
+      if (c.identity.privateStateId !== undefined) {
+        latestByPsId.set(c.identity.privateStateId, c);
+      }
+    }
+    if (latestByPsId.size > 0) {
+      const psp = this.providers.privateStateProvider;
+      if (!psp) {
+        throw new Error(
+          'In-flight calls referenced privateStateIds but providers.privateStateProvider is undefined.'
+        );
+      }
+      for (const [psId, call] of latestByPsId) {
+        await psp.set(psId, call.callData.private.nextPrivateState);
+      }
+    }
+
+    return {
+      public: finalizedTxData,
+      calls: this.inFlightCalls
+    };
+  }
+
+  // ── Internal helpers ────────────────────────────────────────────────────
+
+  /**
+   * Recovers the identity for a merge call from its `privateStateId` argument. The
+   * SDK's `[MergeUnsubmittedCallTxData]` protocol does not directly thread
+   * `contractAddress`, so we identify the matching cached identity by `privateStateId`
+   * (the unique identity key for a given contract within a scope).
+   *
+   * Pathological pipelines where multiple distinct contract addresses share the same
+   * `privateStateId` (or all share `undefined`) cannot be reliably distinguished
+   * here; the most recently cached identity for that `privateStateId` wins.
+   */
+  private identityForCall(privateStateId: PrivateStateId | undefined): CachedStateIdentity {
+    let candidate: CachedStateIdentity | undefined;
+    for (const entry of this.cachedStatesByIdentity.values()) {
+      if (entry.identity.privateStateId === privateStateId) {
+        candidate = entry.identity;
+      }
+    }
+    if (!candidate) {
+      throw new Error(
+        `Cannot recover identity for in-flight call: no cached states match privateStateId=${String(
+          privateStateId
+        )}.`
+      );
+    }
+    return candidate;
+  }
+
+  /** @internal Test-only accessor. */
+  getInFlightCalls(): readonly InFlightCall[] {
+    return this.inFlightCalls;
+  }
+}
+
+/**
+ * @internal
+ *
+ * Test-only options for {@link bundleScoped}. Public callers should use
+ * {@link BundleApi.withMultiContractScopedTransaction}, which does not expose the
+ * test seam.
+ */
+export interface BundleScopedInternalOptions {
+  /**
+   * Override the bundling step. Used by unit tests that don't have access to
+   * round-trippable {@link LedgerContractState} bytes.
+   */
+  readonly bundler?: Bundler;
+}
+
+/**
+ * @internal
+ *
+ * Entry point used by {@link BundleApi.withMultiContractScopedTransaction}. The
+ * `internalOptions` parameter is intended only for unit tests and is omitted from
+ * the public API.
+ */
+export const bundleScoped = async (
+  providers: ContractProviders<Contract.Any, AnyProvableCircuitId>,
+  fn: (txCtx: BundleApi.MultiContractTransactionContext) => Promise<void>,
+  options?: TransactionApi.ScopedTransactionOptions,
+  internalOptions?: BundleScopedInternalOptions
+): Promise<BundleApi.BundledFinalizedTxData> => {
+  const ctx = new BundleContextImpl(providers, options, internalOptions?.bundler);
+
+  try {
+    await fn(ctx as unknown as BundleApi.MultiContractTransactionContext);
+  } catch (err: unknown) {
+    const wrapped = new Error(
+      `Unexpected error executing multi-contract scoped transaction '${
+        options?.scopeName ?? '<unnamed>'
+      }': ${String(err)}`,
+      { cause: err }
+    );
+    providers?.loggerProvider?.error?.call(providers.loggerProvider, wrapped.message);
+    throw wrapped;
+  }
+
+  try {
+    return await ctx.submit();
+  } catch (err: unknown) {
+    if (err instanceof CallTxFailedError) {
+      throw err;
+    }
+    const wrapped = new Error(
+      `Unexpected error submitting multi-contract scoped transaction '${
+        options?.scopeName ?? '<unnamed>'
+      }': ${String(err)}`,
+      { cause: err }
+    );
+    providers?.loggerProvider?.error?.call(providers.loggerProvider, wrapped.message);
+    throw wrapped;
+  }
+};
+

--- a/packages/contracts/src/test/bundle.test.ts
+++ b/packages/contracts/src/test/bundle.test.ts
@@ -1,0 +1,686 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LedgerParameters } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import {
+  type AnyProvableCircuitId,
+  FailEntirely,
+  type PrivateStateId,
+  SucceedEntirely
+} from '@midnight-ntwrk/midnight-js-types';
+import { describe, expect, it, vi } from 'vitest';
+
+import { type MultiContractTransactionContext, withMultiContractScopedTransaction } from '../bundle';
+import { CallTxFailedError } from '../errors';
+import {
+  type Bundler,
+  bundleScoped,
+  type InFlightCall
+} from '../internal/bundle';
+import {
+  CacheStates,
+  GetCurrentStatesForIdentity,
+  MergeUnsubmittedCallTxData,
+  Submit,
+  TypeId
+} from '../internal/transaction';
+import {
+  createMockContractAddress,
+  createMockContractState,
+  createMockFinalizedTxData,
+  createMockProviders,
+  createMockUnprovenCallTxData
+} from './test-mocks';
+
+// ─── Test fixtures ─────────────────────────────────────────────────────────
+
+/**
+ * Builds a `ContractStates`-shaped object whose `contractState` and
+ * `ledgerParameters` are mocks with a usable `serialize()`. The bundler reads
+ * these bytes during {@link MergeUnsubmittedCallTxData}; tests inject a stub
+ * bundler so the bytes never need to deserialize back into real wasm classes.
+ */
+const createCachedStates = (privateState?: unknown) => ({
+  contractState: createMockContractState(),
+  zswapChainState: { tag: 'mock-zswap' } as never,
+  ledgerParameters: LedgerParameters.initialParameters(),
+  ...(privateState !== undefined ? { privateState } : {})
+});
+
+const sampleSentinelTx = (label: string): never =>
+  ({ __sentinelTx: true, label }) as never;
+
+/** A bundler that records the in-flight calls it was invoked with. */
+const recordingStubBundler = (): {
+  bundler: Bundler;
+  invocations: (readonly InFlightCall[])[];
+} => {
+  const invocations: (readonly InFlightCall[])[] = [];
+  return {
+    bundler: ((calls) => {
+      invocations.push(calls);
+      return sampleSentinelTx(`bundle(${calls.length})`);
+    }) as Bundler,
+    invocations
+  };
+};
+
+const installSubmitTxResult = (
+  providers: ReturnType<typeof createMockProviders>,
+  status: 'SucceedEntirely' | 'FailEntirely' = SucceedEntirely
+): void => {
+  const provenTx = { __sentinelTx: true, label: 'proven' } as never;
+  const balancedTx = { __sentinelTx: true, label: 'balanced' } as never;
+  vi.mocked(providers.proofProvider.proveTx).mockResolvedValue(provenTx);
+  vi.mocked(providers.walletProvider.balanceTx).mockResolvedValue(balancedTx);
+  vi.mocked(providers.midnightProvider.submitTx).mockResolvedValue('mock-tx-id');
+  vi.mocked(providers.publicDataProvider.watchForTxData).mockResolvedValue(
+    createMockFinalizedTxData(status)
+  );
+};
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('multi-contract scoped transaction', () => {
+  describe('protocol surface', () => {
+    it('the context is recognised as a TransactionContext by the SDK type guard', async () => {
+      const providers = createMockProviders();
+      installSubmitTxResult(providers);
+      const { bundler } = recordingStubBundler();
+
+      let captured: MultiContractTransactionContext | undefined;
+      // No calls submitted — the scope should reject after fn returns.
+      await expect(
+        bundleScoped(
+          providers,
+          async (ctx) => {
+            captured = ctx;
+          },
+          undefined,
+          { bundler }
+        )
+      ).rejects.toThrow(/No calls were submitted/);
+
+      expect(captured).toBeDefined();
+      expect((captured as unknown as Record<symbol, unknown>)[TypeId]).toBe(TypeId);
+      expect(typeof (captured as unknown as Record<symbol, unknown>)[Submit]).toBe('function');
+      expect(typeof (captured as unknown as Record<symbol, unknown>)[CacheStates]).toBe('function');
+      expect(typeof (captured as unknown as Record<symbol, unknown>)[MergeUnsubmittedCallTxData]).toBe(
+        'function'
+      );
+      expect(typeof (captured as unknown as Record<symbol, unknown>)[GetCurrentStatesForIdentity]).toBe(
+        'function'
+      );
+    });
+
+    it('for(contract) returns the same instance (pure widening)', async () => {
+      const providers = createMockProviders();
+      const { bundler } = recordingStubBundler();
+
+      let captured: MultiContractTransactionContext | undefined;
+      await expect(
+        bundleScoped(
+          providers,
+          async (ctx) => {
+            captured = ctx;
+          },
+          undefined,
+          { bundler }
+        )
+      ).rejects.toThrow();
+
+      // Type-erased FoundContract stand-in is fine — `for` does pure widening.
+      const widened = captured!.for({} as never);
+      expect(widened).toBe(captured);
+    });
+  });
+
+  describe('per-identity state caching', () => {
+    it('caches states per (contractAddress, privateStateId) without identity-mismatch errors', async () => {
+      const providers = createMockProviders();
+      const { bundler } = recordingStubBundler();
+      const senderIdentity = {
+        contractAddress: createMockContractAddress(),
+        privateStateId: 'ps-sender' as PrivateStateId
+      };
+      const recipientIdentity = {
+        contractAddress: createMockContractAddress(),
+        privateStateId: 'ps-recipient' as PrivateStateId
+      };
+      const senderStates = createCachedStates({ who: 'sender' });
+      const recipientStates = createCachedStates({ who: 'recipient' });
+
+      let lookups: unknown[] = [];
+      await expect(
+        bundleScoped(
+          providers,
+          async (ctx) => {
+            const c = ctx as unknown as Record<symbol, (...args: never[]) => unknown>;
+            (c[CacheStates] as (s: unknown, i: unknown) => void)(senderStates, senderIdentity);
+            (c[CacheStates] as (s: unknown, i: unknown) => void)(
+              recipientStates,
+              recipientIdentity
+            );
+            lookups = [
+              (c[GetCurrentStatesForIdentity] as (i: unknown) => unknown)(senderIdentity),
+              (c[GetCurrentStatesForIdentity] as (i: unknown) => unknown)(recipientIdentity)
+            ];
+          },
+          undefined,
+          { bundler }
+        )
+      ).rejects.toThrow();
+
+      expect(lookups[0]).toBe(senderStates);
+      expect(lookups[1]).toBe(recipientStates);
+    });
+
+    it('returns undefined for an unseen identity', async () => {
+      const providers = createMockProviders();
+      const { bundler } = recordingStubBundler();
+      const knownIdentity = {
+        contractAddress: createMockContractAddress(),
+        privateStateId: 'ps-known' as PrivateStateId
+      };
+      const unknownIdentity = {
+        contractAddress: createMockContractAddress(),
+        privateStateId: 'ps-unknown' as PrivateStateId
+      };
+
+      let result: unknown;
+      await expect(
+        bundleScoped(
+          providers,
+          async (ctx) => {
+            const c = ctx as unknown as Record<symbol, (...args: never[]) => unknown>;
+            (c[CacheStates] as (s: unknown, i: unknown) => void)(
+              createCachedStates({}),
+              knownIdentity
+            );
+            result = (c[GetCurrentStatesForIdentity] as (i: unknown) => unknown)(unknownIdentity);
+          },
+          undefined,
+          { bundler }
+        )
+      ).rejects.toThrow();
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('per-call capture and bundling', () => {
+    it('passes the in-flight calls in submission order to the bundler', async () => {
+      const providers = createMockProviders();
+      installSubmitTxResult(providers);
+      const { bundler, invocations } = recordingStubBundler();
+
+      const senderIdentity = {
+        contractAddress: createMockContractAddress(),
+        privateStateId: 'ps-sender' as PrivateStateId
+      };
+      const recipientIdentity = {
+        contractAddress: createMockContractAddress(),
+        privateStateId: 'ps-recipient' as PrivateStateId
+      };
+
+      const result = await bundleScoped(
+        providers,
+        async (ctx) => {
+          const c = ctx as unknown as Record<symbol, (...args: never[]) => unknown>;
+          (c[CacheStates] as (s: unknown, i: unknown) => void)(
+            createCachedStates({ who: 'sender' }),
+            senderIdentity
+          );
+          (c[MergeUnsubmittedCallTxData] as (
+            id: AnyProvableCircuitId,
+            d: unknown,
+            psid?: PrivateStateId
+          ) => void)('send', createMockUnprovenCallTxData(), senderIdentity.privateStateId);
+
+          (c[CacheStates] as (s: unknown, i: unknown) => void)(
+            createCachedStates({ who: 'recipient' }),
+            recipientIdentity
+          );
+          (c[MergeUnsubmittedCallTxData] as (
+            id: AnyProvableCircuitId,
+            d: unknown,
+            psid?: PrivateStateId
+          ) => void)('receive', createMockUnprovenCallTxData(), recipientIdentity.privateStateId);
+        },
+        undefined,
+        { bundler }
+      );
+
+      expect(invocations).toHaveLength(1);
+      const calls = invocations[0]!;
+      expect(calls).toHaveLength(2);
+      expect(calls[0]!.circuitId).toBe('send');
+      expect(calls[1]!.circuitId).toBe('receive');
+      expect(calls[0]!.identity.privateStateId).toBe('ps-sender');
+      expect(calls[1]!.identity.privateStateId).toBe('ps-recipient');
+      expect(result.calls.length).toBe(2);
+      expect(result.public.status).toBe(SucceedEntirely);
+    });
+
+    it('captures contractStateBytes BEFORE the post-call state mutation', async () => {
+      // Establishes the invariant that the bundler's per-call op lookup uses the
+      // pre-call state, not the post-call one. Done by checking that the captured
+      // bytes equal what `serialize()` returned at merge time, even after the
+      // cached entry has been replaced with a post-call state.
+      const providers = createMockProviders();
+      const { bundler, invocations } = recordingStubBundler();
+      const identity = {
+        contractAddress: createMockContractAddress(),
+        privateStateId: 'ps-only' as PrivateStateId
+      };
+
+      const cs = createMockContractState();
+      const preCallBytes = new Uint8Array([1, 2, 3]);
+      const postCallBytes = new Uint8Array([99, 99, 99]);
+      let serializeCalls = 0;
+      vi.mocked(cs.serialize).mockImplementation(() => {
+        serializeCalls += 1;
+        // First call returns the pre-call snapshot; any subsequent call returns
+        // a different value so we can detect a regression that captures late.
+        return serializeCalls === 1 ? preCallBytes : postCallBytes;
+      });
+
+      await expect(
+        bundleScoped(
+          providers,
+          async (ctx) => {
+            const c = ctx as unknown as Record<symbol, (...args: never[]) => unknown>;
+            (c[CacheStates] as (s: unknown, i: unknown) => void)(
+              {
+                contractState: cs,
+                zswapChainState: { tag: 'mock-zswap' } as never,
+                ledgerParameters: LedgerParameters.initialParameters(),
+                privateState: { who: 'sender' }
+              },
+              identity
+            );
+            (c[MergeUnsubmittedCallTxData] as (
+              id: AnyProvableCircuitId,
+              d: unknown,
+              psid?: PrivateStateId
+            ) => void)('send', createMockUnprovenCallTxData(), identity.privateStateId);
+          },
+          undefined,
+          { bundler }
+        )
+      ).rejects.toThrow();
+
+      expect(invocations).toHaveLength(1);
+      const calls = invocations[0]!;
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.contractStateBytes).toBe(preCallBytes);
+    });
+
+    it('threads same-identity in-flight state into the next merge', async () => {
+      // Two calls to the same identity. The second call's cached state should
+      // reflect the first call's nextContractState in its `data` field. We
+      // verify this by capturing the cached state via [GetCurrentStatesForIdentity]
+      // between the two merges.
+      const providers = createMockProviders();
+      const { bundler } = recordingStubBundler();
+      const identity = {
+        contractAddress: createMockContractAddress(),
+        privateStateId: 'ps-only' as PrivateStateId
+      };
+
+      const initialCallData = createMockUnprovenCallTxData({
+        private: { nextPrivateState: { generation: 1 } } as never
+      });
+      const secondCallData = createMockUnprovenCallTxData({
+        private: { nextPrivateState: { generation: 2 } } as never
+      });
+
+      let stateAfterFirst: unknown;
+      await expect(
+        bundleScoped(
+          providers,
+          async (ctx) => {
+            const c = ctx as unknown as Record<symbol, (...args: never[]) => unknown>;
+            (c[CacheStates] as (s: unknown, i: unknown) => void)(
+              createCachedStates({ generation: 0 }),
+              identity
+            );
+            (c[MergeUnsubmittedCallTxData] as (
+              id: AnyProvableCircuitId,
+              d: unknown,
+              psid?: PrivateStateId
+            ) => void)('first', initialCallData, identity.privateStateId);
+            stateAfterFirst = (c[GetCurrentStatesForIdentity] as (i: unknown) => unknown)(
+              identity
+            );
+            (c[MergeUnsubmittedCallTxData] as (
+              id: AnyProvableCircuitId,
+              d: unknown,
+              psid?: PrivateStateId
+            ) => void)('second', secondCallData, identity.privateStateId);
+          },
+          undefined,
+          { bundler }
+        )
+      ).rejects.toThrow();
+
+      expect(stateAfterFirst).toBeDefined();
+      expect((stateAfterFirst as { privateState: { generation: number } }).privateState).toEqual({
+        generation: 1
+      });
+    });
+  });
+
+  describe('private-state persistence', () => {
+    it('writes the latest nextPrivateState per privateStateId on success', async () => {
+      const providers = createMockProviders();
+      installSubmitTxResult(providers);
+      const { bundler } = recordingStubBundler();
+      const senderIdentity = {
+        contractAddress: createMockContractAddress(),
+        privateStateId: 'ps-sender' as PrivateStateId
+      };
+      const recipientIdentity = {
+        contractAddress: createMockContractAddress(),
+        privateStateId: 'ps-recipient' as PrivateStateId
+      };
+
+      await bundleScoped(
+        providers,
+        async (ctx) => {
+          const c = ctx as unknown as Record<symbol, (...args: never[]) => unknown>;
+
+          (c[CacheStates] as (s: unknown, i: unknown) => void)(
+            createCachedStates({ generation: 0 }),
+            senderIdentity
+          );
+          (c[MergeUnsubmittedCallTxData] as (
+            id: AnyProvableCircuitId,
+            d: unknown,
+            psid?: PrivateStateId
+          ) => void)(
+            'send',
+            createMockUnprovenCallTxData({
+              private: { nextPrivateState: { who: 'sender', generation: 1 } } as never
+            }),
+            senderIdentity.privateStateId
+          );
+
+          (c[CacheStates] as (s: unknown, i: unknown) => void)(
+            createCachedStates({ generation: 0 }),
+            recipientIdentity
+          );
+          (c[MergeUnsubmittedCallTxData] as (
+            id: AnyProvableCircuitId,
+            d: unknown,
+            psid?: PrivateStateId
+          ) => void)(
+            'receive',
+            createMockUnprovenCallTxData({
+              private: { nextPrivateState: { who: 'recipient', generation: 1 } } as never
+            }),
+            recipientIdentity.privateStateId
+          );
+
+          // Second sender call: latest update should win.
+          (c[MergeUnsubmittedCallTxData] as (
+            id: AnyProvableCircuitId,
+            d: unknown,
+            psid?: PrivateStateId
+          ) => void)(
+            'deposit',
+            createMockUnprovenCallTxData({
+              private: { nextPrivateState: { who: 'sender', generation: 2 } } as never
+            }),
+            senderIdentity.privateStateId
+          );
+        },
+        undefined,
+        { bundler }
+      );
+
+      const setMock = vi.mocked(providers.privateStateProvider.set);
+      expect(setMock).toHaveBeenCalledTimes(2);
+      const writes = setMock.mock.calls.map(([id, value]) => ({ id, value }));
+      const senderWrite = writes.find((w) => w.id === 'ps-sender');
+      const recipientWrite = writes.find((w) => w.id === 'ps-recipient');
+      expect(senderWrite?.value).toEqual({ who: 'sender', generation: 2 });
+      expect(recipientWrite?.value).toEqual({ who: 'recipient', generation: 1 });
+    });
+
+    it('writes nothing if no in-flight call referenced a privateStateId', async () => {
+      // A purely-public-state contract. Since no privateStateId is in play, the
+      // private-state persistence loop should be a no-op and we don't require a
+      // privateStateProvider to be wired up.
+      const providers = createMockProviders();
+      installSubmitTxResult(providers);
+      const { bundler } = recordingStubBundler();
+      const identity = { contractAddress: createMockContractAddress() };
+
+      await bundleScoped(
+        providers,
+        async (ctx) => {
+          const c = ctx as unknown as Record<symbol, (...args: never[]) => unknown>;
+          (c[CacheStates] as (s: unknown, i: unknown) => void)(createCachedStates(), identity);
+          (c[MergeUnsubmittedCallTxData] as (
+            id: AnyProvableCircuitId,
+            d: unknown,
+            psid?: PrivateStateId
+          ) => void)('public-call', createMockUnprovenCallTxData(), undefined);
+        },
+        undefined,
+        { bundler }
+      );
+
+      expect(vi.mocked(providers.privateStateProvider.set)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error paths', () => {
+    it('rejects with "No calls were submitted" when fn issues no merges', async () => {
+      const providers = createMockProviders();
+      installSubmitTxResult(providers);
+      const { bundler } = recordingStubBundler();
+
+      await expect(
+        bundleScoped(
+          providers,
+          async () => {
+            // intentionally empty
+          },
+          { scopeName: 'empty-scope' },
+          { bundler }
+        )
+      ).rejects.toThrow(/No calls were submitted/);
+    });
+
+    it('wraps unexpected errors in fn with the scopeName', async () => {
+      const providers = createMockProviders();
+      const { bundler } = recordingStubBundler();
+
+      await expect(
+        bundleScoped(
+          providers,
+          async () => {
+            throw new Error('circuit blew up');
+          },
+          { scopeName: 'myTransfer' },
+          { bundler }
+        )
+      ).rejects.toThrow(/myTransfer.*circuit blew up/s);
+    });
+
+    it('shows <unnamed> when no scopeName is provided', async () => {
+      const providers = createMockProviders();
+      const { bundler } = recordingStubBundler();
+
+      await expect(
+        bundleScoped(
+          providers,
+          async () => {
+            throw new Error('circuit blew up');
+          },
+          undefined,
+          { bundler }
+        )
+      ).rejects.toThrow(/<unnamed>/);
+    });
+
+    it('throws CallTxFailedError when the bundled tx does not succeed entirely', async () => {
+      const providers = createMockProviders();
+      installSubmitTxResult(providers, FailEntirely);
+      const { bundler } = recordingStubBundler();
+      const identity = {
+        contractAddress: createMockContractAddress(),
+        privateStateId: 'ps-x' as PrivateStateId
+      };
+
+      let caught: unknown;
+      try {
+        await bundleScoped(
+          providers,
+          async (ctx) => {
+            const c = ctx as unknown as Record<symbol, (...args: never[]) => unknown>;
+            (c[CacheStates] as (s: unknown, i: unknown) => void)(
+              createCachedStates({}),
+              identity
+            );
+            (c[MergeUnsubmittedCallTxData] as (
+              id: AnyProvableCircuitId,
+              d: unknown,
+              psid?: PrivateStateId
+            ) => void)('c', createMockUnprovenCallTxData(), identity.privateStateId);
+          },
+          undefined,
+          { bundler }
+        );
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(CallTxFailedError);
+      const err = caught as CallTxFailedError;
+      expect(err.finalizedTxData.status).toBe(FailEntirely);
+      expect(err.circuitId).toEqual(['c']);
+      expect(vi.mocked(providers.privateStateProvider.set)).not.toHaveBeenCalled();
+    });
+
+    it('throws when a call referenced a privateStateId but providers.privateStateProvider is undefined', async () => {
+      const providers = createMockProviders();
+      installSubmitTxResult(providers);
+      // Simulate a providers tree without a private-state provider.
+      (providers as { privateStateProvider?: unknown }).privateStateProvider = undefined;
+      const { bundler } = recordingStubBundler();
+      const identity = {
+        contractAddress: createMockContractAddress(),
+        privateStateId: 'ps-x' as PrivateStateId
+      };
+
+      await expect(
+        bundleScoped(
+          providers,
+          async (ctx) => {
+            const c = ctx as unknown as Record<symbol, (...args: never[]) => unknown>;
+            (c[CacheStates] as (s: unknown, i: unknown) => void)(
+              createCachedStates({}),
+              identity
+            );
+            (c[MergeUnsubmittedCallTxData] as (
+              id: AnyProvableCircuitId,
+              d: unknown,
+              psid?: PrivateStateId
+            ) => void)('c', createMockUnprovenCallTxData(), identity.privateStateId);
+          },
+          undefined,
+          { bundler }
+        )
+      ).rejects.toThrow(/privateStateProvider is undefined/);
+    });
+
+    it('throws when MergeUnsubmittedCallTxData is invoked without a prior CacheStates', async () => {
+      const providers = createMockProviders();
+      const { bundler } = recordingStubBundler();
+      const identity = {
+        contractAddress: createMockContractAddress(),
+        privateStateId: 'ps-x' as PrivateStateId
+      };
+
+      await expect(
+        bundleScoped(
+          providers,
+          async (ctx) => {
+            const c = ctx as unknown as Record<symbol, (...args: never[]) => unknown>;
+            // Skip CacheStates — this violates the SDK protocol.
+            (c[MergeUnsubmittedCallTxData] as (
+              id: AnyProvableCircuitId,
+              d: unknown,
+              psid?: PrivateStateId
+            ) => void)('c', createMockUnprovenCallTxData(), identity.privateStateId);
+          },
+          undefined,
+          { bundler }
+        )
+      ).rejects.toThrow();
+    });
+
+    it('rejects with the wrapped scopeName when bundling itself throws', async () => {
+      const providers = createMockProviders();
+      installSubmitTxResult(providers);
+      const explosiveBundler: Bundler = () => {
+        throw new Error('bundler blew up');
+      };
+      const identity = {
+        contractAddress: createMockContractAddress(),
+        privateStateId: 'ps-x' as PrivateStateId
+      };
+
+      await expect(
+        bundleScoped(
+          providers,
+          async (ctx) => {
+            const c = ctx as unknown as Record<symbol, (...args: never[]) => unknown>;
+            (c[CacheStates] as (s: unknown, i: unknown) => void)(
+              createCachedStates({}),
+              identity
+            );
+            (c[MergeUnsubmittedCallTxData] as (
+              id: AnyProvableCircuitId,
+              d: unknown,
+              psid?: PrivateStateId
+            ) => void)('c', createMockUnprovenCallTxData(), identity.privateStateId);
+          },
+          { scopeName: 'split-test' },
+          { bundler: explosiveBundler }
+        )
+      ).rejects.toThrow(/split-test.*bundler blew up/s);
+    });
+  });
+
+  describe('public entry point', () => {
+    it('withMultiContractScopedTransaction routes through the default bundler', async () => {
+      // The public function does not expose the test seam — assert that submission
+      // pipeline invariants still hold even with no internalOptions provided.
+      const providers = createMockProviders();
+      installSubmitTxResult(providers);
+
+      // No calls — should error out before reaching the default bundler, exercising
+      // only the public surface signature.
+      await expect(
+        withMultiContractScopedTransaction(providers, async () => {
+          // empty
+        })
+      ).rejects.toThrow(/No calls were submitted/);
+    });
+  });
+});


### PR DESCRIPTION
Adds `withMultiContractScopedTransaction` for batching circuit calls to different contracts into a single ledger intent. Same shape as `withContractScopedTransaction`, but the scope is contract-polymorphic — `ctx.for(contract)` widens the type at each call site.

Cross-contract unshielded flows (A.send / B.receive) only validate when both calls share an intent segment and guaranteed/fallible half. The ledger's effects check (`verify.rs:1599-1651`) matches `claimed_unshielded_spends` against `unshielded_inputs` keyed on `(intent_seg, is_guaranteed_half, token_type, recipient, value). merge()` splices independently-partitioned intents, so alignment is on us; `Transaction.addCalls` jointly partitions, so it's on the ledger. We want the latter.