### PR TITLE
ci: stabilize CD tests and limit e2e parallel runners

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -82,7 +82,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
 
       - name: Run tests
-        run: yarn test
+        run: yarn test --concurrency 1
         env:
           GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
 

--- a/.github/workflows/ci-testkit-js.yml
+++ b/.github/workflows/ci-testkit-js.yml
@@ -219,6 +219,7 @@ jobs:
     timeout-minutes: ${{ inputs.build_timeout }}
     strategy:
       fail-fast: false
+      max-parallel: 8
       matrix:
         test-file: ${{ fromJson(needs.generate-test-matrix.outputs.test-files) }}
     steps:

--- a/.github/workflows/ci-testkit-js.yml
+++ b/.github/workflows/ci-testkit-js.yml
@@ -219,7 +219,7 @@ jobs:
     timeout-minutes: ${{ inputs.build_timeout }}
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 6
       matrix:
         test-file: ${{ fromJson(needs.generate-test-matrix.outputs.test-files) }}
     steps:

--- a/packages/protocol/src/test/eslint-restriction.test.ts
+++ b/packages/protocol/src/test/eslint-restriction.test.ts
@@ -16,7 +16,7 @@
 import { resolve } from 'node:path';
 
 import { ESLint, type Linter } from 'eslint';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 const MONOREPO_ROOT = resolve(__dirname, '../../../..');
 const CONFIG_FILE = resolve(MONOREPO_ROOT, 'eslint.config.mjs');
@@ -44,6 +44,15 @@ const lintRestricted = async (code: string, filePath: string): Promise<Linter.Li
   const [result] = await eslint.lintText(code, { filePath });
   return result.messages.filter((m) => m.ruleId === RULE_ID);
 };
+
+// The first `lintText` call pays a one-time cost: loading the root ESLint
+// config, instantiating plugins, and warming `eslint-import-resolver-typescript`
+// which reads every `tsconfig.json` across the monorepo. Under parallel CI
+// load that can exceed the 5s per-test default. Warming once in a hook keeps
+// individual tests fast and deterministic.
+beforeAll(async () => {
+  await eslint.lintText(importStatement('@midnight-ntwrk/ledger-v8'), { filePath: CONSUMER_PATH });
+}, 60_000);
 
 describe('Protocol ACL: no-restricted-imports rule', () => {
   describe('flags direct imports from consumer packages', () => {


### PR DESCRIPTION
# Overview

Stabilizes two intermittent CI/CD problems:

1. **CD `Run tests` step timed out in `eslint-restriction.test.ts`** (protocol package). CD invoked `yarn test` without `--concurrency 1`, so turbo ran package test workspaces with its default fan-out of 10. The first `lintText` call in that file pays a one-time cost — loading the root ESLint config, instantiating plugins, and warming `eslint-import-resolver-typescript` which reads every `tsconfig.json` across the monorepo — and under that contention it exceeded the 5s per-test default timeout. CI did not see this because `ci-base.yml` already passes `--concurrency 1`.

2. **E2E matrix fan-out**. `e2e_tests` in `ci-testkit-js.yml` is generated dynamically from every `*.test.ts` file under `testkit-js/testkit-js-e2e/test` with no upper bound. Capping it reduces contention on shared CI infrastructure while preserving meaningful parallelism.

## Summary

- `.github/workflows/cd.yml`: append `--concurrency 1` to the `Run tests` step so CD matches CI's serialization of turbo test tasks.
- `packages/protocol/src/test/eslint-restriction.test.ts`: add a `beforeAll` that pre-warms the ESLint instance, so individual `it.each` iterations are not charged the one-time initialization cost. Bounded to a 60s hook timeout.
- `.github/workflows/ci-testkit-js.yml`: cap `jobs.e2e_tests.strategy.max-parallel` at `6`.

`fail-fast: false` is unchanged — all e2e test files still run even if one fails. The workflow-level `concurrency` group (per-PR cancellation) is also unchanged.

## Submission Checklist

- [x] Useful pull request description
- [x] Key commits have useful messages
- [x] Self-reviewed the diff
- [ ] All check jobs of the CI have succeeded
- [ ] Reviewer requested

## Test plan

- [x] `yarn vitest run src/test/eslint-restriction.test.ts` in `packages/protocol` passes (26/26) locally with the pre-warm in place
- [x] `yarn lint -- packages/protocol/src/test/eslint-restriction.test.ts` clean
- [ ] CD `Run tests` step succeeds on tag push
- [ ] At most 6 `E2E Tests` jobs run concurrently; the rest queue and start as slots free up
- [ ] Total e2e wall time remains within the existing `build_timeout` per-job budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)
