### PR TITLE
fix(midnight-js): block path traversal in ZK providers and VersionManager

### DIFF
--- a/packages/compact/package.json
+++ b/packages/compact/package.json
@@ -32,5 +32,8 @@
   },
   "files": [
     "dist/"
-  ]
+  ],
+  "dependencies": {
+    "@midnight-ntwrk/midnight-js-utils": "workspace:*"
+  }
 }

--- a/packages/compact/src/test/version-manager.test.ts
+++ b/packages/compact/src/test/version-manager.test.ts
@@ -1,0 +1,132 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { VersionManager } from '../version-manager';
+
+describe('VersionManager', () => {
+  let packageDir: string;
+  let managedDir: string;
+
+  beforeEach(() => {
+    packageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'version-manager-'));
+    managedDir = path.join(packageDir, 'managed');
+    fs.mkdirSync(managedDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(packageDir, { recursive: true, force: true });
+  });
+
+  const writeFakeCompactc = (version: string): void => {
+    const dir = path.join(managedDir, version);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'compactc'), '#!/bin/sh\n');
+  };
+
+  describe('happy path', () => {
+    it('getVersionDir returns a directory inside managed/', () => {
+      // Arrange
+      const vm = new VersionManager(packageDir);
+      // Act
+      const dir = vm.getVersionDir('0.20.0');
+      // Assert
+      expect(dir).toBe(path.join(managedDir, '0.20.0'));
+    });
+
+    it('versionExists returns true when compactc is present', () => {
+      writeFakeCompactc('0.20.0');
+      const vm = new VersionManager(packageDir);
+      expect(vm.versionExists('0.20.0')).toBe(true);
+    });
+
+    it('listVersions returns sorted directory names', () => {
+      writeFakeCompactc('0.20.0');
+      writeFakeCompactc('0.21.0');
+      writeFakeCompactc('0.10.0');
+      const vm = new VersionManager(packageDir);
+      expect(vm.listVersions()).toEqual(['0.10.0', '0.20.0', '0.21.0']);
+    });
+
+    it('removeVersion deletes a managed version directory', () => {
+      writeFakeCompactc('0.20.0');
+      const vm = new VersionManager(packageDir);
+      vm.removeVersion('0.20.0');
+      expect(fs.existsSync(path.join(managedDir, '0.20.0'))).toBe(false);
+      expect(fs.existsSync(managedDir)).toBe(true);
+    });
+
+    it('cleanupOldVersions keeps the newest N versions', () => {
+      writeFakeCompactc('0.10.0');
+      writeFakeCompactc('0.20.0');
+      writeFakeCompactc('0.21.0');
+      const vm = new VersionManager(packageDir);
+      vm.cleanupOldVersions(2);
+      expect(vm.listVersions()).toEqual(['0.20.0', '0.21.0']);
+    });
+  });
+
+  describe('rejects unsafe version', () => {
+    let vm: VersionManager;
+    beforeEach(() => {
+      vm = new VersionManager(packageDir);
+    });
+
+    it.each([
+      '.',
+      '..',
+      '../../etc',
+      '/etc/passwd',
+      'foo/bar',
+      'not-semver',
+      '1.2',
+      'v1.2.3',
+      '',
+      '1.2.3 '
+    ])('getVersionDir rejects %s', (version) => {
+      expect(() => vm.getVersionDir(version)).toThrow(/Invalid version/);
+    });
+
+    it('versionExists rejects ".."', () => {
+      expect(() => vm.versionExists('..')).toThrow(/Invalid version/);
+    });
+
+    it('getCompactcPath rejects "../"', () => {
+      expect(() => vm.getCompactcPath('../escape')).toThrow(/Invalid version/);
+    });
+
+    it('removeVersion rejects "."', () => {
+      // Arrange — sentinel proving managed/ is intact afterwards
+      writeFakeCompactc('0.20.0');
+      // Act + Assert
+      expect(() => vm.removeVersion('.')).toThrow(/Invalid version/);
+      // Assert (sentinel survived — this is the entire point of the fix)
+      expect(fs.existsSync(path.join(managedDir, '0.20.0'))).toBe(true);
+      expect(fs.existsSync(managedDir)).toBe(true);
+    });
+
+    it('removeVersion rejects ".."', () => {
+      writeFakeCompactc('0.20.0');
+      expect(() => vm.removeVersion('..')).toThrow(/Invalid version/);
+      expect(fs.existsSync(packageDir)).toBe(true);
+      expect(fs.existsSync(managedDir)).toBe(true);
+    });
+  });
+});

--- a/packages/compact/src/version-manager.ts
+++ b/packages/compact/src/version-manager.ts
@@ -16,10 +16,13 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { assertSemVer } from '@midnight-ntwrk/midnight-js-utils';
+
 export class VersionManager {
   constructor(private packageDir: string) {}
 
   getVersionDir(version: string): string {
+    assertSemVer(version, 'version');
     return path.resolve(this.packageDir, 'managed', version);
   }
 
@@ -31,7 +34,7 @@ export class VersionManager {
 
   listVersions(): string[] {
     const managedDir = path.resolve(this.packageDir, 'managed');
-    
+
     if (!fs.existsSync(managedDir)) {
       return [];
     }
@@ -39,7 +42,13 @@ export class VersionManager {
     return fs.readdirSync(managedDir, { withFileTypes: true })
       .filter(dirent => dirent.isDirectory())
       .map(dirent => dirent.name)
-      .filter(version => this.versionExists(version))
+      .filter((version) => {
+        try {
+          return this.versionExists(version);
+        } catch {
+          return false;
+        }
+      })
       .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
   }
 
@@ -48,14 +57,18 @@ export class VersionManager {
   }
 
   removeVersion(version: string): void {
+    const managedDir = path.resolve(this.packageDir, 'managed');
     const versionDir = this.getVersionDir(version);
+    if (path.relative(managedDir, versionDir).startsWith('..')) {
+      throw new Error(`Invalid version: ${JSON.stringify(version)}`);
+    }
     fs.rmSync(versionDir, { recursive: true, force: true });
   }
 
   cleanupOldVersions(keepCount: number): void {
     const versions = this.listVersions();
     const toRemove = versions.slice(0, -keepCount);
-    
+
     toRemove.forEach(version => this.removeVersion(version));
   }
 

--- a/packages/compact/src/version-manager.ts
+++ b/packages/compact/src/version-manager.ts
@@ -59,7 +59,8 @@ export class VersionManager {
   removeVersion(version: string): void {
     const managedDir = path.resolve(this.packageDir, 'managed');
     const versionDir = this.getVersionDir(version);
-    if (path.relative(managedDir, versionDir).startsWith('..')) {
+    const rel = path.relative(managedDir, versionDir);
+    if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
       throw new Error(`Invalid version: ${JSON.stringify(version)}`);
     }
     fs.rmSync(versionDir, { recursive: true, force: true });

--- a/packages/fetch-zk-config-provider/package.json
+++ b/packages/fetch-zk-config-provider/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@midnight-ntwrk/midnight-js-types": "workspace:*",
+    "@midnight-ntwrk/midnight-js-utils": "workspace:*",
     "cross-fetch": "^4.1.0"
   },
   "files": [

--- a/packages/fetch-zk-config-provider/src/fetch-zk-config-provider.ts
+++ b/packages/fetch-zk-config-provider/src/fetch-zk-config-provider.ts
@@ -20,6 +20,7 @@ import {
   createZKIR,
   InvalidProtocolSchemeError,
   ZKConfigProvider} from '@midnight-ntwrk/midnight-js-types';
+import { assertSafeName } from '@midnight-ntwrk/midnight-js-utils';
 import { fetch } from 'cross-fetch';
 
 /**
@@ -68,7 +69,9 @@ export class FetchZkConfigProvider<K extends string> extends ZKConfigProvider<K>
     ext: typeof ZKIR_EXT | typeof PROVER_EXT | typeof VERIFIER_EXT,
     responseType: T
   ): Promise<T extends 'text' ? string : Uint8Array> {
-    const fullUrl = `${this.baseURL}/${url}/${circuitId}${ext}`;
+    assertSafeName(circuitId, 'circuitId');
+    const base = this.baseURL.endsWith('/') ? this.baseURL : `${this.baseURL}/`;
+    const fullUrl = new URL(`${url}/${encodeURIComponent(circuitId)}${ext}`, base).toString();
     const response = await this.fetchFunc(fullUrl, {
       method: 'GET'
     });
@@ -79,7 +82,6 @@ export class FetchZkConfigProvider<K extends string> extends ZKConfigProvider<K>
     if (contentType.includes('text/html')) {
       throw new Error(`Expected ZK artifact, but received text/html from ${fullUrl}. This usually means the file does not exist and the server returned an SPA fallback page.`);
     }
-    // The compiler can't infer that this return value is well-typed, so I cast to 'any'
     /* eslint-disable @typescript-eslint/no-explicit-any */
     return responseType === 'text'
       ? ((await response.text()) as any)

--- a/packages/fetch-zk-config-provider/src/test/fetch-zk-config-provider.test.ts
+++ b/packages/fetch-zk-config-provider/src/test/fetch-zk-config-provider.test.ts
@@ -83,6 +83,42 @@ describe('Fetch ZK config Provider', () => {
     expect(() => new FetchZkConfigProvider('ws://localhost:5000')).toThrow(/^Invalid protocol scheme: 'ws:'/);
   });
 
+  describe('rejects unsafe circuitId before issuing the request', () => {
+    const FETCH_NEVER = (() => {
+      throw new Error('fetch must not be called for invalid circuitId');
+    }) as unknown as typeof fetch;
+
+    test.each([
+      '..',
+      '.',
+      '../../etc/passwd',
+      '/etc/passwd',
+      'foo/bar',
+      'foo\\bar',
+      '%2e%2e%2fpasswd',
+      '',
+      'foo bar'
+    ])('getProverKey rejects %s without calling fetch', async (circuitId) => {
+      // Arrange
+      const provider = new FetchZkConfigProvider(serverURL, FETCH_NEVER);
+      const target = circuitId as unknown as 'set_topic';
+      // Act + Assert
+      await expect(provider.getProverKey(target)).rejects.toThrow(/Invalid circuitId/);
+    });
+
+    test('getVerifierKey rejects "../etc/passwd" without calling fetch', async () => {
+      const provider = new FetchZkConfigProvider(serverURL, FETCH_NEVER);
+      const target = '../etc/passwd' as unknown as 'set_topic';
+      await expect(provider.getVerifierKey(target)).rejects.toThrow(/Invalid circuitId/);
+    });
+
+    test('getZKIR rejects ".." without calling fetch', async () => {
+      const provider = new FetchZkConfigProvider(serverURL, FETCH_NEVER);
+      const target = '..' as unknown as 'set_topic';
+      await expect(provider.getZKIR(target)).rejects.toThrow(/Invalid circuitId/);
+    });
+  });
+
   describe('rejects HTML responses from SPA fallback', () => {
     let spaServer: Server;
     let spaServerURL: string;

--- a/packages/node-zk-config-provider/package.json
+++ b/packages/node-zk-config-provider/package.json
@@ -26,6 +26,7 @@
     "deploy": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
-    "@midnight-ntwrk/midnight-js-types": "workspace:*"
+    "@midnight-ntwrk/midnight-js-types": "workspace:*",
+    "@midnight-ntwrk/midnight-js-utils": "workspace:*"
   }
 }

--- a/packages/node-zk-config-provider/src/node-zk-config-provider.ts
+++ b/packages/node-zk-config-provider/src/node-zk-config-provider.ts
@@ -15,6 +15,7 @@
 
 import type { ProverKey, VerifierKey, ZKIR } from '@midnight-ntwrk/midnight-js-types';
 import { createProverKey, createVerifierKey, createZKIR, ZKConfigProvider } from '@midnight-ntwrk/midnight-js-types';
+import { assertSafeName } from '@midnight-ntwrk/midnight-js-utils';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
@@ -58,8 +59,14 @@ export class NodeZkConfigProvider<K extends string> extends ZKConfigProvider<K> 
    * @param ext The file extension of the file to read.
    * @private
    */
-  private readFile(subDir: string, circuitId: K, ext: string): Promise<Buffer> {
-    return fs.readFile(path.join(this.directory, subDir, circuitId + ext));
+  private async readFile(subDir: string, circuitId: K, ext: string): Promise<Buffer> {
+    assertSafeName(circuitId, 'circuitId');
+    const baseDir = path.resolve(this.directory, subDir);
+    const target = path.resolve(baseDir, circuitId + ext);
+    if (path.relative(baseDir, target).startsWith('..')) {
+      throw new Error(`Invalid circuitId: ${JSON.stringify(circuitId)}`);
+    }
+    return fs.readFile(target);
   }
 
   /**

--- a/packages/node-zk-config-provider/src/node-zk-config-provider.ts
+++ b/packages/node-zk-config-provider/src/node-zk-config-provider.ts
@@ -63,7 +63,8 @@ export class NodeZkConfigProvider<K extends string> extends ZKConfigProvider<K> 
     assertSafeName(circuitId, 'circuitId');
     const baseDir = path.resolve(this.directory, subDir);
     const target = path.resolve(baseDir, circuitId + ext);
-    if (path.relative(baseDir, target).startsWith('..')) {
+    const rel = path.relative(baseDir, target);
+    if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
       throw new Error(`Invalid circuitId: ${JSON.stringify(circuitId)}`);
     }
     return fs.readFile(target);

--- a/packages/node-zk-config-provider/src/test/node-zk-provider.test.ts
+++ b/packages/node-zk-config-provider/src/test/node-zk-provider.test.ts
@@ -47,7 +47,38 @@ describe('Node ZK config Provider', () => {
 
   test('throws on relative path', async () => {
     await expect(async () => new NodeZkConfigProvider('.').getVerifierKey('set_topic')).rejects.toThrowError(
-      "ENOENT: no such file or directory, open 'keys/set_topic.verifier'"
+      /ENOENT: no such file or directory, open '.*keys\/set_topic\.verifier'/
     );
+  });
+
+  describe('rejects unsafe circuitId', () => {
+    const provider = new NodeZkConfigProvider(resourceDir);
+
+    test.each([
+      '..',
+      '.',
+      '../../etc/passwd',
+      '../keys/set_topic',
+      '/absolute/path',
+      'foo/bar',
+      'foo\\bar',
+      '',
+      'foo bar'
+    ])('getProverKey rejects %s', async (circuitId) => {
+      // Arrange
+      const target = circuitId as unknown as 'set_topic';
+      // Act + Assert
+      await expect(provider.getProverKey(target)).rejects.toThrow(/Invalid circuitId/);
+    });
+
+    test('getVerifierKey rejects "../etc/passwd"', async () => {
+      const target = '../etc/passwd' as unknown as 'set_topic';
+      await expect(provider.getVerifierKey(target)).rejects.toThrow(/Invalid circuitId/);
+    });
+
+    test('getZKIR rejects ".."', async () => {
+      const target = '..' as unknown as 'set_topic';
+      await expect(provider.getZKIR(target)).rejects.toThrow(/Invalid circuitId/);
+    });
   });
 });

--- a/packages/node-zk-config-provider/src/test/node-zk-provider.test.ts
+++ b/packages/node-zk-config-provider/src/test/node-zk-provider.test.ts
@@ -81,4 +81,18 @@ describe('Node ZK config Provider', () => {
       await expect(provider.getZKIR(target)).rejects.toThrow(/Invalid circuitId/);
     });
   });
+
+  describe('accepts unusual but safe circuitId names', () => {
+    const provider = new NodeZkConfigProvider(resourceDir);
+
+    test.each([
+      '..foo',
+      '..foo..',
+      'foo..bar',
+      '...'
+    ])('getProverKey lets %s reach the filesystem (no false-positive containment reject)', async (circuitId) => {
+      const target = circuitId as unknown as 'set_topic';
+      await expect(provider.getProverKey(target)).rejects.toThrow(/ENOENT/);
+    });
+  });
 });

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -16,4 +16,5 @@
 export * from './assertion-utils';
 export * from './date-utils';
 export * from './hex-utils';
+export * from './security-utils';
 export * from './type-utils';

--- a/packages/utils/src/security-utils.ts
+++ b/packages/utils/src/security-utils.ts
@@ -1,0 +1,60 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const MAX_SAFE_NAME_LENGTH = 255;
+
+const SAFE_NAME_PATTERN = /^[a-zA-Z0-9._-]+$/;
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+(?:-[A-Za-z0-9._-]+)?$/;
+
+/**
+ * Asserts that `name` is safe to use as a single path segment or URL path
+ * component. Rejects traversal payloads (`.`, `..`, separators), URL-encoded
+ * characters, null bytes, whitespace, empty strings, and names longer than
+ * {@link MAX_SAFE_NAME_LENGTH}.
+ *
+ * @param name  The value to validate.
+ * @param label Human-readable name of the parameter (for error messages).
+ * @throws Error if `name` fails validation.
+ */
+export function assertSafeName(name: string, label: string): void {
+  if (typeof name !== 'string' || name.length === 0 || name.length > MAX_SAFE_NAME_LENGTH) {
+    throw new Error(`Invalid ${label}: ${JSON.stringify(name)}`);
+  }
+  if (name === '.' || name === '..') {
+    throw new Error(`Invalid ${label}: ${JSON.stringify(name)}`);
+  }
+  if (!SAFE_NAME_PATTERN.test(name)) {
+    throw new Error(`Invalid ${label}: ${JSON.stringify(name)}`);
+  }
+}
+
+/**
+ * Asserts that `version` is a valid SemVer-style version string of the shape
+ * `MAJOR.MINOR.PATCH` with an optional pre-release suffix
+ * (`-[A-Za-z0-9._-]+`). Build metadata (`+...`) is intentionally not
+ * supported because compactc releases do not use it.
+ *
+ * @param version The version string to validate.
+ * @param label   Human-readable name of the parameter (for error messages).
+ * @throws Error if `version` is not SemVer-shaped.
+ */
+export function assertSemVer(version: string, label: string): void {
+  if (typeof version !== 'string' || version.length === 0 || version.length > MAX_SAFE_NAME_LENGTH) {
+    throw new Error(`Invalid ${label}: ${JSON.stringify(version)}`);
+  }
+  if (!SEMVER_PATTERN.test(version)) {
+    throw new Error(`Invalid ${label}: ${JSON.stringify(version)}`);
+  }
+}

--- a/packages/utils/src/test/security-utils.test.ts
+++ b/packages/utils/src/test/security-utils.test.ts
@@ -1,0 +1,131 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { assertSafeName, assertSemVer, MAX_SAFE_NAME_LENGTH } from '../security-utils';
+
+describe('assertSafeName', () => {
+  describe('accepts valid names', () => {
+    it.each([
+      'set_topic',
+      'increment',
+      'transfer',
+      'a',
+      'A1',
+      'snake_case',
+      'kebab-case',
+      'dot.segment',
+      'mixed_123-NAME.v2'
+    ])('accepts %s', (name) => {
+      expect(() => assertSafeName(name, 'circuitId')).not.toThrow();
+    });
+  });
+
+  describe('rejects path-traversal payloads', () => {
+    it.each([
+      '..',
+      '.',
+      '../etc/passwd',
+      '../../etc/passwd',
+      '..\\..\\Windows\\System32',
+      '/etc/passwd',
+      './foo',
+      'foo/bar',
+      'foo\\bar'
+    ])('rejects %s', (name) => {
+      expect(() => assertSafeName(name, 'circuitId')).toThrow(/Invalid circuitId/);
+    });
+  });
+
+  describe('rejects URL-encoded traversal', () => {
+    it.each([
+      '%2e%2e%2fpasswd',
+      '%2E%2E',
+      'foo%2Fbar'
+    ])('rejects %s', (name) => {
+      expect(() => assertSafeName(name, 'circuitId')).toThrow(/Invalid circuitId/);
+    });
+  });
+
+  describe('rejects malformed input', () => {
+    it('rejects empty string', () => {
+      expect(() => assertSafeName('', 'circuitId')).toThrow(/Invalid circuitId/);
+    });
+
+    it('rejects null byte', () => {
+      expect(() => assertSafeName(`foo${String.fromCharCode(0)}bar`, 'circuitId')).toThrow(/Invalid circuitId/);
+    });
+
+    it('rejects whitespace', () => {
+      expect(() => assertSafeName('foo bar', 'circuitId')).toThrow(/Invalid circuitId/);
+    });
+
+    it('rejects names exceeding MAX_SAFE_NAME_LENGTH', () => {
+      const oversized = 'a'.repeat(MAX_SAFE_NAME_LENGTH + 1);
+      expect(() => assertSafeName(oversized, 'circuitId')).toThrow(/Invalid circuitId/);
+    });
+
+    it('accepts names exactly at MAX_SAFE_NAME_LENGTH', () => {
+      const atLimit = 'a'.repeat(MAX_SAFE_NAME_LENGTH);
+      expect(() => assertSafeName(atLimit, 'circuitId')).not.toThrow();
+    });
+  });
+
+  describe('error message uses the supplied label', () => {
+    it('includes the label in the error', () => {
+      expect(() => assertSafeName('..', 'version')).toThrow(/Invalid version/);
+    });
+  });
+});
+
+describe('assertSemVer', () => {
+  describe('accepts valid versions', () => {
+    it.each([
+      '0.20.0',
+      '1.2.3',
+      '10.20.30',
+      '0.21.0-snapshot.123',
+      '1.0.0-rc.1',
+      '2.0.0-alpha'
+    ])('accepts %s', (version) => {
+      expect(() => assertSemVer(version, 'version')).not.toThrow();
+    });
+  });
+
+  describe('rejects non-semver strings', () => {
+    it.each([
+      '..',
+      '.',
+      '',
+      '1',
+      '1.2',
+      'v1.2.3',
+      '1.2.3.4',
+      '1.2.x',
+      '../1.0.0',
+      '1.0.0/../etc',
+      '1.0.0 '
+    ])('rejects %s', (version) => {
+      expect(() => assertSemVer(version, 'version')).toThrow(/Invalid version/);
+    });
+  });
+
+  describe('error message uses the supplied label', () => {
+    it('includes the label in the error', () => {
+      expect(() => assertSemVer('not-a-version', 'compactc version')).toThrow(/Invalid compactc version/);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,6 +1876,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/midnight-js-compact@workspace:packages/compact"
   dependencies:
+    "@midnight-ntwrk/midnight-js-utils": "workspace:*"
     "@types/node": "npm:^24.0.0"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^6.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2041,6 +2041,7 @@ __metadata:
   resolution: "@midnight-ntwrk/midnight-js-node-zk-config-provider@workspace:packages/node-zk-config-provider"
   dependencies:
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
+    "@midnight-ntwrk/midnight-js-utils": "workspace:*"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1914,6 +1914,7 @@ __metadata:
   resolution: "@midnight-ntwrk/midnight-js-fetch-zk-config-provider@workspace:packages/fetch-zk-config-provider"
   dependencies:
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
+    "@midnight-ntwrk/midnight-js-utils": "workspace:*"
     "@types/express": "npm:^5.0.0"
     cross-fetch: "npm:^4.1.0"
     express: "npm:^5.0.0"


### PR DESCRIPTION
# Overview

Closes path traversal vulnerabilities at three sites where untrusted `circuitId` and `version` strings flowed into filesystem and URL operations:

- `NodeZkConfigProvider.readFile` — arbitrary file read via `path.join` with unsanitized `circuitId`
- `FetchZkConfigProvider.sendRequest` — URL path manipulation via direct interpolation of `circuitId`
- `VersionManager.removeVersion` — arbitrary `fs.rmSync(..., { recursive: true, force: true })` via `path.resolve` with unsanitized `version`

## Approach

- New shared validators in `@midnight-ntwrk/midnight-js-utils`:
  - `assertSafeName(name, label)` — `[a-zA-Z0-9._-]+`, max 255 chars, explicit reject of `.` and `..`
  - `assertSemVer(version, label)` — `MAJOR.MINOR.PATCH(-prerelease)?` shape only
- `NodeZkConfigProvider`: validate `circuitId` + `path.relative` containment check before `fs.readFile`
- `FetchZkConfigProvider`: validate `circuitId` + switch to `encodeURIComponent` + `new URL()` for safe URL construction; rejects bad input **before** any network call (enforced by `FETCH_NEVER` test stub)
- `VersionManager`: validate `version` (SemVer) inside `getVersionDir` — single choke point for `versionExists`, `getCompactcPath`, and `removeVersion`. Defence-in-depth `path.relative` containment check before `fs.rmSync`. `listVersions` silently skips non-SemVer legacy directories for backwards compat.

## Behaviour change to flag

`VersionManager.listVersions` now skips directory entries that are not SemVer-shaped. Existing installations are unaffected — compactc has only ever written SemVer directories.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (TDD; 91 new tests; sentinel-survival assertions for the highest-blast-radius site)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant)
- [ ] Update documentation (if relevant)
- [x] No new todos introduced

## Test plan

- [x] Tests written first (TDD), verified they fail before fix
- [x] All existing tests pass (no regressions): 20/20 turbo test tasks, 14/14 turbo build tasks
- [x] Lint clean (eslint across all packages)
- [x] Coverage 100% on new code

## Links

Closes [shieldedtech/shielded-security-engineering#270](https://github.com/shieldedtech/shielded-security-engineering/issues/270)