### PR TITLE
fix(indexer): preserve ApolloError context in withCompleteQueryData (#822)

### DIFF
--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -103,7 +103,7 @@ const maybeThrowQueryError = <R extends { error?: { message: string } }>(result:
 const withCompleteQueryData = <A>(): Rx.OperatorFunction<ApolloQueryResult<A>, A> =>
   Rx.pipe(
     Rx.filter((result: ApolloQueryResult<A>) => {
-      if (result.error) throw new Error(result.error.message);
+      if (result.error) throw result.error;
       return result.dataState === 'complete';
     }),
     // Safe: dataState === 'complete' guarantees data is Complete<A> which defaults to A


### PR DESCRIPTION
## Problem

`withCompleteQueryData` throws `new Error(result.error.message)` which loses:
- Network errors and stack trace
- GraphQL error details
- Original error cause chain

## Fix

Throw the original `ApolloError` directly:
```diff
- if (result.error) throw new Error(result.error.message);
+ if (result.error) throw result.error;
```

This preserves the full error context for debugging.

Fixes midnightntwrk/midnight-js#822

Wallet: 0xdaE5d307339074A24F579dB48e7c639359D94904