### PR TITLE
fix(midnight-js): warn on plain http/ws for non-loopback provider URLs

### DIFF
--- a/packages/http-client-proof-provider/src/http-client-proving-provider.ts
+++ b/packages/http-client-proof-provider/src/http-client-proving-provider.ts
@@ -20,6 +20,7 @@ import {
   type ProvingKeyMaterial,
   type ProvingProvider} from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { InvalidProtocolSchemeError, type ZKConfigProvider, zkConfigToProvingKeyMaterial } from '@midnight-ntwrk/midnight-js-types';
+import { warnIfInsecureRemoteUrl } from '@midnight-ntwrk/midnight-js-utils';
 import fetch from 'cross-fetch';
 import fetchBuilder from 'fetch-retry';
 
@@ -90,6 +91,8 @@ export const httpClientProvingProvider = <K extends string>(
   if (proveUrl.protocol !== 'http:' && proveUrl.protocol !== 'https:') {
     throw new InvalidProtocolSchemeError(proveUrl.protocol, ['http:', 'https:']);
   }
+
+  warnIfInsecureRemoteUrl(url, 'proof server URL');
 
   const timeout = config?.timeout ?? DEFAULT_TIMEOUT;
   const headers = config?.headers ?? {};

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -48,7 +48,7 @@ import {
   SegmentFail,
   SegmentSuccess,
   SucceedEntirely} from '@midnight-ntwrk/midnight-js-types';
-import { assertIsContractAddress } from '@midnight-ntwrk/midnight-js-utils';
+import { assertIsContractAddress, warnIfInsecureRemoteUrl } from '@midnight-ntwrk/midnight-js-utils';
 import { Buffer } from 'buffer';
 import fetch from 'cross-fetch';
 import { createClient } from 'graphql-ws';
@@ -440,6 +440,8 @@ const indexerPublicDataProviderInternal = (
   if (subscriptionURLObj.protocol !== 'ws:' && subscriptionURLObj.protocol !== 'wss:') {
     throw new InvalidProtocolSchemeError(subscriptionURLObj.protocol, ['ws:', 'wss:']);
   }
+  warnIfInsecureRemoteUrl(queryURL, 'indexer query URL');
+  warnIfInsecureRemoteUrl(subscriptionURL, 'indexer subscription URL');
   // Construct the Apollo client.
   const link = new HttpLink({ fetch, uri: queryURL });
   // Retry link with exponential backoff.

--- a/packages/utils/src/security-utils.ts
+++ b/packages/utils/src/security-utils.ts
@@ -17,6 +17,8 @@ export const MAX_SAFE_NAME_LENGTH = 255;
 
 const SAFE_NAME_PATTERN = /^[a-zA-Z0-9._-]+$/;
 const SEMVER_PATTERN = /^\d+\.\d+\.\d+(?:-[A-Za-z0-9._-]+)?$/;
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+const INSECURE_SCHEMES = new Set(['http:', 'ws:']);
 
 /**
  * Asserts that `name` is safe to use as a single path segment or URL path
@@ -57,4 +59,40 @@ export function assertSemVer(version: string, label: string): void {
   if (!SEMVER_PATTERN.test(version)) {
     throw new Error(`Invalid ${label}: ${JSON.stringify(version)}`);
   }
+}
+
+/**
+ * Emits a `console.warn` when `url` uses an unencrypted scheme (`http:` or `ws:`)
+ * targeting a non-loopback host. No-op for encrypted schemes (`https:`, `wss:`),
+ * other schemes, and unparseable input.
+ *
+ * Intended to be called once at provider-factory construction time so
+ * misconfigured remote endpoints surface immediately rather than after sensitive
+ * payloads are transmitted in clear text. As a diagnostic helper it never throws —
+ * an unparseable URL will produce errors through other channels (the protocol
+ * checks at every call site already throw `InvalidProtocolSchemeError`), and
+ * crashing the factory from a warning helper would be worse than silence.
+ *
+ * @param url   An absolute URL string to inspect (e.g. `https://indexer.example/graphql`).
+ * @param label Human-readable label used in the warning (e.g. "indexer query URL").
+ */
+export function warnIfInsecureRemoteUrl(url: string, label: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return;
+  }
+  if (!INSECURE_SCHEMES.has(parsed.protocol)) {
+    return;
+  }
+  if (LOOPBACK_HOSTNAMES.has(parsed.hostname)) {
+    return;
+  }
+  const scheme = parsed.protocol.replace(/:$/, '');
+  const secureReplacement = scheme === 'http' ? 'https://' : 'wss://';
+  console.warn(
+    `midnight-js: ${label} uses unencrypted ${scheme}:// for non-loopback host '${parsed.hostname}'; ` +
+      `sensitive data may be transmitted in clear text. Use ${secureReplacement} in production.`
+  );
 }

--- a/packages/utils/src/test/security-utils.test.ts
+++ b/packages/utils/src/test/security-utils.test.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
-import { assertSafeName, assertSemVer, MAX_SAFE_NAME_LENGTH } from '../security-utils';
+import { assertSafeName, assertSemVer, MAX_SAFE_NAME_LENGTH, warnIfInsecureRemoteUrl } from '../security-utils';
 
 describe('assertSafeName', () => {
   describe('accepts valid names', () => {
@@ -127,5 +127,109 @@ describe('assertSemVer', () => {
     it('includes the label in the error', () => {
       expect(() => assertSemVer('not-a-version', 'compactc version')).toThrow(/Invalid compactc version/);
     });
+  });
+});
+
+describe('warnIfInsecureRemoteUrl', () => {
+  let warnSpy: MockInstance<typeof console.warn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe('does not warn for encrypted schemes', () => {
+    it.each([
+      'https://example.com',
+      'https://indexer.testnet.midnight.network/graphql',
+      'wss://example.com',
+      'wss://indexer.testnet.midnight.network/graphql'
+    ])('does not warn for %s', (url) => {
+      warnIfInsecureRemoteUrl(url, 'test URL');
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('does not warn for unknown schemes', () => {
+    it.each([
+      'file:///tmp/foo',
+      'ftp://example.com',
+      'data:text/plain,hello'
+    ])('does not warn for %s', (url) => {
+      warnIfInsecureRemoteUrl(url, 'test URL');
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('does not warn for malformed input', () => {
+    it.each([
+      'not a url',
+      '',
+      '://missing-scheme'
+    ])('does not throw and does not warn for %s', (url) => {
+      expect(() => warnIfInsecureRemoteUrl(url, 'test URL')).not.toThrow();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('does not warn for loopback hosts on plain schemes', () => {
+    it.each([
+      'http://localhost:8080/graphql',
+      'http://localhost/',
+      'http://127.0.0.1/',
+      'http://127.0.0.1:6300/check',
+      'http://[::1]/',
+      'http://[::1]:8080/graphql',
+      'ws://localhost:8080/',
+      'ws://127.0.0.1/',
+      'ws://[::1]/'
+    ])('does not warn for %s', (url) => {
+      warnIfInsecureRemoteUrl(url, 'test URL');
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('warns for non-loopback hosts on plain schemes', () => {
+    it.each([
+      'http://indexer.testnet.midnight.network',
+      'http://indexer.testnet.midnight.network/graphql',
+      'http://proof.testnet.midnight.network/',
+      'http://192.168.1.5',
+      'http://10.0.0.1/',
+      'ws://indexer.testnet.midnight.network',
+      'ws://indexer.testnet.midnight.network/graphql'
+    ])('warns for %s', (url) => {
+      warnIfInsecureRemoteUrl(url, 'test URL');
+      expect(warnSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('warning includes the supplied label and the host', () => {
+    warnIfInsecureRemoteUrl('http://indexer.testnet.midnight.network/graphql', 'indexer query URL');
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const message = String(warnSpy.mock.calls[0][0]);
+    expect(message).toContain('indexer query URL');
+    expect(message).toContain('indexer.testnet.midnight.network');
+  });
+
+  it('warning for http:// suggests https:// as the secure replacement', () => {
+    warnIfInsecureRemoteUrl('http://indexer.testnet.midnight.network', 'indexer query URL');
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const message = String(warnSpy.mock.calls[0][0]);
+    expect(message).toContain('http://');
+    expect(message).toContain('https://');
+    expect(message).not.toContain('wss://');
+  });
+
+  it('warning for ws:// suggests wss:// as the secure replacement', () => {
+    warnIfInsecureRemoteUrl('ws://indexer.testnet.midnight.network', 'indexer subscription URL');
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const message = String(warnSpy.mock.calls[0][0]);
+    expect(message).toContain('ws://');
+    expect(message).toContain('wss://');
+    expect(message).not.toContain('https://');
   });
 });


### PR DESCRIPTION
# Overview

`IndexerPublicDataProvider` and `HttpClientProofProvider` accepted arbitrary URLs but did not warn when plain `http://` (or `ws://` for the indexer subscription endpoint) was used against a remote host. Sensitive payloads — transaction bodies, proof requests, contract state queries — could be transmitted in clear text without the dApp developer noticing.

This PR adds a `warnIfInsecureRemoteUrl` helper in `midnight-js-utils` that emits a single `console.warn` at provider-factory construction when the scheme is `http:`/`ws:` and the hostname is not `localhost`, `127.0.0.1`, or `::1`. The connection itself is not blocked. The helper is wired into both provider factories.

## What changed

- New `warnIfInsecureRemoteUrl(url, label)` helper in `packages/utils/src/security-utils.ts`. Emits one `console.warn` when the scheme is unencrypted (`http:`, `ws:`) and the host is non-loopback. No-op for encrypted schemes (`https:`, `wss:`), other schemes, and unparseable input.
- Three call sites at provider-factory construction time (eager, fires once per factory build, not per request):
  - `indexerPublicDataProviderInternal` — for both `queryURL` and `subscriptionURL`, after the existing `InvalidProtocolSchemeError` check.
  - `httpClientProvingProvider` — for the proof server URL, after the existing protocol checks. This also covers `httpClientProofProvider` which delegates to it.
- Warning message is scheme-aware: `http://` is told to use `https://`, `ws://` is told to use `wss://`.
- The helper is non-throwing. Malformed URLs no-op silently so a diagnostic warning helper never crashes provider construction.

## Why these decisions

- **`console.warn`, not `LoggerProvider`.** The factory signatures do not currently accept a logger, and the warning fires exactly once at startup. Plumbing `LoggerProvider` through every provider factory would change public API for a single informational line.
- **Loopback set: `localhost`, `127.0.0.1`, `::1`, `[::1]`.** Strictest reasonable definition of "local". RFC1918 private ranges (10.x, 192.168.x, 172.16–31.x) are intentionally not whitelisted — a staging indexer on a VPN-routed private IP is still a remote host and the developer should know.
- **No opt-out flag.** The connection still proceeds; the warning is informational. Adding a "silence" toggle would create a footgun.
- **Eager check at construction, not per-request.** Surfaces the misconfig once, in the construction stack trace, instead of flooding logs.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README.md file (if relevant) — N/A
- [x] Update documentation (if relevant) — N/A
- [x] No new todos introduced

## Test plan

- [x] Tests written first (TDD), verified red before fix
- [x] All existing tests pass (no regressions in `midnight-js-utils`, `indexer-public-data-provider`, `http-client-proof-provider`)
- [x] Lint clean, build succeeds
- [x] New tests cover: encrypted schemes silent; loopback (incl. `[::1]`, ports, paths) silent; non-loopback http/ws warns; RFC1918 warns; unknown schemes (`file:`, `ftp:`, `data:`) silent; malformed URLs do not throw and do not warn; warning message identifies the correct secure replacement scheme and includes the label and host.

## Links

Closes #818