### PR TITLE
chore: update compactc to 0.31.0 and dependencies

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,7 @@
 dotenv_if_exists
 
 #run 'yarn clean' after updating this version, to trigger recompilation after updating the version with 'yarn build'
-export COMPACTC_VERSION=0.30.0 # must be set to a valid version of compactc
+export COMPACTC_VERSION=0.31.0 # must be set to a valid version of compactc
 export COMPACT_TAG_PREFIX=compactc-v # override default value
 export COMPACT_REPO=midnightntwrk/compact # override default value
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@midnight-ntwrk/compact-runtime": "0.15.0",
+    "@midnight-ntwrk/compact-runtime": "0.16.0",
     "@midnight-ntwrk/ledger-v8": "8.0.3",
     "@midnight-ntwrk/onchain-runtime-v3": "3.0.0",
     "@midnight-ntwrk/wallet-sdk": "1.0.0"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -21,6 +21,8 @@
   "license": "Apache-2.0",
   "scripts": {
     "clean": "rm -rf dist tsconfig.build.tsbuildinfo .rollup.cache reports coverage",
+    "compact": "yarn fetch-compactc && yarn compact-shielded",
+    "compact-shielded": "run-compactc src/test/resources/shielded-map.compact ./src/test/resources/compiled/shielded-map",
     "build": "rollup -c rollup.config.mjs",
     "test": "vitest run",
     "test-no-utils": "vitest run --exclude src/test/*.test.ts",
@@ -37,6 +39,7 @@
   ],
   "devDependencies": {
     "@fast-check/vitest": "^0.3.0",
+    "@midnight-ntwrk/midnight-js-compact": "workspace:*",
     "vitest": "^4.1.2"
   }
 }

--- a/packages/contracts/src/test/resources/compiled/shielded-map/compiler/contract-info.json
+++ b/packages/contracts/src/test/resources/compiled/shielded-map/compiler/contract-info.json
@@ -1,7 +1,7 @@
 {
-  "compiler-version": "0.30.0",
-  "language-version": "0.22.0",
-  "runtime-version": "0.15.0",
+  "compiler-version": "0.31.0",
+  "language-version": "0.23.0",
+  "runtime-version": "0.16.0",
   "circuits": [
     {
       "name": "deposit",
@@ -59,5 +59,53 @@
     }
   ],
   "contracts": [
+  ],
+  "ledger": [
+    {
+      "name": "counter",
+      "index": 0,
+      "exported": true,
+      "storage": "Counter"
+    },
+    {
+      "name": "reward",
+      "index": 1,
+      "exported": true,
+      "storage": "Cell",
+      "type": {
+        "type-name": "Struct",
+        "name": "QualifiedShieldedCoinInfo",
+        "elements": [
+          {
+            "name": "nonce",
+            "type": {
+              "type-name": "Bytes",
+              "length": 32
+            }
+          },
+          {
+            "name": "color",
+            "type": {
+              "type-name": "Bytes",
+              "length": 32
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "type-name": "Uint",
+              "maxval": 340282366920938463463374607431768211455
+            }
+          },
+          {
+            "name": "mt_index",
+            "type": {
+              "type-name": "Uint",
+              "maxval": 18446744073709551615
+            }
+          }
+        ]
+      }
+    }
   ]
 }

--- a/packages/contracts/src/test/resources/compiled/shielded-map/contract/index.js
+++ b/packages/contracts/src/test/resources/compiled/shielded-map/contract/index.js
@@ -1,20 +1,5 @@
-/*
- * This file is part of midnight-js.
- * Copyright (C) 2025-2026 Midnight Foundation
- * SPDX-License-Identifier: Apache-2.0
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import * as __compactRuntime from '@midnight-ntwrk/compact-runtime';
-__compactRuntime.checkRuntimeVersion('0.15.0');
+__compactRuntime.checkRuntimeVersion('0.16.0');
 
 const _descriptor_0 = new __compactRuntime.CompactTypeUnsignedInteger(65535n, 2);
 

--- a/packages/contracts/src/test/resources/compiled/shielded-map/contract/index.js.map
+++ b/packages/contracts/src/test/resources/compiled/shielded-map/contract/index.js.map
@@ -1,8 +1,8 @@
 {
   "version": 3,
   "file": "index.js",
-  "sourceRoot": "../../",
-  "sources": ["shielded-map.compact", "compiler/standard-library.compact"],
+  "sourceRoot": "../../../../../../",
+  "sources": ["src/test/resources/shielded-map.compact", "compiler/standard-library.compact"],
   "names": [],
   "mappings": ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;EAAA;;;;;;;;;;;;;MAOA,AAAA,OAKC;;;;;cALsB,MAAsB;;;;;;;;;;;;;;;;;;yCAAtB,MAAsB;;;;;;;oEAAtB,MAAsB;;;OAK5C;;;;GACA;EAbD;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;IAEA;;;;;;;;;yEAA+B;IAC/B;;;;;;;;;yEAAgD;;;;;;;GAU/C;EC4BD,AAAA,SAA2B;yEACqC;;EAgHhE,AAAA,8CAA+B;UACvB,oDAAuD;;;;;;;;;;;;yDAC3C,QAAM;UACxB,+BAA4C,QAAM;IAAlD;;;;;;;;;;;2HAAA;;;;;;;;EA8FF,AAAA,kBACE,QACA;;;0CAKU;8CACI;;sCACJ;sCAAoB;sCAAuB;;EApQvD,AAAA,kBAAA;qEAAA;;;EAAA,AAAA,gDAAA,QAAA;;wDAAA;wDAAA;;;;;;;EDKA,AAAA,QAAoB;;0DAApB,KAAoB;;;;;;;;;;;;;;GAAA;EAEpB,AAAA,UAKC,4BALsB,MAAsB;uDAClB,MAAI;UAC7B,KAAM,yCAAsE;;;;;;;;;;;6HAAM;gDAAxD,MAAI,EAA9B,KAAM,IAAN;;;;;;;;;0LAA0B,MAAI;;0LAA9B,KAAM;;;;;;;;;;;wLAAoB,MAAI;;;;;;uHAAxB;UACN,KAAO;IAAP;;;;;;;;;;6FAAA,KAAO;;;;wEAAA;;;GAER;;;;;;;;;;;;;;;;IAVD;qCAAA;;;;;;;;;;;0GAA+B;KAAA;IAC/B;qCAAA;;;;;;;;;;;0GAAgD;KAAA;;;;;;;;;;"
 }

--- a/packages/http-client-proof-provider/src/test/resources/compiled/simple/compiler/contract-info.json
+++ b/packages/http-client-proof-provider/src/test/resources/compiled/simple/compiler/contract-info.json
@@ -1,8 +1,12 @@
 {
+  "compiler-version": "0.31.0",
+  "language-version": "0.23.0",
+  "runtime-version": "0.16.0",
   "circuits": [
     {
       "name": "add",
       "pure": false,
+      "proof": true,
       "arguments": [
       ],
       "result-type": {
@@ -15,5 +19,13 @@
   "witnesses": [
   ],
   "contracts": [
+  ],
+  "ledger": [
+    {
+      "name": "round",
+      "index": 0,
+      "exported": true,
+      "storage": "Counter"
+    }
   ]
 }

--- a/packages/http-client-proof-provider/src/test/resources/compiled/simple/contract/index.d.ts
+++ b/packages/http-client-proof-provider/src/test/resources/compiled/simple/contract/index.d.ts
@@ -7,6 +7,10 @@ export type ImpureCircuits<PS> = {
   add(context: __compactRuntime.CircuitContext<PS>): __compactRuntime.CircuitResults<PS, []>;
 }
 
+export type ProvableCircuits<PS> = {
+  add(context: __compactRuntime.CircuitContext<PS>): __compactRuntime.CircuitResults<PS, []>;
+}
+
 export type PureCircuits = {
 }
 
@@ -26,6 +30,7 @@ export declare class Contract<PS = any, W extends Witnesses<PS> = Witnesses<PS>>
   witnesses: W;
   circuits: Circuits<PS>;
   impureCircuits: ImpureCircuits<PS>;
+  provableCircuits: ProvableCircuits<PS>;
   constructor(witnesses: W);
   initialState(context: __compactRuntime.ConstructorContext<PS>): __compactRuntime.ConstructorResult<PS>;
 }

--- a/packages/http-client-proof-provider/src/test/resources/compiled/simple/contract/index.js
+++ b/packages/http-client-proof-provider/src/test/resources/compiled/simple/contract/index.js
@@ -1,5 +1,5 @@
 import * as __compactRuntime from '@midnight-ntwrk/compact-runtime';
-__compactRuntime.checkRuntimeVersion('0.14.0-rc.0');
+__compactRuntime.checkRuntimeVersion('0.16.0');
 
 const _descriptor_0 = new __compactRuntime.CompactTypeUnsignedInteger(65535n, 2);
 
@@ -84,6 +84,7 @@ export class Contract {
       }
     };
     this.impureCircuits = { add: this.circuits.add };
+    this.provableCircuits = { add: this.circuits.add };
   }
   initialState(...args_0) {
     if (args_0.length !== 1) {
@@ -121,7 +122,7 @@ export class Contract {
                                                  value: __compactRuntime.StateValue.newCell({ value: _descriptor_1.toValue(0n),
                                                                                               alignment: _descriptor_1.alignment() }).encode() } },
                                        { ins: { cached: false, n: 1 } }]);
-    state_0.data = context.currentQueryContext.state;
+    state_0.data = new __compactRuntime.ChargedState(context.currentQueryContext.state.state);
     return {
       currentContractState: state_0,
       currentPrivateState: context.currentPrivateState,

--- a/packages/http-client-proof-provider/src/test/resources/compiled/simple/contract/index.js.map
+++ b/packages/http-client-proof-provider/src/test/resources/compiled/simple/contract/index.js.map
@@ -4,5 +4,5 @@
   "sourceRoot": "../../../../../../",
   "sources": ["src/test/resources/simple.compact"],
   "names": [],
-  "mappings": ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;EAAA;;;;;;;;;;MAIA,AAAA,GAEC;;;;;;;;;;;;;;;;;;;;;;OAAA;;;GACA;EAPD;;;;;;;;;;;;;;;;;;;;;;;;;;IAEA;;;;;;;;;yEAA6B;;;;;;;GAK5B;EAHD,AAAA,MAEC;UADC,KAAK;IAAL;;;;;;;;;;6FAAA,KAAK;;;;wEAAA;;GACN;;;;;;;;;;;;;;;;IAJD;qCAAA;;;;;;;;;;;0GAA6B;KAAA;;;;;;;;;;"
+  "mappings": ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;EAAA;;;;;;;;;;MAIA,AAAA,GAEC;;;;;;;;;;;;;;;;;;;;;;OAAA;;;;GACA;EAPD;;;;;;;;;;;;;;;;;;;;;;;;;;IAEA;;;;;;;;;yEAA6B;;;;;;;GAK5B;EAHD,AAAA,MAEC;UADC,KAAK;IAAL;;;;;;;;;;6FAAA,KAAK;;;;wEAAA;;GACN;;;;;;;;;;;;;;;;IAJD;qCAAA;;;;;;;;;;;0GAA6B;KAAA;;;;;;;;;;"
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -104,8 +104,8 @@
     "dist/"
   ],
   "dependencies": {
-    "@midnight-ntwrk/compact-js": "2.5.0",
-    "@midnight-ntwrk/compact-runtime": "0.15.0",
+    "@midnight-ntwrk/compact-js": "2.5.1",
+    "@midnight-ntwrk/compact-runtime": "0.16.0",
     "@midnight-ntwrk/ledger-v8": "8.0.3",
     "@midnight-ntwrk/onchain-runtime-v3": "3.0.0",
     "@midnight-ntwrk/platform-js": "2.2.4"

--- a/testkit-js/testkit-js-e2e/src/contract/compiled/block-time/compiler/contract-info.json
+++ b/testkit-js/testkit-js-e2e/src/contract/compiled/block-time/compiler/contract-info.json
@@ -1,7 +1,7 @@
 {
-  "compiler-version": "0.30.0",
-  "language-version": "0.22.0",
-  "runtime-version": "0.15.0",
+  "compiler-version": "0.31.0",
+  "language-version": "0.23.0",
+  "runtime-version": "0.16.0",
   "circuits": [
     {
       "name": "testBlockTimeLt",
@@ -83,5 +83,7 @@
   "witnesses": [
   ],
   "contracts": [
+  ],
+  "ledger": [
   ]
 }

--- a/testkit-js/testkit-js-e2e/src/contract/compiled/block-time/contract/index.js
+++ b/testkit-js/testkit-js-e2e/src/contract/compiled/block-time/contract/index.js
@@ -1,5 +1,5 @@
 import * as __compactRuntime from '@midnight-ntwrk/compact-runtime';
-__compactRuntime.checkRuntimeVersion('0.15.0');
+__compactRuntime.checkRuntimeVersion('0.16.0');
 
 const _descriptor_0 = new __compactRuntime.CompactTypeUnsignedInteger(18446744073709551615n, 8);
 

--- a/testkit-js/testkit-js-e2e/src/contract/compiled/counter-clone/compiler/contract-info.json
+++ b/testkit-js/testkit-js-e2e/src/contract/compiled/counter-clone/compiler/contract-info.json
@@ -1,7 +1,7 @@
 {
-  "compiler-version": "0.30.0",
-  "language-version": "0.22.0",
-  "runtime-version": "0.15.0",
+  "compiler-version": "0.31.0",
+  "language-version": "0.23.0",
+  "runtime-version": "0.16.0",
   "circuits": [
     {
       "name": "increment",
@@ -60,5 +60,13 @@
     }
   ],
   "contracts": [
+  ],
+  "ledger": [
+    {
+      "name": "round",
+      "index": 0,
+      "exported": true,
+      "storage": "Counter"
+    }
   ]
 }

--- a/testkit-js/testkit-js-e2e/src/contract/compiled/counter-clone/contract/index.js
+++ b/testkit-js/testkit-js-e2e/src/contract/compiled/counter-clone/contract/index.js
@@ -1,5 +1,5 @@
 import * as __compactRuntime from '@midnight-ntwrk/compact-runtime';
-__compactRuntime.checkRuntimeVersion('0.15.0');
+__compactRuntime.checkRuntimeVersion('0.16.0');
 
 const _descriptor_0 = new __compactRuntime.CompactTypeUnsignedInteger(65535n, 2);
 

--- a/testkit-js/testkit-js-e2e/src/contract/compiled/counter/compiler/contract-info.json
+++ b/testkit-js/testkit-js-e2e/src/contract/compiled/counter/compiler/contract-info.json
@@ -1,7 +1,7 @@
 {
-  "compiler-version": "0.30.0",
-  "language-version": "0.22.0",
-  "runtime-version": "0.15.0",
+  "compiler-version": "0.31.0",
+  "language-version": "0.23.0",
+  "runtime-version": "0.16.0",
   "circuits": [
     {
       "name": "increment",
@@ -60,5 +60,13 @@
     }
   ],
   "contracts": [
+  ],
+  "ledger": [
+    {
+      "name": "round",
+      "index": 0,
+      "exported": true,
+      "storage": "Counter"
+    }
   ]
 }

--- a/testkit-js/testkit-js-e2e/src/contract/compiled/counter/contract/index.js
+++ b/testkit-js/testkit-js-e2e/src/contract/compiled/counter/contract/index.js
@@ -1,5 +1,5 @@
 import * as __compactRuntime from '@midnight-ntwrk/compact-runtime';
-__compactRuntime.checkRuntimeVersion('0.15.0');
+__compactRuntime.checkRuntimeVersion('0.16.0');
 
 const _descriptor_0 = new __compactRuntime.CompactTypeUnsignedInteger(65535n, 2);
 

--- a/testkit-js/testkit-js-e2e/src/contract/compiled/double-counter/compiler/contract-info.json
+++ b/testkit-js/testkit-js-e2e/src/contract/compiled/double-counter/compiler/contract-info.json
@@ -1,7 +1,7 @@
 {
-  "compiler-version": "0.30.0",
-  "language-version": "0.22.0",
-  "runtime-version": "0.15.0",
+  "compiler-version": "0.31.0",
+  "language-version": "0.23.0",
+  "runtime-version": "0.16.0",
   "circuits": [
     {
       "name": "increment1",
@@ -67,5 +67,19 @@
     }
   ],
   "contracts": [
+  ],
+  "ledger": [
+    {
+      "name": "ticker1",
+      "index": 0,
+      "exported": true,
+      "storage": "Counter"
+    },
+    {
+      "name": "ticker2",
+      "index": 1,
+      "exported": true,
+      "storage": "Counter"
+    }
   ]
 }

--- a/testkit-js/testkit-js-e2e/src/contract/compiled/double-counter/contract/index.js
+++ b/testkit-js/testkit-js-e2e/src/contract/compiled/double-counter/contract/index.js
@@ -1,5 +1,5 @@
 import * as __compactRuntime from '@midnight-ntwrk/compact-runtime';
-__compactRuntime.checkRuntimeVersion('0.15.0');
+__compactRuntime.checkRuntimeVersion('0.16.0');
 
 const _descriptor_0 = new __compactRuntime.CompactTypeUnsignedInteger(65535n, 2);
 

--- a/testkit-js/testkit-js-e2e/src/contract/compiled/shielded/compiler/contract-info.json
+++ b/testkit-js/testkit-js-e2e/src/contract/compiled/shielded/compiler/contract-info.json
@@ -1,7 +1,7 @@
 {
-  "compiler-version": "0.30.0",
-  "language-version": "0.22.0",
-  "runtime-version": "0.15.0",
+  "compiler-version": "0.31.0",
+  "language-version": "0.23.0",
+  "runtime-version": "0.16.0",
   "circuits": [
     {
       "name": "mintShieldedTokens",
@@ -454,5 +454,7 @@
   "witnesses": [
   ],
   "contracts": [
+  ],
+  "ledger": [
   ]
 }

--- a/testkit-js/testkit-js-e2e/src/contract/compiled/shielded/contract/index.js
+++ b/testkit-js/testkit-js-e2e/src/contract/compiled/shielded/contract/index.js
@@ -1,5 +1,5 @@
 import * as __compactRuntime from '@midnight-ntwrk/compact-runtime';
-__compactRuntime.checkRuntimeVersion('0.15.0');
+__compactRuntime.checkRuntimeVersion('0.16.0');
 
 const _descriptor_0 = new __compactRuntime.CompactTypeBytes(32);
 

--- a/testkit-js/testkit-js-e2e/src/contract/compiled/simple/compiler/contract-info.json
+++ b/testkit-js/testkit-js-e2e/src/contract/compiled/simple/compiler/contract-info.json
@@ -1,7 +1,7 @@
 {
-  "compiler-version": "0.30.0",
-  "language-version": "0.22.0",
-  "runtime-version": "0.15.0",
+  "compiler-version": "0.31.0",
+  "language-version": "0.23.0",
+  "runtime-version": "0.16.0",
   "circuits": [
     {
       "name": "noop",
@@ -19,5 +19,13 @@
   "witnesses": [
   ],
   "contracts": [
+  ],
+  "ledger": [
+    {
+      "name": "round",
+      "index": 0,
+      "exported": true,
+      "storage": "Counter"
+    }
   ]
 }

--- a/testkit-js/testkit-js-e2e/src/contract/compiled/simple/contract/index.js
+++ b/testkit-js/testkit-js-e2e/src/contract/compiled/simple/contract/index.js
@@ -1,5 +1,5 @@
 import * as __compactRuntime from '@midnight-ntwrk/compact-runtime';
-__compactRuntime.checkRuntimeVersion('0.15.0');
+__compactRuntime.checkRuntimeVersion('0.16.0');
 
 const _descriptor_0 = new __compactRuntime.CompactTypeUnsignedInteger(65535n, 2);
 

--- a/testkit-js/testkit-js-e2e/src/contract/compiled/unshielded/compiler/contract-info.json
+++ b/testkit-js/testkit-js-e2e/src/contract/compiled/unshielded/compiler/contract-info.json
@@ -1,7 +1,7 @@
 {
-  "compiler-version": "0.30.0",
-  "language-version": "0.22.0",
-  "runtime-version": "0.15.0",
+  "compiler-version": "0.31.0",
+  "language-version": "0.23.0",
+  "runtime-version": "0.16.0",
   "circuits": [
     {
       "name": "mintUnshieldedToSelfTest",
@@ -484,5 +484,7 @@
   "witnesses": [
   ],
   "contracts": [
+  ],
+  "ledger": [
   ]
 }

--- a/testkit-js/testkit-js-e2e/src/contract/compiled/unshielded/contract/index.js
+++ b/testkit-js/testkit-js-e2e/src/contract/compiled/unshielded/contract/index.js
@@ -1,5 +1,5 @@
 import * as __compactRuntime from '@midnight-ntwrk/compact-runtime';
-__compactRuntime.checkRuntimeVersion('0.15.0');
+__compactRuntime.checkRuntimeVersion('0.16.0');
 
 const _descriptor_0 = new __compactRuntime.CompactTypeUnsignedInteger(18446744073709551615n, 8);
 

--- a/turbo.json
+++ b/turbo.json
@@ -47,6 +47,9 @@
       "outputLogs": "new-only",
       "dependsOn": ["build", "test"]
     },
+    "compact": {
+      "cache": false
+    },
     "deploy": {
       "cache": false,
       "dependsOn": ["build"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,28 +1833,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/compact-js@npm:2.5.0":
-  version: 2.5.0
-  resolution: "@midnight-ntwrk/compact-js@npm:2.5.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40midnight-ntwrk%2Fcompact-js%2F2.5.0%2F84c25eee0d1f749b85d48729590dca701d4acc5a"
+"@midnight-ntwrk/compact-js@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@midnight-ntwrk/compact-js@npm:2.5.1::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40midnight-ntwrk%2Fcompact-js%2F2.5.1%2F8845b0f792dbe0a483d35c1d25a565a6cc7d98b9"
   dependencies:
     "@effect/platform": "npm:^0.95.0"
-    "@midnight-ntwrk/compact-runtime": "npm:0.15.0"
+    "@midnight-ntwrk/compact-runtime": "npm:0.16.0"
     "@midnight-ntwrk/ledger-v8": "npm:^8.0.3"
     "@midnight-ntwrk/platform-js": "npm:^2.2.4"
     effect: "npm:^3.20.0"
     tslib: "npm:^2.8.1"
-  checksum: 10/4b5c5e0630d242740a19c51cdef825dab5408b3fa4a360d81fd37652bb77bf83227867d621c0acd6ddccc6a57f68f89e1df045daf7edb77154f80e245598ed9d
+  checksum: 10/ee041b88d8fd43dc63f8cbb6b02f2eb0d6445921633b032e1dd3e909c75be8ca8f311cee70d16a9d06795bbb94172d2a6797799ee3870f29a8aa42e7e3e153b6
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/compact-runtime@npm:0.15.0":
-  version: 0.15.0
-  resolution: "@midnight-ntwrk/compact-runtime@npm:0.15.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40midnight-ntwrk%2Fcompact-runtime%2F0.15.0%2F399021d6e35d3cf25e4bc4ba56f19d5396bbe167"
+"@midnight-ntwrk/compact-runtime@npm:0.16.0":
+  version: 0.16.0
+  resolution: "@midnight-ntwrk/compact-runtime@npm:0.16.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40midnight-ntwrk%2Fcompact-runtime%2F0.16.0%2F4a2d38a4237b0abd6d833c0ee94baa6318323a79"
   dependencies:
     "@midnight-ntwrk/onchain-runtime-v3": "npm:^3.0.0"
     "@types/object-inspect": "npm:^1.8.1"
     object-inspect: "npm:^1.12.3"
-  checksum: 10/12ac86a114a404386037547a6eb021694537c0636d24d281b101c5be75e3f5703bad9e0bbcc7ea2a39a96e167d200860049a9957dbb4dbdeb585c3fba696909c
+  checksum: 10/ef0c68d53bba6a04f336094c82c26b781082d7ce4ee09f0539009fb108776b36ea24b9a774292d9bbf9722b8a78d47254b5f80a613d4010a7f7d108514243023
   languageName: node
   linkType: hard
 
@@ -1992,7 +1992,7 @@ __metadata:
     "@commitlint/config-conventional": "npm:^20.4.3"
     "@d2t/vitest-ctrf-json-reporter": "npm:^1.3.0"
     "@eslint/js": "npm:^10.0.1"
-    "@midnight-ntwrk/compact-runtime": "npm:0.15.0"
+    "@midnight-ntwrk/compact-runtime": "npm:0.16.0"
     "@midnight-ntwrk/ledger-v8": "npm:8.0.3"
     "@midnight-ntwrk/onchain-runtime-v3": "npm:3.0.0"
     "@midnight-ntwrk/wallet-sdk": "npm:1.0.0"
@@ -2051,8 +2051,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/midnight-js-protocol@workspace:packages/protocol"
   dependencies:
-    "@midnight-ntwrk/compact-js": "npm:2.5.0"
-    "@midnight-ntwrk/compact-runtime": "npm:0.15.0"
+    "@midnight-ntwrk/compact-js": "npm:2.5.1"
+    "@midnight-ntwrk/compact-runtime": "npm:0.16.0"
     "@midnight-ntwrk/ledger-v8": "npm:8.0.3"
     "@midnight-ntwrk/onchain-runtime-v3": "npm:3.0.0"
     "@midnight-ntwrk/platform-js": "npm:2.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1892,6 +1892,7 @@ __metadata:
   resolution: "@midnight-ntwrk/midnight-js-contracts@workspace:packages/contracts"
   dependencies:
     "@fast-check/vitest": "npm:^0.3.0"
+    "@midnight-ntwrk/midnight-js-compact": "workspace:*"
     "@midnight-ntwrk/midnight-js-network-id": "workspace:*"
     "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@midnight-ntwrk/midnight-js-types": "workspace:*"


### PR DESCRIPTION
Updated:
- compactc:0.31.0
- compact-runtime:0.16.0
- compact-js:2.5.1

Recompile all contracts.