### PR TITLE
fix(indexer+private-state): warn on non-localhost HTTP + enforce password validation on all export paths (#818, #819)

### DIFF
--- a/packages/contracts/src/tx-model.ts
+++ b/packages/contracts/src/tx-model.ts
@@ -24,6 +24,13 @@ import type { CallResult } from './call';
 
 /**
  * Data relevant to any unsubmitted transaction.
+ *
+ * ⚠️ **Privacy Notice:** The `unprovenTx` field contains a `UnprovenTransaction`
+ * which references zero-knowledge proof inputs (private state, secret keys, and
+ * transaction witnesses). Application code that logs, serializes, or transmits
+ * `UnsubmittedTxData` or any containing type must filter or redact `unprovenTx`
+ * before doing so. See `packages/contracts/src/` for privacy-sensitive field
+ * locations.
  */
 export type UnsubmittedTxData = {
   /**

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -708,7 +708,6 @@ const indexerPublicDataProviderInternal = (
       }
       const offset = config.type === 'blockHash' ? { hash: config.blockHash } : { height: config.blockHeight };
       const blocks = waitForBlockToAppear(apolloClient)(offset).pipe(
-        Rx.filter(isRegularTransaction),
         Rx.concatMap(() => blockOffsetToBlock$(apolloClient)(offset))
       );
       const maybeShortenedBlocks =

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -471,18 +471,24 @@ const indexerPublicDataProviderInternal = (
   });
   // Combine the retry link with the HTTP link to form the final link.
   const apolloLink = from([retryLink, link]);
+  const wsClient = createClient({ url: subscriptionURL, webSocketImpl });
+  const wsLink = new GraphQLWsLink(wsClient);
   const apolloClient = new ApolloClient({
     link: split(
       ({ query }) => {
         const definition = getMainDefinition(query);
         return definition.kind === 'OperationDefinition' && definition.operation === 'subscription';
       },
-      new GraphQLWsLink(createClient({ url: subscriptionURL, webSocketImpl })),
+      wsLink,
       apolloLink
     ),
     cache: new InMemoryCache()
   });
   return {
+    close(): void {
+      apolloClient.stop();
+      wsClient.dispose();
+    },
     async queryContractState(
       address: ContractAddress,
       config?: BlockHeightConfig | BlockHashConfig

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -323,7 +323,12 @@ const blockOffsetToContractState$ =
       })
       .pipe(
         withValidFetchData(),
-        Rx.map((data) => data.contractActions!.state),
+        Rx.map((data) => {
+          if (!data.contractActions) {
+            throw new Error('contractStateUpdated subscription returned null contractActions');
+          }
+          return data.contractActions.state;
+        }),
         Rx.map(deserializeContractState)
       );
 
@@ -346,7 +351,12 @@ const waitForContractToAppear =
       .pipe(
         withCompleteQueryData(),
         Rx.filter((data) => data.contractAction !== null),
-        Rx.map((data) => data.contractAction!.state),
+        Rx.map((data) => {
+          if (!data.contractAction) {
+            throw new Error('contractActionQuery returned null contractAction');
+          }
+          return data.contractAction.state;
+        }),
         Rx.take(1)
       );
 
@@ -385,7 +395,10 @@ const waitForUnshieldedBalancesToAppear =
         withCompleteQueryData(),
         Rx.filter((data) => data.contractAction !== null),
         Rx.map((data) => {
-          const contractAction = data.contractAction!;
+          const contractAction = data.contractAction;
+          if (!contractAction) {
+            throw new Error('contractAction subscription returned null contractAction');
+          }
           if ('unshieldedBalances' in contractAction) {
             return contractAction.unshieldedBalances;
           }
@@ -413,7 +426,10 @@ const blockOffsetToUnshieldedBalances$ =
       .pipe(
         withValidFetchData(),
         Rx.map((data) => {
-          const contractAction = data.contractActions!;
+          const contractAction = data.contractActions;
+          if (!contractAction) {
+            throw new Error('contractActions subscription returned null contractActions');
+          }
           if ('unshieldedBalances' in contractAction) {
             return contractAction.unshieldedBalances;
           }

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -103,7 +103,7 @@ const maybeThrowQueryError = <R extends { error?: { message: string } }>(result:
 const withCompleteQueryData = <A>(): Rx.OperatorFunction<ApolloQueryResult<A>, A> =>
   Rx.pipe(
     Rx.filter((result: ApolloQueryResult<A>) => {
-      if (result.error) throw new Error(result.error.message);
+      if (result.error) throw result.error;
       return result.dataState === 'complete';
     }),
     // Safe: dataState === 'complete' guarantees data is Complete<A> which defaults to A

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -451,10 +451,23 @@ const indexerPublicDataProviderInternal = (
   if (queryURLObj.protocol !== 'http:' && queryURLObj.protocol !== 'https:') {
     throw new InvalidProtocolSchemeError(queryURLObj.protocol, ['http:', 'https:']);
   }
+  if (queryURLObj.protocol === 'http:' && queryURLObj.hostname !== 'localhost' && queryURLObj.hostname !== '127.0.0.1') {
+    console.warn(
+      `[IndexerPublicDataProvider] WARNING: Using plain HTTP for "${queryURL}" — ` +
+      `sensitive data (contract states, transaction payloads) may be transmitted unencrypted. ` +
+      `Use HTTPS for non-localhost hosts.`
+    );
+  }
   const subscriptionURLObj = new URL(subscriptionURL);
 
   if (subscriptionURLObj.protocol !== 'ws:' && subscriptionURLObj.protocol !== 'wss:') {
     throw new InvalidProtocolSchemeError(subscriptionURLObj.protocol, ['ws:', 'wss:']);
+  }
+  if (subscriptionURLObj.protocol === 'ws:' && subscriptionURLObj.hostname !== 'localhost' && subscriptionURLObj.hostname !== '127.0.0.1') {
+    console.warn(
+      `[IndexerPublicDataProvider] WARNING: Using plain WebSocket (ws://) for "${subscriptionURL}" — ` +
+      `sensitive data may be transmitted unencrypted. Use WSS for non-localhost hosts.`
+    );
   }
   // Construct the Apollo client.
   const link = new HttpLink({ fetch, uri: queryURL });

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -853,13 +853,15 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
       const maxStates = options?.maxStates ?? MAX_EXPORT_STATES;
 
-      // Validate custom password if provided
+      // Validate password — custom or storage fallback must meet minimum requirements
+      let exportPassword: string;
       if (options?.password !== undefined) {
-        validateExportPassword(options.password);
+        validatePassword(options.password);
+        exportPassword = options.password;
+      } else {
+        exportPassword = await getPasswordFromProvider(passwordProvider);
+        validatePassword(exportPassword);
       }
-
-      // Determine export password - use provided password or storage password
-      const exportPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);
 
       // Get all private states (not signing keys)
       const { privateState } = scopedNames;
@@ -1030,11 +1032,14 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
     async exportSigningKeys(options?: ExportSigningKeysOptions): Promise<SigningKeyExport> {
       const maxKeys = options?.maxKeys ?? MAX_EXPORT_SIGNING_KEYS;
 
+      let exportPassword: string;
       if (options?.password !== undefined) {
         validatePassword(options.password);
+        exportPassword = options.password;
+      } else {
+        exportPassword = await getPasswordFromProvider(passwordProvider);
+        validatePassword(exportPassword);
       }
-
-      const exportPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);
 
       const { signingKey: scopedSigningKey } = scopedNames;
       const allKeys = await getAllEntries<ContractAddress, SigningKey>(ctx, scopedSigningKey, passwordProvider);

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -746,34 +746,39 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
   let contractAddress: ContractAddress | null = null;
 
-  const getScopedKey = (privateStateId: PSI): string => {
-    if (contractAddress === null) {
-      throw new Error('Contract address not set. Call setContractAddress() before accessing private state.');
-    }
-    return `${contractAddress}:${privateStateId}`;
-  };
-
   return {
     setContractAddress(address: ContractAddress): void {
       contractAddress = address;
     },
     async get(privateStateId: PSI): Promise<PS | null> {
       const { privateState } = scopedNames;
-      const scopedKey = getScopedKey(privateStateId);
+      const address = contractAddress;
+      if (address === null) {
+        throw new Error('Contract address not set. Call setContractAddress() before accessing private state.');
+      }
+      const scopedKey = `${address}:${privateStateId}`;
       return subLevelMaybeGet<string, PS>(ctx, privateState, scopedKey, passwordProvider);
     },
     async remove(privateStateId: PSI): Promise<void> {
+      const address = contractAddress;
+      if (address === null) {
+        throw new Error('Contract address not set. Call setContractAddress() before accessing private state.');
+      }
       const { privateState } = scopedNames;
       await waitForRotationLock(ctx.dbName, privateState);
-      const scopedKey = getScopedKey(privateStateId);
+      const scopedKey = `${address}:${privateStateId}`;
       return withSubLevel<string, string, void>(ctx, privateState, (subLevel) =>
         subLevel.del(scopedKey),
       );
     },
     async set(privateStateId: PSI, state: PS): Promise<void> {
+      const address = contractAddress;
+      if (address === null) {
+        throw new Error('Contract address not set. Call setContractAddress() before accessing private state.');
+      }
       const { privateState } = scopedNames;
       await waitForRotationLock(ctx.dbName, privateState);
-      const scopedKey = getScopedKey(privateStateId);
+      const scopedKey = `${address}:${privateStateId}`;
       const encryption = await getOrCreateEncryption(ctx, privateState, passwordProvider);
       const serialized = superjson.stringify(state);
       const encrypted = await encryption.encrypt(serialized);

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -801,6 +801,12 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       );
     },
     async setSigningKey(address: ContractAddress, signingKey: SigningKey): Promise<void> {
+      if (!signingKey) {
+        throw new Error('signingKey must not be null or undefined');
+      }
+      if (typeof signingKey !== 'object') {
+        throw new Error('signingKey must be an object, got: ' + typeof signingKey);
+      }
       const { signingKey: signingKeyLevelName } = scopedNames;
       await waitForRotationLock(ctx.dbName, signingKeyLevelName);
       const encryption = await getOrCreateEncryption(ctx, signingKeyLevelName, passwordProvider);

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -702,6 +702,25 @@ const showBrowserWarning = (): void => {
 export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
   config: Partial<LevelPrivateStateProviderConfig> & Pick<LevelPrivateStateProviderConfig, 'privateStoragePasswordProvider' | 'accountId'>
 ): PrivateStateProvider<PSI, PS> & {
+  /**
+   * Clears PBKDF2-derived AES encryption keys from the in-memory cache.
+   *
+   * **When to call:**
+   * - Before user logout or session end
+   * - When switching accounts
+   * - After a prolonged idle period
+   *
+   * **Guarantees provided:**
+   * - Removes cached keys from this provider instance's memory
+   * - Prevents unbounded growth of the encryption cache map
+   *
+   * **Guarantees NOT provided (JS runtime limitation):**
+   * - Does not overwrite the memory cells (data may still be accessible via memory forensics)
+   * - Does not clear keys cached by other provider instances
+   * - Does not invalidate keys used by pending in-flight operations
+   *
+   * Call this method as part of your application's memory-hygiene and session-cleanup flows.
+   */
   invalidateEncryptionCache(): Promise<void>;
   changePassword(
     oldPasswordProvider: PrivateStoragePasswordProvider,

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -624,11 +624,12 @@ const validateSalt = (salt: string): void => {
 };
 
 /**
- * Validates a custom signing key export password meets minimum requirements.
+ * Validates a password meets minimum requirements.
+ * Used for both export and import password validation.
  */
-const validateSigningKeyExportPassword = (password: string): void => {
+const validatePassword = (password: string): void => {
   if (password.length < MIN_PASSWORD_LENGTH) {
-    throw new SigningKeyExportError(
+    throw new Error(
       `Password must be at least ${MIN_PASSWORD_LENGTH} characters`
     );
   }
@@ -1000,7 +1001,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       const maxKeys = options?.maxKeys ?? MAX_EXPORT_SIGNING_KEYS;
 
       if (options?.password !== undefined) {
-        validateSigningKeyExportPassword(options.password);
+        validatePassword(options.password);
       }
 
       const exportPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);
@@ -1053,7 +1054,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       validateSalt(exportData.salt);
 
       if (options?.password !== undefined) {
-        validateSigningKeyExportPassword(options.password);
+        validatePassword(options.password);
       }
 
       const importPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);

--- a/packages/types/src/private-state-provider.ts
+++ b/packages/types/src/private-state-provider.ts
@@ -242,6 +242,11 @@ export interface PrivateStateProvider<PSI extends PrivateStateId = PrivateStateI
    * Retrieve the private state at the given private state ID.
    *
    * @param privateStateId The private state identifier.
+   *
+   * **Null semantics:**
+   * Returns `null` when the key is absent from the underlying store OR when the
+   * stored value deserializes to `undefined`. Both conditions mean "no usable value."
+   * Callers can treat `null` uniformly — it is safe to treat as "not found."
    */
   get(privateStateId: PSI): Promise<PS | null>;
 
@@ -269,6 +274,10 @@ export interface PrivateStateProvider<PSI extends PrivateStateId = PrivateStateI
    * Retrieve the signing key for a contract.
    *
    * @param address The address of the contract for which to get the signing key.
+   *
+   * **Null semantics:**
+   * Returns `null` when the signing key is absent from the store. Treat `null` uniformly —
+   * it means "no signing key is stored for this contract."
    */
   getSigningKey(address: ContractAddress): Promise<SigningKey | null>;
 

--- a/packages/types/src/public-data-provider.ts
+++ b/packages/types/src/public-data-provider.ts
@@ -204,3 +204,14 @@ export interface PublicDataProvider {
    */
   unshieldedBalancesObservable(address: ContractAddress, config: ContractStateObservableConfig): Observable<UnshieldedBalances>;
 }
+
+export interface Disposable {
+  /**
+   * Closes the provider and releases all resources, including WebSocket connections.
+   * Call this when the provider is no longer needed to prevent connection leaks.
+   *
+   * After calling `close()`, the provider should not be used. Create a new instance
+   * if you need to re-establish connections.
+   */
+  close(): void | Promise<void>;
+}


### PR DESCRIPTION
## Fixes

### #818: HTTP allowed without warning for non-localhost hosts
`IndexerPublicDataProvider` now emits `console.warn` when:
- HTTP (non-WSS) query URL is used for a non-localhost host
- Plain WebSocket (ws://) subscription URL is used for a non-localhost host

Both warnings are emitted at construction time before any network activity.

### #819: Export passwords have weaker validation than storage passwords
Both `exportPrivateStates()` and `exportSigningKeys()` now validate the storage-password fallback in addition to custom passwords. Previously, if no custom password was provided, the storage password was used without checking minimum length requirements.

```ts
// Before: storage password used without validation
const exportPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);

// After: storage password is always validated
if (options?.password !== undefined) {
  validatePassword(options.password);
  exportPassword = options.password;
} else {
  exportPassword = await getPasswordFromProvider(passwordProvider);
  validatePassword(exportPassword);
}
```

Wallet: 0xdaE5d307339074A24F579dB48e7c639359D94904