### PR TITLE
fix: preserve ApolloError context + rename validatePassword (#822, #825)

### DIFF
--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -103,7 +103,7 @@ const maybeThrowQueryError = <R extends { error?: { message: string } }>(result:
 const withCompleteQueryData = <A>(): Rx.OperatorFunction<ApolloQueryResult<A>, A> =>
   Rx.pipe(
     Rx.filter((result: ApolloQueryResult<A>) => {
-      if (result.error) throw new Error(result.error.message);
+      if (result.error) throw result.error;
       return result.dataState === 'complete';
     }),
     // Safe: dataState === 'complete' guarantees data is Complete<A> which defaults to A

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -624,11 +624,12 @@ const validateSalt = (salt: string): void => {
 };
 
 /**
- * Validates a custom signing key export password meets minimum requirements.
+ * Validates a password meets minimum requirements.
+ * Used for both export and import password validation.
  */
-const validateSigningKeyExportPassword = (password: string): void => {
+const validatePassword = (password: string): void => {
   if (password.length < MIN_PASSWORD_LENGTH) {
-    throw new SigningKeyExportError(
+    throw new Error(
       `Password must be at least ${MIN_PASSWORD_LENGTH} characters`
     );
   }
@@ -1000,7 +1001,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       const maxKeys = options?.maxKeys ?? MAX_EXPORT_SIGNING_KEYS;
 
       if (options?.password !== undefined) {
-        validateSigningKeyExportPassword(options.password);
+        validatePassword(options.password);
       }
 
       const exportPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);
@@ -1053,7 +1054,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       validateSalt(exportData.salt);
 
       if (options?.password !== undefined) {
-        validateSigningKeyExportPassword(options.password);
+        validatePassword(options.password);
       }
 
       const importPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);


### PR DESCRIPTION
## Fixes

### #822: maybeThrowApolloError discards error context

`withCompleteQueryData` in `indexer-public-data-provider.ts:106` replaced the original `ApolloError` (containing network errors, GraphQL errors, and stack trace) with a plain `Error` using just the message string.

**Before:** `throw new Error(result.error.message)`
**After:** `throw result.error`

### #825: validateSigningKeyExportPassword throws SigningKeyExportError during import

The function was called during both export and import operations but threw `SigningKeyExportError` in both cases, confusing developers.

**Before:** `validateSigningKeyExportPassword` → throws `SigningKeyExportError`
**After:** `validatePassword` → throws generic `Error`

## Files Changed
- `packages/indexer-public-data-provider/src/indexer-public-data-provider.ts`
- `packages/level-private-state-provider/src/level-private-state-provider.ts`

Wallet: 0xdaE5d307339074A24F579dB48e7c639359D94904