### PR TITLE
docs: refresh v4.1.0 release notes for post-#860 changes

### DIFF
--- a/docs/releases/v4.1.0/README.md
+++ b/docs/releases/v4.1.0/README.md
@@ -1,6 +1,6 @@
 # midnight-js v4.1.0 Release Documentation
 
-**Release Date:** April 22, 2026
+**Release Date:** May 19, 2026
 **Previous Version:** v4.0.4
 **Migration Complexity:** Medium (breaking changes in storage encryption API and protocol imports)
 
@@ -17,12 +17,31 @@
 1. **StorageEncryption migrated to async Web Crypto API** - Constructor replaced with async factory `StorageEncryption.create()`, all encrypt/decrypt methods now async (#798)
 2. **Protocol imports via ACL package** - Direct imports from `@midnight-ntwrk/ledger-v8`, `@midnight-ntwrk/compact-runtime`, etc. replaced with `@midnight-ntwrk/midnight-js-protocol` subpaths (#832)
 
-## New Features (4)
+## Notable Behaviour Changes
+
+- **`verifyPassword` now runs PBKDF2** (hundreds of milliseconds, hardware-dependent) instead of microsecond SHA-256 — security fix for memory-dump brute force; paid on cold reads after cache miss; on-disk format unchanged (#883)
+- **`assertDefined` / `assertUndefined` now accept falsy values** (`0`, `''`, `false`, `0n`) — bug fix for #806 (#900)
+- **`decryptValue` fails closed** on unrecognized data during password rotation (was fail-open passthrough) (#885)
+
+## New Features (6)
 
 1. Web Crypto API for storage encryption -- browser compatibility (#798)
 2. CryptoBackend abstraction with Noble fallback -- React Native and non-secure contexts (#827)
-3. Protocol ACL package -- version-agnostic protocol imports (#832)
-4. DAppConnectorWalletAdapter for testkit-js -- wallet-delegated proving in e2e tests (#855)
+3. Injectable `levelFactory` for React Native and custom storage backends (#827)
+4. Protocol ACL package -- version-agnostic protocol imports (#832)
+5. DAppConnectorWalletAdapter for testkit-js -- wallet-delegated proving in e2e tests (#855)
+6. `assertSafeName` / `assertSemVer` utilities -- path-traversal-safe input validation (#875)
+
+## Key Security Fixes
+
+- PBKDF2 password verifier replaces in-memory SHA-256 hash (#883)
+- Path traversal blocked in `node-zk-config-provider`, `fetch-zk-config-provider`, and `VersionManager` (#875)
+- `decryptValue` fails closed on unrecognized data (#885)
+
+## Key Bug Fixes
+
+- Shielded coins from fallible-segment circuit operations (e.g., LP-token mints) now route to the correct Zswap offer — no more `InsufficientFunds` on freshly-minted token colors (#876, #877)
+- `@midnight-ntwrk/midnight-js-contracts` is now browser-bundleable (Node-only `fs`/`path` imports removed from `submit-tx`) (#869)
 
 ## Quick Migration
 
@@ -68,5 +87,5 @@ import { type ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/compa
 
 ---
 
-**Last Updated:** April 22, 2026
+**Last Updated:** May 19, 2026
 **License:** Apache-2.0

--- a/docs/releases/v4.1.0/api-changes.md
+++ b/docs/releases/v4.1.0/api-changes.md
@@ -9,12 +9,12 @@
 **v4.0.4:**
 ```typescript
 class StorageEncryption {
-  constructor(password: string, options?: { existingSalt?: Buffer });
+  constructor(password: string, existingSalt?: Buffer);
   encrypt(data: string): string;
   decrypt(data: string): string;
   decryptWithPassword(data: string, password: string): string;
   verifyPassword(password: string): boolean;
-  get salt(): Buffer;
+  getSalt(): Buffer;
 }
 ```
 
@@ -26,7 +26,7 @@ class StorageEncryption {
   decrypt(data: string): Promise<string>;
   decryptWithPassword(data: string, password: string): Promise<string>;
   verifyPassword(password: string): Promise<boolean>;
-  get salt(): Buffer;
+  getSalt(): Buffer;
 }
 ```
 
@@ -130,11 +130,11 @@ Each subpath re-exports `*` from the underlying protocol package:
 - `./compact-runtime` -> `@midnight-ntwrk/compact-runtime`
 - `./compact-js` -> `@midnight-ntwrk/compact-js`
 - `./compact-js/effect` -> `@midnight-ntwrk/compact-js/effect`
-- `./compact-js/effect-contract` -> `@midnight-ntwrk/compact-js/effect-contract`
+- `./compact-js/effect/Contract` -> `@midnight-ntwrk/compact-js/effect/Contract`
 - `./onchain-runtime` -> `@midnight-ntwrk/onchain-runtime-v3`
 - `./platform-js` -> `@midnight-ntwrk/platform-js`
-- `./platform-js/effect-configuration` -> `@midnight-ntwrk/platform-js/effect-configuration`
-- `./platform-js/effect-contract-address` -> `@midnight-ntwrk/platform-js/effect-contract-address`
+- `./platform-js/effect/Configuration` -> `@midnight-ntwrk/platform-js/effect/Configuration`
+- `./platform-js/effect/ContractAddress` -> `@midnight-ntwrk/platform-js/effect/ContractAddress`
 
 ---
 
@@ -146,7 +146,10 @@ Each subpath re-exports `*` from the underlying protocol package:
 
 ```typescript
 class DAppConnectorWalletAdapter implements ConnectedAPI {
-  constructor(walletProvider: MidnightWalletProvider);
+  constructor(
+    walletProvider: Pick<MidnightWalletProvider, 'wallet' | 'unshieldedKeystore' | 'zswapSecretKeys' | 'dustSecretKey'>,
+    environmentConfiguration: EnvironmentConfiguration,
+  );
   // Implements full ConnectedAPI interface from @midnight-ntwrk/dapp-connector-api
 }
 ```
@@ -155,7 +158,11 @@ class DAppConnectorWalletAdapter implements ConnectedAPI {
 
 ```typescript
 class DAppConnectorInitialAPI implements InitialAPI {
-  constructor(walletAdapter: DAppConnectorWalletAdapter, expectedNetworkId: string);
+  constructor(
+    connectedWallet: ConnectedAPI,
+    networkId: string,
+    options?: { rdns?: string; name?: string; icon?: string; apiVersion?: string },
+  );
 }
 ```
 
@@ -178,3 +185,108 @@ class DAppConnectorInitialAPI implements InitialAPI {
 **v4.0.4:** Accepted any HTTP 200 response regardless of Content-Type.
 
 **v4.1.0:** Rejects responses with `Content-Type: text/html` and includes the full URL and status code in error messages for non-ok responses.
+
+#### `circuitId` validation (#875)
+
+**v4.0.4:** `circuitId` was interpolated directly into the request URL.
+
+**v4.1.0:** `circuitId` is passed through `assertSafeName` and URL segments are constructed with `encodeURIComponent` + `new URL()`. Traversal payloads (`..`, `/`, NUL, etc.) are rejected before any network call.
+
+---
+
+## Package: @midnight-ntwrk/midnight-js-node-zk-config-provider
+
+### Modified Behavior (#875)
+
+`circuitId` is validated via `assertSafeName` before any `path.resolve` call. Traversal payloads are rejected with a descriptive error.
+
+---
+
+## Package: @midnight-ntwrk/midnight-js-compact
+
+### Modified Behavior (#875)
+
+`VersionManager.getVersionDir` is now the single validation choke point for `versionExists`, `getCompactcPath`, and `removeVersion`. The version string is validated via `assertSemVer`, and a containment check is performed before any `rmSync` as defence in depth.
+
+---
+
+## Package: @midnight-ntwrk/midnight-js-utils
+
+### New Exports (#875)
+
+```typescript
+const MAX_SAFE_NAME_LENGTH = 255;
+function assertSafeName(name: string, label: string): void;
+function assertSemVer(version: string, label: string): void;
+```
+
+Re-exported from the package root via `security-utils`.
+
+### Modified Behavior (#900)
+
+#### `assertDefined` / `assertUndefined`
+
+**v4.0.4:** Used truthiness checks (`!value` / `value`), so `0`, `''`, `false`, and `0n` were incorrectly rejected by `assertDefined` and incorrectly accepted by `assertUndefined`.
+
+**v4.1.0:** Both helpers now use explicit `=== null || === undefined` checks. Signature is unchanged.
+
+**Behaviour change:** falsy-but-defined values now pass `assertDefined` and fail `assertUndefined`, as documented.
+
+---
+
+## Package: @midnight-ntwrk/midnight-js-level-private-state-provider
+
+### Modified Behavior
+
+#### `StorageEncryption.verifyPassword` (#883)
+
+**v4.0.4:** Compared a single-round SHA-256 hash of the password (stored in memory) — microsecond-scale.
+
+**v4.1.0:** Runs PBKDF2 with the original salt and constant-time-compares the derived key against the in-memory `encryptionKey`. ~300ms per call. On-disk format unchanged.
+
+The internal `passwordHash` field and `hashPassword` helper are removed. A new internal `deriveEncryptionKey(backend, password, salt, iterations)` helper is reused by `create`, `verifyPassword`, and `decryptWithPassword`.
+
+#### `decryptValue` and `isEncrypted` (#885)
+
+**v4.0.4:** `decryptValue` logged `console.debug` and returned raw bytes when `isEncrypted()` returned false. `isEncrypted()` swallowed all errors via a `try/catch` and returned false.
+
+**v4.1.0:** `decryptValue` throws on unrecognized data. The two call sites both live inside `rotateStorePassword`. `isEncrypted` drops its always-false `catch` (`Buffer.from` on string input cannot throw). Read paths (`getState`, `getAllEntries`) inline `isEncrypted` and continue to transparently migrate legacy plaintext.
+
+---
+
+## Package: @midnight-ntwrk/midnight-js-contracts
+
+### Modified Behavior (#869)
+
+`submit-tx.ts` no longer imports `node:fs` or `node:path`. `logTransaction()` previously wrote a debug trace file; the fs/path imports and file writes are removed and `console` logging is preserved. The package is now browser-bundleable.
+
+### New Internal Exports (#876, #877)
+
+The shielded-coin segment routing fix introduces three new symbols in `packages/contracts/src/utils/zswap-utils.ts` (internal — not re-exported from the package barrel):
+
+```typescript
+const GUARANTEED_SEGMENT_NUMBER = 0;
+const FALLIBLE_SEGMENT_NUMBER = 1;
+function zswapStateToSegmentedOffer(
+  zswapLocalState: ZswapLocalState,
+  encryptionPublicKeyOrResolver: EncPublicKey | EncryptionPublicKeyResolver,
+  addressAndChainStateTuple?: { contractAddress: ContractAddress; zswapChainState: ZswapChainState },
+  partitionedTranscript?: PartitionedTranscript,
+): { guaranteed: UnprovenOffer | undefined; fallible: UnprovenOffer | undefined };
+```
+
+`zswapStateToOffer` is preserved as a thin wrapper over `zswapStateToSegmentedOffer()` for callers without a partitioned transcript. `createUnprovenLedgerCallTx` now routes inputs by nullifier match against `claimedNullifiers` and outputs by the union of `claimedShieldedReceives` ∪ `claimedShieldedSpends`, matching ledger v8 `construct.rs`. Cross-segment ambiguity throws explicitly instead of silently routing to the guaranteed offer.
+
+---
+
+## Package: @midnight-ntwrk/testkit-js (additional changes)
+
+### Migrated wallet-sdk imports (#862)
+
+Testkit-js now imports from the new `@midnight-ntwrk/wallet-sdk` barrel package (v1.0.0) instead of individual `wallet-sdk-*` subpackages. Aligns with ledger 8.0.3 binding marker renames and the updated `InMemoryTransactionHistoryStorage` constructor.
+
+Two granular subpath imports remain where the barrel does not re-export: `wallet-sdk-prover-client/effect` and `wallet-sdk-shielded/v1`.
+
+Configuration helpers renamed for clarity:
+- `DefaultV1Configuration` -> `DefaultShieldedConfiguration`
+- New: `DefaultUnshieldedConfiguration`, `DefaultDustConfiguration`

--- a/docs/releases/v4.1.0/breaking-changes.md
+++ b/docs/releases/v4.1.0/breaking-changes.md
@@ -38,7 +38,7 @@ const isValid = await encryption.verifyPassword(password);
 ### Migration Steps
 
 1. Replace all `new StorageEncryption(password)` with `await StorageEncryption.create(password)`
-2. Replace all `new StorageEncryption(password, { existingSalt })` with `await StorageEncryption.create(password, { existingSalt })`
+2. Replace all `new StorageEncryption(password, existingSalt)` (positional `Buffer`) with `await StorageEncryption.create(password, { existingSalt })` (options object)
 3. Add `await` before every `encrypt()`, `decrypt()`, `decryptWithPassword()`, and `verifyPassword()` call
 4. Add `await` before `invalidateEncryptionCache()` calls (return type changed from `void` to `Promise<void>`)
 5. Convert synchronous `.toThrow()` test assertions to `await .rejects.toThrow()`
@@ -68,7 +68,7 @@ An ESLint rule is added that blocks direct imports from these packages.
 import { type Transaction, type UnbalancedTransaction } from '@midnight-ntwrk/ledger-v8';
 import { type ContractAddress } from '@midnight-ntwrk/compact-runtime';
 import { Contract } from '@midnight-ntwrk/compact-js';
-import { createEffectContract } from '@midnight-ntwrk/compact-js/effect-contract';
+import { createContract } from '@midnight-ntwrk/compact-js/effect/Contract';
 import { type Resource } from '@midnight-ntwrk/onchain-runtime-v3';
 import { type NetworkId } from '@midnight-ntwrk/platform-js';
 ```
@@ -79,7 +79,7 @@ import { type NetworkId } from '@midnight-ntwrk/platform-js';
 import { type Transaction, type UnbalancedTransaction } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { type ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
-import { createEffectContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect-contract';
+import { createContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
 import { type Resource } from '@midnight-ntwrk/midnight-js-protocol/onchain-runtime';
 import { type NetworkId } from '@midnight-ntwrk/midnight-js-protocol/platform-js';
 ```
@@ -95,11 +95,11 @@ import { type NetworkId } from '@midnight-ntwrk/midnight-js-protocol/platform-js
 | `@midnight-ntwrk/compact-runtime` | `@midnight-ntwrk/midnight-js-protocol/compact-runtime` |
 | `@midnight-ntwrk/compact-js` | `@midnight-ntwrk/midnight-js-protocol/compact-js` |
 | `@midnight-ntwrk/compact-js/effect` | `@midnight-ntwrk/midnight-js-protocol/compact-js/effect` |
-| `@midnight-ntwrk/compact-js/effect-contract` | `@midnight-ntwrk/midnight-js-protocol/compact-js/effect-contract` |
+| `@midnight-ntwrk/compact-js/effect/Contract` | `@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract` |
 | `@midnight-ntwrk/onchain-runtime-v3` | `@midnight-ntwrk/midnight-js-protocol/onchain-runtime` |
 | `@midnight-ntwrk/platform-js` | `@midnight-ntwrk/midnight-js-protocol/platform-js` |
-| `@midnight-ntwrk/platform-js/effect-configuration` | `@midnight-ntwrk/midnight-js-protocol/platform-js/effect-configuration` |
-| `@midnight-ntwrk/platform-js/effect-contract-address` | `@midnight-ntwrk/midnight-js-protocol/platform-js/effect-contract-address` |
+| `@midnight-ntwrk/platform-js/effect/Configuration` | `@midnight-ntwrk/midnight-js-protocol/platform-js/effect/Configuration` |
+| `@midnight-ntwrk/platform-js/effect/ContractAddress` | `@midnight-ntwrk/midnight-js-protocol/platform-js/effect/ContractAddress` |
 
 3. Remove direct protocol package dependencies from your `package.json`
 4. Run `yarn lint` to verify no direct imports remain

--- a/docs/releases/v4.1.0/migration-guide.md
+++ b/docs/releases/v4.1.0/migration-guide.md
@@ -51,13 +51,13 @@ import { type ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/compa
 **Before (v4.0.4):**
 ```typescript
 import { Contract } from '@midnight-ntwrk/compact-js';
-import { createEffectContract } from '@midnight-ntwrk/compact-js/effect-contract';
+import { createContract } from '@midnight-ntwrk/compact-js/effect/Contract';
 ```
 
 **After (v4.1.0):**
 ```typescript
 import { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
-import { createEffectContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect-contract';
+import { createContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
 ```
 
 ### 2.4 Onchain Runtime
@@ -97,13 +97,13 @@ If you use `StorageEncryption` directly (most consumers use `levelPrivateStatePr
 **Before (v4.0.4):**
 ```typescript
 const encryption = new StorageEncryption(password);
-const encryption2 = new StorageEncryption(password, { existingSalt: salt });
+const encryption2 = new StorageEncryption(password, salt); // positional Buffer
 ```
 
 **After (v4.1.0):**
 ```typescript
 const encryption = await StorageEncryption.create(password);
-const encryption2 = await StorageEncryption.create(password, { existingSalt: salt });
+const encryption2 = await StorageEncryption.create(password, { existingSalt: salt }); // options object
 ```
 
 ### 3.2 Add Await to Methods
@@ -146,7 +146,59 @@ const provider = await levelPrivateStateProvider({
 });
 ```
 
-## Step 5: Verify
+## Step 5: Audit Behaviour Changes
+
+Three non-breaking-API-but-observable behaviour changes ship in v4.1.0. Review your code if any apply.
+
+### 5.1 `verifyPassword` is now ~hundreds of ms (#883)
+
+`StorageEncryption.verifyPassword` previously compared a single-round SHA-256 of the password in microseconds. It now runs full PBKDF2 with `PBKDF2_ITERATIONS_V2` (600K iterations) and constant-time-compares the derived key against the in-memory `encryptionKey`. Wall-clock cost is hardware-dependent — expect roughly 200–400ms on commodity x86, ~100–200ms on Apple Silicon, and potentially >1s on the Noble pure-JS backend.
+
+**Impact for consumers of `levelPrivateStateProvider`:** the provider verifies the password on cold reads after a cache miss (e.g., the first state read of a session, or the first read after `invalidateEncryptionCache`). Subsequent reads from the same session hit the cached `encryptionKey` and do not re-run PBKDF2. If your dApp eagerly invalidates the cache or opens new sessions in a tight loop, restructure to verify once per session.
+
+Legacy V1 ciphertext (`PBKDF2_ITERATIONS_V1` = 100K iterations) continues to decrypt via `decryptWithPassword`; new writes use V2. **On-disk format is unchanged — no data migration is required.**
+
+### 5.2 `assertDefined` / `assertUndefined` falsy-value fix (#900)
+
+If your code relied on the buggy truthiness behaviour, switch to an explicit predicate:
+
+**Before (relied on bug):**
+```typescript
+// Was incorrectly rejecting 0
+assertDefined(value);
+if (value !== 0) {
+  // ...
+}
+```
+
+**After (v4.1.0):**
+```typescript
+// 0 is now correctly treated as defined — assert explicitly
+assertDefined(value);
+if (value > 0) {
+  // ...
+}
+```
+
+### 5.3 `decryptValue` fails closed (#885)
+
+`decryptValue` in `level-private-state-provider` now throws on unrecognized data instead of returning raw bytes. This only affects `rotateStorePassword`. If you wrap rotation, expect a distinct error during rotation if the LevelDB store contains plaintext entries that the password-rotation path encounters; both call sites already wrap with `{ cause }`.
+
+Read paths (`getState`, `getAllEntries`) are unchanged and continue to transparently migrate legacy plaintext.
+
+## Step 6: Audit Bug Fixes That May Affect You
+
+### 6.1 Shielded coin segment routing (#876, #877)
+
+If you build dApps that emit user-bound shielded coins from fallible-segment circuit operations (e.g., LP-token mints, conditional outputs), the wallet balancer no longer reports `InsufficientFunds` for the freshly-minted token color. **No action required** — this is a transparent fix to `createUnprovenLedgerCallTx`.
+
+If you depended on the buggy guaranteed-bucket fallback, your transactions will now route correctly. Cross-segment ambiguity throws explicitly — if your transcript leaves a commitment / nullifier in both halves, you will see an error rather than silent guaranteed routing.
+
+### 6.2 Browser-bundleable contracts (#869)
+
+`@midnight-ntwrk/midnight-js-contracts` no longer imports `node:fs` or `node:path`. If you were bundling for the browser with a polyfill stub for these modules, you can drop the stubs.
+
+## Step 7: Verify
 
 ```bash
 yarn lint       # Check protocol imports and code style
@@ -173,6 +225,10 @@ You are running in a non-secure context (not HTTPS or localhost). Either:
 ### Apollo Client type errors
 
 `@apollo/client` was upgraded from 3.x to 4.x. If you interact with Apollo types directly, consult the [Apollo Client 4 migration guide](https://www.apollographql.com/docs/react/migrating/apollo-client-3-to-4).
+
+### Error: "Unsafe name" or "Invalid semver" from a ZK provider or VersionManager (#875)
+
+`circuitId` is now validated by `assertSafeName` in both `node-zk-config-provider` and `fetch-zk-config-provider`. Compactc versions are validated by `assertSemVer` in `VersionManager`. If you pass user-controlled values, route them through these validators before the provider call so you can surface a friendly error to the user.
 
 ## Rollback Plan
 

--- a/docs/releases/v4.1.0/new-features.md
+++ b/docs/releases/v4.1.0/new-features.md
@@ -14,10 +14,10 @@ The migration is transparent for `levelPrivateStateProvider` consumers -- the pr
 
 ## 2. CryptoBackend Abstraction with Noble Fallback (#827)
 
-A pluggable `CryptoBackend` interface abstracts the cryptographic primitives used by `StorageEncryption`. Two implementations are provided:
+A pluggable `CryptoBackend` interface abstracts the cryptographic primitives used by `StorageEncryption`. Two backends ship with the package and are selected via the `cryptoBackend` config string — the concrete classes themselves are internal and are not exported from the package barrel:
 
-- **WebCryptoCryptoBackend** -- delegates to `globalThis.crypto.subtle` (default when available)
-- **NobleCryptoBackend** -- pure-JS implementation using `@noble/ciphers` (AES-256-GCM) and `@noble/hashes` (SHA-256, PBKDF2)
+- **`'webcrypto'`** -- delegates to `globalThis.crypto.subtle` (default when available)
+- **`'noble'`** -- pure-JS implementation using `@noble/ciphers` (AES-256-GCM) and `@noble/hashes` (SHA-256, PBKDF2)
 
 Auto-resolution: WebCrypto is preferred when `crypto.subtle` is available; Noble is used as fallback (e.g., React Native without a secure context).
 
@@ -97,11 +97,11 @@ New `@midnight-ntwrk/midnight-js-protocol` package wraps all 5 external protocol
 | `./compact-runtime` | `@midnight-ntwrk/compact-runtime` |
 | `./compact-js` | `@midnight-ntwrk/compact-js` |
 | `./compact-js/effect` | `@midnight-ntwrk/compact-js/effect` |
-| `./compact-js/effect-contract` | `@midnight-ntwrk/compact-js/effect-contract` |
+| `./compact-js/effect/Contract` | `@midnight-ntwrk/compact-js/effect/Contract` |
 | `./onchain-runtime` | `@midnight-ntwrk/onchain-runtime-v3` |
 | `./platform-js` | `@midnight-ntwrk/platform-js` |
-| `./platform-js/effect-configuration` | `@midnight-ntwrk/platform-js/effect-configuration` |
-| `./platform-js/effect-contract-address` | `@midnight-ntwrk/platform-js/effect-contract-address` |
+| `./platform-js/effect/Configuration` | `@midnight-ntwrk/platform-js/effect/Configuration` |
+| `./platform-js/effect/ContractAddress` | `@midnight-ntwrk/platform-js/effect/ContractAddress` |
 
 ### Usage
 
@@ -132,9 +132,39 @@ New testing infrastructure that enables e2e testing of wallet-delegated proving 
 ```typescript
 import { DAppConnectorWalletAdapter, DAppConnectorInitialAPI } from '@midnight-ntwrk/testkit-js';
 
-const walletAdapter = new DAppConnectorWalletAdapter(walletProvider);
+const walletAdapter = new DAppConnectorWalletAdapter(walletProvider, environmentConfiguration);
 const initialAPI = new DAppConnectorInitialAPI(walletAdapter, expectedNetworkId);
+// Optional 3rd arg overrides defaults: { rdns, name, icon, apiVersion }
 
 // Use with dapp-connector-proof-provider in e2e tests
 const proofProvider = await dappConnectorProofProvider(walletAdapter, zkConfigProvider, costModel);
+```
+
+---
+
+## 6. `assertSafeName` and `assertSemVer` utilities (#875)
+
+Two pure string validators land in `@midnight-ntwrk/midnight-js-utils` (re-exported as `security-utils`). Both are used internally to lock down path-traversal-prone inputs in the ZK providers and `VersionManager`, and are available to dApp code that needs to validate user-controlled filesystem / URL segments.
+
+### API
+
+```typescript
+import { assertSafeName, assertSemVer, MAX_SAFE_NAME_LENGTH } from '@midnight-ntwrk/midnight-js-utils';
+
+assertSafeName(name: string, label: string): void;
+assertSemVer(version: string, label: string): void;
+```
+
+- `assertSafeName` rejects empty strings, anything longer than `MAX_SAFE_NAME_LENGTH` (255), and names containing path separators, NUL, or traversal payloads (`..`, leading dots that compose into traversal).
+- `assertSemVer` rejects anything that does not match a strict semver-like grammar.
+
+### Usage
+
+```typescript
+import { assertSafeName } from '@midnight-ntwrk/midnight-js-utils';
+
+function loadArtifact(circuitId: string) {
+  assertSafeName(circuitId, 'circuitId');
+  return fs.readFileSync(path.join(artifactDir, circuitId));
+}
 ```

--- a/docs/releases/v4.1.0/release-notes.md
+++ b/docs/releases/v4.1.0/release-notes.md
@@ -1,6 +1,6 @@
 # Release Notes v4.1.0
 
-**Release Date:** April 22, 2026
+**Release Date:** May 19, 2026
 **Previous Version:** v4.0.4
 **Node.js Requirement:** >=22
 
@@ -29,26 +29,55 @@ New `@midnight-ntwrk/midnight-js-protocol` package wraps all 5 external protocol
 | `@midnight-ntwrk/onchain-runtime-v3` | `@midnight-ntwrk/midnight-js-protocol/onchain-runtime` |
 | `@midnight-ntwrk/platform-js` | `@midnight-ntwrk/midnight-js-protocol/platform-js` |
 
-Additional subpaths: `./compact-js/effect`, `./compact-js/effect-contract`, `./platform-js/effect-configuration`, `./platform-js/effect-contract-address`.
+Additional subpaths: `./compact-js/effect`, `./compact-js/effect/Contract`, `./platform-js/effect/Configuration`, `./platform-js/effect/ContractAddress`.
 
 ## Security
+
+### Replace SHA-256 password verifier with PBKDF2 (#883)
+
+`StorageEncryption` previously stored a single-round SHA-256 hash of the user's password in memory for cache-hit verification. An attacker who dumped process memory could brute-force the plaintext password offline at hardware speed, bypassing the 600K-iteration PBKDF2 protection used for the encryption key.
+
+The fast hash is removed entirely. `verifyPassword` now runs PBKDF2 with `PBKDF2_ITERATIONS_V2` (600K iterations) and constant-time-compares the derived key against the in-memory `encryptionKey`. On-disk format is unchanged — no data migration is required. Legacy V1 ciphertext continues to decrypt at 100K iterations through `decryptWithPassword`; new writes use V2.
+
+**Performance trade-off:** `verifyPassword` now takes hundreds of milliseconds (PBKDF2 cost — hardware-dependent, roughly 200–400ms on commodity x86; longer on the Noble pure-JS backend) instead of microseconds. Inside `levelPrivateStateProvider` this cost is paid on cold reads after a cache miss (e.g., first state read of a session, or after `invalidateEncryptionCache`) — subsequent reads in the same session hit the cached `encryptionKey` and do not re-run PBKDF2. This is the accepted security trade-off per audit.
+
+### Block path traversal in ZK providers and VersionManager (#875)
+
+Hardens filesystem and URL inputs against `../` traversal payloads. New pure-string validators are added to `@midnight-ntwrk/midnight-js-utils`:
+
+- `assertSafeName(name, label)` — rejects empty / over-long / traversal-bearing names
+- `assertSemVer(version, label)` — rejects non-semver strings
+
+Applied at three choke points:
+
+- `node-zk-config-provider` — validates `circuitId` before any `path.resolve`
+- `fetch-zk-config-provider` — validates `circuitId` and uses `encodeURIComponent` + `new URL()` for safe URL construction
+- `compact/version-manager` — `getVersionDir` is now the single validator for `versionExists`, `getCompactcPath`, and `removeVersion`, with a containment check before `rmSync` as defence in depth
+
+### Fail closed on unrecognized data in `decryptValue` (#885)
+
+`decryptValue` in `level-private-state-provider` previously logged a debug message and returned raw bytes when `StorageEncryption.isEncrypted()` returned false. This fail-open behaviour could mask storage corruption or plaintext injection into the LevelDB store during password rotation.
+
+`decryptValue` now throws on unrecognized data. The two call sites both live inside `rotateStorePassword` and already wrap errors with `{ cause }`, so the new error surfaces as a distinct failure during rotation. Read paths (`getState`, `getAllEntries`) do not call `decryptValue` — they check `StorageEncryption.isEncrypted()` directly and re-encrypt legacy plaintext in place, so transparent migration is preserved.
+
+The always-false `catch` in `isEncrypted` is also removed (it only hid programmer errors — `Buffer.from` on string input cannot throw).
 
 ### Update axios (#834)
 
 Security update to axios in testkit-js packages, addressing known vulnerabilities.
 
-### Fix critical protobufjs vulnerability (#854)
+### Dependabot security bumps (#854)
 
-Bumps `protobufjs` from 7.5.4 to 7.5.5, fixing CVE-2026-41242 (arbitrary code execution via `__proto__` poisoning in Message constructor and invalid characters in type names).
+Bumps `protobufjs` from 7.5.4 to 7.5.5 and `follow-redirects` from 1.15.11 to 1.16.0 via a grouped Dependabot update. See each package's upstream changelog for the underlying advisories.
 
 ## Features
 
 ### CryptoBackend abstraction with Noble fallback (#827)
 
-Introduces a pluggable `CryptoBackend` interface for `level-private-state-provider` with two implementations:
+Introduces a pluggable `CryptoBackend` interface for `level-private-state-provider` with two backends selected via the `cryptoBackend` config string (concrete implementation classes are internal — not exported from the package barrel):
 
-- **WebCryptoCryptoBackend** -- uses `globalThis.crypto.subtle` (default when available)
-- **NobleCryptoBackend** -- pure-JS fallback using `@noble/ciphers` and `@noble/hashes`
+- **`'webcrypto'`** -- uses `globalThis.crypto.subtle` (default when available)
+- **`'noble'`** -- pure-JS fallback using `@noble/ciphers` and `@noble/hashes`
 
 The backend is auto-resolved: WebCrypto is preferred when available, Noble is used as fallback (e.g., React Native without secure context).
 
@@ -59,10 +88,10 @@ const provider = await levelPrivateStateProvider({
 });
 ```
 
-New exports from `@midnight-ntwrk/midnight-js-level-private-state-provider`:
-- `CryptoBackend` (interface)
-- `CryptoBackendType` (`'webcrypto' | 'noble'`)
-- `StorageEncryptionOptions`
+New type exports from `@midnight-ntwrk/midnight-js-level-private-state-provider`:
+- `type CryptoBackend` (interface)
+- `type CryptoBackendType` (`'webcrypto' | 'noble'`)
+- `type StorageEncryptionOptions`
 
 ### Injectable levelFactory for React Native support (#827)
 
@@ -96,6 +125,29 @@ Enables e2e testing of the dapp-connector proving flow without a standalone proo
 
 ## Bug Fixes
 
+### Route shielded coins to the correct segment (#876, #877)
+
+`createUnprovenLedgerCallTx` previously bucketed all shielded outputs and inputs into the guaranteed Zswap offer regardless of which circuit segment produced them. User-bound shielded coins emitted from fallible-segment circuit operations (e.g., LP-token mints) therefore landed in the guaranteed offer, and the wallet balancer reported `InsufficientFunds` for the freshly-minted token color.
+
+The fix introduces `zswapStateToSegmentedOffer` in `packages/contracts/src/utils/zswap-utils.ts`, which builds separate guaranteed and fallible `UnprovenOffer` instances by matching each coin against `partitionedTranscript[i].effects`:
+
+- **Outputs** route by the union of `claimedShieldedReceives` ∪ `claimedShieldedSpends` (matches ledger v8 `construct.rs`)
+- **Inputs** route by nullifier match against `claimedNullifiers` (matches ledger v8)
+- **Transients** are detected before nullifier routing so transient callers (without chain state) continue to work
+- Cross-segment ambiguity now throws explicitly instead of silently falling back to the guaranteed offer
+
+New internal exports from `packages/contracts/src/utils/zswap-utils.ts`: `GUARANTEED_SEGMENT_NUMBER`, `FALLIBLE_SEGMENT_NUMBER`, `zswapStateToSegmentedOffer`. `zswapStateToOffer` is preserved as a thin wrapper for partial-transcript callers.
+
+### Correctly handle falsy values in `assertDefined` and `assertUndefined` (#900)
+
+`assertDefined` and `assertUndefined` in `@midnight-ntwrk/midnight-js-utils` used truthiness checks (`!value` / `value`), so valid falsy values — `0`, `''`, `false`, `0n` — were incorrectly rejected by `assertDefined` and incorrectly accepted by `assertUndefined`. Both helpers now use explicit `=== null || === undefined` checks. Closes #806.
+
+**Behaviour change:** if your code relied on the buggy truthiness behaviour (e.g., `assertDefined(value)` to also reject `0`), it must now use an explicit predicate.
+
+### Remove `fs`/`path` imports from `contracts/submit-tx` for browser compatibility (#869)
+
+`logTransaction()` in `packages/contracts/src/submit-tx.ts` previously imported `node:fs` and `node:path` to write a debug trace file. These Node-only imports prevented `@midnight-ntwrk/midnight-js-contracts` from being bundled for the browser. The fs/path imports and debug file writes are removed; `console` logging is preserved.
+
 ### Reject HTML responses in FetchZkConfigProvider (#785)
 
 SPA servers return `index.html` with HTTP 200 for non-existent artifact paths. Without Content-Type validation, HTML bytes were silently accepted as ZK key material, causing cryptic proof server failures. The fix validates the Content-Type header and rejects `text/html` responses with a descriptive error including the full URL and status code.
@@ -107,6 +159,14 @@ SPA servers return `index.html` with HTTP 200 for non-existent artifact paths. W
 - `graphql`: 16.13.1 -> 16.13.2 (#778)
 - `graphql-ws`: 6.0.7 -> 6.0.8 (#796)
 - `@noble/ciphers` and `@noble/hashes`: added (#827)
+
+### Toolchain
+- `compactc`: bumped to 0.31.0; contract test fixtures recompiled (#902)
+- `yarn`: 4.12.0 -> 4.14.1 (#878)
+
+### Testkit Dependencies
+- `@midnight-ntwrk/wallet-sdk` barrel: migrated to v1.0.0 — testkit-js now uses the new barrel package instead of individual `wallet-sdk-*` subpackages; aligns with ledger 8.0.3 binding marker renames and updated `InMemoryTransactionHistoryStorage` constructor. Two granular subpath imports remain (`wallet-sdk-prover-client/effect`, `wallet-sdk-shielded/v1`) where the barrel does not re-export. New default configs: `DefaultShieldedConfiguration`, `DefaultUnshieldedConfiguration`, `DefaultDustConfiguration`. (#862)
+- Indexer and node container images updated to match the current preview channel (#879)
 
 ### Development Dependencies Updated
 - `turbo`: 2.8.21 -> 2.9.5 (#845)
@@ -134,7 +194,7 @@ SPA servers return `index.html` with HTTP 200 for non-existent artifact paths. W
 
 - Rewrite CLAUDE.md as contributor guide (#747)
 - Add protocol package README and update main README (#835)
-- API documentation updates (#846, #841, #833, #826, #784)
+- API documentation updates (#884, #866, #846, #841, #833, #826, #784)
 
 ## Links
 


### PR DESCRIPTION
# Overview

Brings the v4.1.0 release notes up to date with the 12 commits merged since the original release-notes PR (#860), and corrects accuracy bugs caught reviewing the docs against the actual source.

## Post-#860 changes folded in

| PR | Change | Section |
|---|---|---|
| #876 / #877 | Route shielded coins to correct segment (fixes `InsufficientFunds` for LP-token mints from fallible-segment circuit ops) | Bug Fixes |
| #883 | Replace SHA-256 password verifier with PBKDF2 | Security |
| #875 | Block path traversal in ZK providers and `VersionManager`; new `assertSafeName` / `assertSemVer` utilities | Security + Features |
| #885 | Fail closed in `decryptValue` on unrecognized data | Security |
| #900 | Correctly handle falsy values in `assertDefined` / `assertUndefined` (closes #806) | Bug Fixes |
| #869 | Remove fs/path imports from contracts `submit-tx` (browser-bundleable) | Bug Fixes |
| #902 | compactc 0.31.0 + recompiled contract fixtures | Dependencies |
| #862 | Wallet-sdk barrel v1.0.0 migration in testkit-js | Dependencies |
| #879 | Indexer / node container images | Dependencies |
| #878 | Yarn 4.14.1 | Dependencies |
| #884, #866 | API documentation updates | Documentation |

## Accuracy fixes against the codebase

Verified against the actual source on `HEAD` and `v4.0.4`:

- **Protocol ACL subpaths**: `compact-js/effect/Contract`, `platform-js/effect/Configuration`, `platform-js/effect/ContractAddress` — capitalised, slash-separated. Matches `packages/protocol/package.json`. Previous docs had `effect-contract` etc. which do not exist as subpath exports.
- **`StorageEncryption.getSalt()`** is a method, not a `get salt(): Buffer` getter (both v4.0.4 and v4.1.0).
- **v4.0.4 constructor**: `new StorageEncryption(password, salt)` took a positional `Buffer`, not an `{ existingSalt }` options object. The `{ existingSalt }` shape only exists in v4.1.0 via `StorageEncryption.create()`.
- **`zswapStateToSegmentedOffer`** signature corrected to `(zswapLocalState, encryptionPublicKeyOrResolver, addressAndChainStateTuple?, partitionedTranscript = [undefined, undefined])` with `{ guaranteed: UnprovenOffer | undefined; fallible: UnprovenOffer | undefined }` return.
- **`DAppConnectorWalletAdapter`** requires `EnvironmentConfiguration` as its second arg.
- **`DAppConnectorInitialAPI`** takes `(ConnectedAPI, networkId, options?)` — not `(DAppConnectorWalletAdapter, expectedNetworkId)`.
- **PBKDF2 latency**: V1 (100K) vs V2 (600K) iteration paths now called out. "~300ms on every cache hit" replaced with hardware-dependent range and cold-read-after-cache-miss framing — the previous wording suggested every state read costs 300ms.
- **`WebCryptoCryptoBackend` / `NobleCryptoBackend`** are not exported from the barrel. Now framed as `'webcrypto' | 'noble'` config strings; only the `CryptoBackend` and `CryptoBackendType` *types* are exported.
- **README feature count** corrected from 5 to 6 — injectable `levelFactory` was missing from the README bullet list while it is documented as a distinct feature in `new-features.md`.
- **#854** reframed as a grouped Dependabot bump for `protobufjs` (7.5.4 -> 7.5.5) and `follow-redirects` (1.15.11 -> 1.16.0). The previous text named CVE-2026-41242 with a specific `__proto__`-poisoning mechanism that I could not verify against the commit or upstream changelogs — dropped to avoid an unverifiable claim shipping in release notes.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible) — N/A, docs-only
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README.md file (if relevant) — `docs/releases/v4.1.0/README.md` updated
- [x] Update documentation (if relevant)
- [x] No new todos introduced

## Test plan

- [ ] CI lints + builds green (docs-only PR; no code paths exercised)
- [ ] Markdown renders correctly on GitHub
- [ ] All listed PR numbers resolve to the right merged commits
- [ ] ACL subpath examples match `packages/protocol/package.json` exports

## Links

Follow-up to #860 (the original v4.1.0 release-notes PR).