### PR TITLE
fix(midnight-js): fail closed in decryptValue on unrecognized data

### DIFF
--- a/packages/level-private-state-provider/src/storage-encryption.ts
+++ b/packages/level-private-state-provider/src/storage-encryption.ts
@@ -188,14 +188,10 @@ export class StorageEncryption {
   }
 
   static isEncrypted(data: string): boolean {
-    try {
-      const buffer = Buffer.from(data, 'base64');
-      const version = buffer[0];
-      return buffer.length >= HEADER_LENGTH &&
-        (version === ENCRYPTION_VERSION_V1 || version === ENCRYPTION_VERSION_V2);
-    } catch {
-      return false;
-    }
+    const buffer = Buffer.from(data, 'base64');
+    const version = buffer[0];
+    return buffer.length >= HEADER_LENGTH &&
+      (version === ENCRYPTION_VERSION_V1 || version === ENCRYPTION_VERSION_V2);
   }
 
   static getVersion(encryptedData: string): number {

--- a/packages/level-private-state-provider/src/storage-encryption.ts
+++ b/packages/level-private-state-provider/src/storage-encryption.ts
@@ -317,8 +317,9 @@ export const decryptValue = async (
   password: string
 ): Promise<string> => {
   if (!StorageEncryption.isEncrypted(encryptedValue)) {
-    console.debug('MIDNIGHT: Encountered unencrypted data during decryption - passing through as-is');
-    return encryptedValue;
+    throw new Error(
+      'Unrecognized or unencrypted data encountered during decryption'
+    );
   }
 
   const version = StorageEncryption.getVersion(encryptedValue);

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -1782,6 +1782,40 @@ describe('Level Private State Provider', (): void => {
         ).resolves.not.toThrow();
       });
 
+      test('aborts rotation when sublevel contains an unencrypted entry', async () => {
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD,
+          accountId: TEST_ACCOUNT_ID
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+        await db.set('key1', 'value1');
+        await db.set('key2', 'value2');
+
+        const hashedAccountId = crypto.createHash('sha256').update(TEST_ACCOUNT_ID).digest('hex').substring(0, 32);
+        const sublevelName = `private-states:${hashedAccountId}`;
+        const plaintextKey = `${ROTATION_CONTRACT_ADDRESS}:plaintext-entry`;
+
+        const directLevel = new Level(ROTATION_TEST_DB, { createIfMissing: true });
+        const directSublevel = directLevel.sublevel<string, string>(sublevelName, { valueEncoding: 'utf-8' });
+        await directLevel.open();
+        await directSublevel.open();
+        await directSublevel.put(plaintextKey, 'this-is-not-encrypted');
+        await directSublevel.close();
+        await directLevel.close();
+
+        await expect(
+          db.changePassword(() => OLD_PASSWORD, () => NEW_PASSWORD)
+        ).rejects.toThrow(/Failed to decrypt entry.*Unrecognized or unencrypted data/);
+
+        const value1 = await db.get('key1');
+        const value2 = await db.get('key2');
+        expect(value1).toBe('value1');
+        expect(value2).toBe('value2');
+      });
+
       test('re-encrypts all contracts data in sublevel to prevent data loss', async () => {
         const OTHER_CONTRACT = 'other-contract' as ContractAddress;
         let currentPassword = OLD_PASSWORD;

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -1782,6 +1782,10 @@ describe('Level Private State Provider', (): void => {
         ).resolves.not.toThrow();
       });
 
+      // The sublevel name format mirrors getScopedLevelName in level-private-state-provider.ts (sha256 hex prefix sliced to ACCOUNT_ID_HASH_LENGTH).
+      const buildScopedSublevelName = (accountId: string): string =>
+        `private-states:${crypto.createHash('sha256').update(accountId).digest('hex').substring(0, 32)}`;
+
       test('aborts rotation when sublevel contains an unencrypted entry', async () => {
         const config = {
           midnightDbName: ROTATION_TEST_DB,
@@ -1794,8 +1798,7 @@ describe('Level Private State Provider', (): void => {
         await db.set('key1', 'value1');
         await db.set('key2', 'value2');
 
-        const hashedAccountId = crypto.createHash('sha256').update(TEST_ACCOUNT_ID).digest('hex').substring(0, 32);
-        const sublevelName = `private-states:${hashedAccountId}`;
+        const sublevelName = buildScopedSublevelName(TEST_ACCOUNT_ID);
         const plaintextKey = `${ROTATION_CONTRACT_ADDRESS}:plaintext-entry`;
 
         const directLevel = new Level(ROTATION_TEST_DB, { createIfMissing: true });
@@ -1809,6 +1812,42 @@ describe('Level Private State Provider', (): void => {
         await expect(
           db.changePassword(() => OLD_PASSWORD, () => NEW_PASSWORD)
         ).rejects.toThrow(/Failed to decrypt entry.*Unrecognized or unencrypted data/);
+
+        const value1 = await db.get('key1');
+        const value2 = await db.get('key2');
+        expect(value1).toBe('value1');
+        expect(value2).toBe('value2');
+      });
+
+      test('propagates raw error when first iterated entry is unencrypted', async () => {
+        const config = {
+          midnightDbName: ROTATION_TEST_DB,
+          privateStoragePasswordProvider: () => OLD_PASSWORD,
+          accountId: TEST_ACCOUNT_ID
+        };
+
+        const db = levelPrivateStateProvider<string, string>(config);
+        db.setContractAddress(ROTATION_CONTRACT_ADDRESS);
+        await db.set('key1', 'value1');
+        await db.set('key2', 'value2');
+
+        const sublevelName = buildScopedSublevelName(TEST_ACCOUNT_ID);
+        // Lex-sort before ROTATION_CONTRACT_ADDRESS so iterator hits this first.
+        const plaintextKey = 'aaa-contract:plaintext-first';
+
+        const directLevel = new Level(ROTATION_TEST_DB, { createIfMissing: true });
+        const directSublevel = directLevel.sublevel<string, string>(sublevelName, { valueEncoding: 'utf-8' });
+        await directLevel.open();
+        await directSublevel.open();
+        await directSublevel.put(plaintextKey, 'this-is-not-encrypted');
+        await directSublevel.close();
+        await directLevel.close();
+
+        // First-entry path at rotateStorePassword: isDecryptionError returns false for the new message,
+        // so the error propagates raw (not wrapped by "Failed to decrypt entry" nor "Old password is incorrect").
+        await expect(
+          db.changePassword(() => OLD_PASSWORD, () => NEW_PASSWORD)
+        ).rejects.toThrow(/^Unrecognized or unencrypted data encountered during decryption$/);
 
         const value1 = await db.get('key1');
         const value2 = await db.get('key2');

--- a/packages/level-private-state-provider/src/test/storage-encryption.test.ts
+++ b/packages/level-private-state-provider/src/test/storage-encryption.test.ts
@@ -121,13 +121,13 @@ describe('StorageEncryption', () => {
   });
 
   describe('decryptValue', () => {
-    test('passes through unencrypted data as-is', async () => {
+    test('throws on unrecognized or unencrypted data', async () => {
       const encryption = await StorageEncryption.create(testPassword);
       const plaintext = 'not-encrypted-data';
 
-      const result = await decryptValue(plaintext, encryption, testPassword);
-
-      expect(result).toBe(plaintext);
+      await expect(decryptValue(plaintext, encryption, testPassword)).rejects.toThrow(
+        'Unrecognized or unencrypted data encountered during decryption'
+      );
     });
 
     test('decrypts V2 encrypted data', async () => {

--- a/packages/level-private-state-provider/src/test/storage-encryption.test.ts
+++ b/packages/level-private-state-provider/src/test/storage-encryption.test.ts
@@ -130,6 +130,14 @@ describe('StorageEncryption', () => {
       );
     });
 
+    test('throws on empty string input', async () => {
+      const encryption = await StorageEncryption.create(testPassword);
+
+      await expect(decryptValue('', encryption, testPassword)).rejects.toThrow(
+        'Unrecognized or unencrypted data encountered during decryption'
+      );
+    });
+
     test('decrypts V2 encrypted data', async () => {
       const encryption = await StorageEncryption.create(testPassword);
       const encrypted = await encryption.encrypt(testData);
@@ -146,6 +154,20 @@ describe('StorageEncryption', () => {
       const result = await decryptValue(V1_FIXTURES.encrypted, encryption, V1_FIXTURES.password);
 
       expect(result).toBe(V1_FIXTURES.plaintext);
+    });
+  });
+
+  describe('isEncrypted', () => {
+    test('returns false for empty string without throwing', () => {
+      expect(StorageEncryption.isEncrypted('')).toBe(false);
+    });
+
+    test('returns false for invalid base64 input without throwing', () => {
+      expect(StorageEncryption.isEncrypted('!!!not-base64$$$')).toBe(false);
+    });
+
+    test('returns false for plaintext that decodes to a too-short buffer', () => {
+      expect(StorageEncryption.isEncrypted('short')).toBe(false);
     });
   });
 


### PR DESCRIPTION
# Overview

`decryptValue` previously silently passed through values that did not pass the `isEncrypted()` heuristic, only emitting a `console.debug`. For a privacy-preserving framework backed by LevelDB this is a fail-open pattern: corrupted ciphertext or plaintext injected into the store would return as-is, hiding the anomaly.

This PR makes `decryptValue` fail closed — it throws when it encounters unrecognized or unencrypted data, surfacing the condition as an observable error instead of swallowing it. It also removes a dead `try/catch` in `StorageEncryption.isEncrypted` that was masking programmer errors (non-string inputs) as `false`.

## Changes

### Production code (`packages/level-private-state-provider/src/storage-encryption.ts`)

1. **`decryptValue` fails closed.** Replaces the `console.debug` + passthrough with `throw new Error('Unrecognized or unencrypted data encountered during decryption')`.
2. **`StorageEncryption.isEncrypted` `try/catch` removed.** `Buffer.from(string, 'base64')` cannot throw for string input on any Node version — the catch was only hiding TypeScript-signature violations (non-string input via `any` erosion). Removal converts those silent `false` returns into loud `TypeError`s, surfacing programmer errors instead of masking them.

### Test additions

- `decryptValue`: unit tests for the new throw on unrecognized data and on empty-string input.
- `isEncrypted`: unit tests for empty string, invalid base64, and too-short plaintext (all return `false` without throwing — pins the contract post-`try/catch` removal).
- `rotateStorePassword` integration test (`aborts rotation when sublevel contains an unencrypted entry`): seeds a sublevel with a raw plaintext entry via direct `Level` access, asserts `changePassword` aborts with the wrapped error (`Failed to decrypt entry "<key>": Unrecognized or unencrypted data...`), and verifies original entries remain decryptable with the OLD password (atomicity).
- `rotateStorePassword` integration test (`propagates raw error when first iterated entry is unencrypted`): exercises the distinct first-entry code path at `level-private-state-provider.ts:402-410`, asserting the raw error propagates unwrapped (since `isDecryptionError` correctly does NOT match the new message, so it isn't mis-classified as "Old password is incorrect"). Acts as a regression guard against future changes to `isDecryptionError`'s substring list.

## Scope check

- Only callers of `decryptValue` are inside `rotateStorePassword` (`level-private-state-provider.ts:404, 415`); both wrap errors with `{ cause }`.
- Read paths (`getState`, `getAllEntries`) do **not** use `decryptValue` — they inline `isEncrypted()` and re-encrypt legacy plaintext on the fly, so transparent migration of legacy data on the read path is unaffected.
- `isEncrypted` is externally re-exported via `index.ts`, so the `try/catch` removal is technically a behaviour change for consumers passing non-string inputs via `any` erosion. Such callers now get a loud `TypeError` instead of silent `false` — the correct fail-loud upgrade for a privacy-critical primitive.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided — TDD: existing passthrough test inverted (red before fix, green after); five additional tests added across three commits in response to review feedback.
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README.md file (if relevant) — n/a
- [x] Update documentation (if relevant) — n/a (behaviour change is internal to the rotation path; external `isEncrypted` change is fail-loud only for invalid usage)
- [x] No new todos introduced

## Links

Closes: https://github.com/shieldedtech/shielded-security-engineering/issues/274
