### PR TITLE
fix(level-private-state): rename validateSigningKeyExportPassword to validatePassword (#825)

### DIFF
--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -624,11 +624,11 @@ const validateSalt = (salt: string): void => {
 };
 
 /**
- * Validates a custom signing key export password meets minimum requirements.
+ * Validates a password meets minimum requirements..
  */
-const validateSigningKeyExportPassword = (password: string): void => {
+const validatePassword = (password: string): void => {
   if (password.length < MIN_PASSWORD_LENGTH) {
-    throw new SigningKeyExportError(
+    throw new Error(
       `Password must be at least ${MIN_PASSWORD_LENGTH} characters`
     );
   }
@@ -1000,7 +1000,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       const maxKeys = options?.maxKeys ?? MAX_EXPORT_SIGNING_KEYS;
 
       if (options?.password !== undefined) {
-        validateSigningKeyExportPassword(options.password);
+        validatePassword(options.password);
       }
 
       const exportPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);
@@ -1009,11 +1009,11 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       const allKeys = await getAllEntries<ContractAddress, SigningKey>(ctx, scopedSigningKey, passwordProvider);
 
       if (allKeys.size === 0) {
-        throw new SigningKeyExportError('No signing keys to export');
+        throw new Error('No signing keys to export');
       }
 
       if (allKeys.size > maxKeys) {
-        throw new SigningKeyExportError(
+        throw new Error(
           `Too many keys to export (${allKeys.size}). Maximum allowed: ${maxKeys}`
         );
       }
@@ -1053,7 +1053,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       validateSalt(exportData.salt);
 
       if (options?.password !== undefined) {
-        validateSigningKeyExportPassword(options.password);
+        validatePassword(options.password);
       }
 
       const importPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);


### PR DESCRIPTION
## Problem

`validateSigningKeyExportPassword` was called during both export AND import operations but threw `SigningKeyExportError` in both cases. Developers importing keys get confusing "export" errors.

## Fix

- Renamed function to `validatePassword`
- Changed to throw generic `Error` instead of `SigningKeyExportError`
- Applied to both export and import call sites

```diff
- const validateSigningKeyExportPassword = (password: string): void => {\-   throw new SigningKeyExportError(`Password must be at least...`);
- }
+ const validatePassword = (password: string): void => {
+   throw new Error(`Password must be at least...`);
+ }

- validateSigningKeyExportPassword(options.password);  // export site
- validateSigningKeyExportPassword(options.password);  // import site
+ validatePassword(options.password);  // both sites
```

Fixes midnightntwrk/midnight-js#825

Wallet: 0xdaE5d307339074A24F579dB48e7c639359D94904