### PR TITLE
fix(midnight-js): apply full password policy to export operations

### DIFF
--- a/packages/level-private-state-provider/package.json
+++ b/packages/level-private-state-provider/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
     "@midnight-ntwrk/midnight-js-types": "workspace:*",
+    "@midnight-ntwrk/midnight-js-utils": "workspace:*",
     "@noble/ciphers": "^2.0.0",
     "@noble/hashes": "^2.0.0",
     "abstract-level": "^3.0.0",

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -33,6 +33,7 @@ import {
   type SigningKeyExport,
   SigningKeyExportError
 } from '@midnight-ntwrk/midnight-js-types';
+import { validatePassword } from '@midnight-ntwrk/midnight-js-utils';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex, randomBytes } from '@noble/hashes/utils.js';
 import { type AbstractLevel, type AbstractSublevel } from 'abstract-level';
@@ -41,7 +42,12 @@ import { Level } from 'level';
 import * as superjson from 'superjson';
 
 import type { CryptoBackendType } from './crypto-backend';
-import { decryptValue, getPasswordFromProvider, type PrivateStoragePasswordProvider, StorageEncryption } from './storage-encryption';
+import {
+  decryptValue,
+  getPasswordFromProvider,
+  type PrivateStoragePasswordProvider,
+  StorageEncryption
+} from './storage-encryption';
 
 /**
  * The default name of the indexedDB database for Midnight.
@@ -598,39 +604,31 @@ interface SigningKeyPayload {
 const CURRENT_EXPORT_VERSION = 1;
 const SUPPORTED_EXPORT_VERSIONS = [1];
 const EXPECTED_SALT_LENGTH = 64; // 32 bytes as hex
-const MIN_PASSWORD_LENGTH = 16;
 
-/**
- * Validates a custom password meets minimum requirements.
- */
 const validateExportPassword = (password: string): void => {
-  if (password.length < MIN_PASSWORD_LENGTH) {
-    throw new PrivateStateExportError(
-      `Password must be at least ${MIN_PASSWORD_LENGTH} characters`
-    );
+  try {
+    validatePassword(password);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid export password';
+    throw new PrivateStateExportError(message, { cause: error });
   }
 };
 
-/**
- * Validates the salt format and length.
- */
+const validateSigningKeyExportPassword = (password: string): void => {
+  try {
+    validatePassword(password);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid export password';
+    throw new SigningKeyExportError(message, { cause: error });
+  }
+};
+
 const validateSalt = (salt: string): void => {
   if (salt.length !== EXPECTED_SALT_LENGTH) {
     throw new InvalidExportFormatError('Invalid salt length');
   }
   if (!/^[0-9a-fA-F]+$/.test(salt)) {
     throw new InvalidExportFormatError('Invalid salt format');
-  }
-};
-
-/**
- * Validates a custom signing key export password meets minimum requirements.
- */
-const validateSigningKeyExportPassword = (password: string): void => {
-  if (password.length < MIN_PASSWORD_LENGTH) {
-    throw new SigningKeyExportError(
-      `Password must be at least ${MIN_PASSWORD_LENGTH} characters`
-    );
   }
 };
 

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -82,7 +82,20 @@ export interface LevelPrivateStateProviderConfig {
   readonly signingKeyStoreName: string;
   /**
    * Provider function that returns the password used for encrypting private state.
-   * The password must be at least 16 characters long.
+   *
+   * The password must satisfy the strength policy enforced by `validatePassword`
+   * from `@midnight-ntwrk/midnight-js-utils`:
+   * - minimum 16 characters
+   * - at least 3 of: uppercase, lowercase, digits, special characters
+   * - no more than 3 consecutive identical characters
+   * - no sequential patterns of length 4+ (e.g. `1234`, `abcd`)
+   *
+   * The same policy is applied to custom passwords passed to
+   * {@link PrivateStateProvider.exportPrivateStates} / `exportSigningKeys` and
+   * their `importPrivateStates` / `importSigningKeys` counterparts. Violations
+   * surface as `PasswordValidationError` on storage paths, or wrapped as
+   * `PrivateStateExportError` / `SigningKeyExportError` (with `cause`) on
+   * export/import paths.
    *
    * SECURITY: Use a strong, secret password. Never use public key material
    * or other non-secret values as the password source.

--- a/packages/level-private-state-provider/src/storage-encryption.ts
+++ b/packages/level-private-state-provider/src/storage-encryption.ts
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import { validatePassword } from '@midnight-ntwrk/midnight-js-utils';
 import { Buffer } from 'buffer';
 
 import { type CryptoBackend, type CryptoBackendType, resolveCryptoBackend } from './crypto-backend';
@@ -206,100 +207,6 @@ export class StorageEncryption {
     return Buffer.from(this.salt);
   }
 }
-
-const MIN_PASSWORD_LENGTH = 16;
-const MIN_CHARACTER_CLASSES = 3;
-const MAX_CONSECUTIVE_REPEATED = 3;
-const MIN_SEQUENTIAL_LENGTH = 4;
-
-const countCharacterClasses = (password: string): number => {
-  let count = 0;
-  if (/[a-z]/.test(password)) count++;
-  if (/[A-Z]/.test(password)) count++;
-  if (/[0-9]/.test(password)) count++;
-  if (/[^a-zA-Z0-9]/.test(password)) count++;
-  return count;
-};
-
-const hasRepeatedCharacters = (password: string): boolean => {
-  let consecutiveCount = 1;
-  for (let i = 1; i < password.length; i++) {
-    if (password[i] === password[i - 1]) {
-      consecutiveCount++;
-      if (consecutiveCount > MAX_CONSECUTIVE_REPEATED) {
-        return true;
-      }
-    } else {
-      consecutiveCount = 1;
-    }
-  }
-  return false;
-};
-
-const hasSequentialPattern = (password: string): boolean => {
-  const lowerPassword = password.toLowerCase();
-
-  for (let i = 0; i <= lowerPassword.length - MIN_SEQUENTIAL_LENGTH; i++) {
-    let ascendingCount = 1;
-    let descendingCount = 1;
-
-    for (let j = 1; j < MIN_SEQUENTIAL_LENGTH; j++) {
-      const currentCode = lowerPassword.charCodeAt(i + j);
-      const prevCode = lowerPassword.charCodeAt(i + j - 1);
-
-      if (currentCode === prevCode + 1) {
-        ascendingCount++;
-      } else {
-        ascendingCount = 1;
-      }
-
-      if (currentCode === prevCode - 1) {
-        descendingCount++;
-      } else {
-        descendingCount = 1;
-      }
-
-      if (ascendingCount >= MIN_SEQUENTIAL_LENGTH || descendingCount >= MIN_SEQUENTIAL_LENGTH) {
-        return true;
-      }
-    }
-  }
-  return false;
-};
-
-const validatePassword = (password: string): void => {
-  if (!password) {
-    throw new Error(
-      'Password is required for private state encryption.\n' +
-        'Please provide a password via privateStoragePasswordProvider in the configuration.'
-    );
-  }
-
-  if (password.length < MIN_PASSWORD_LENGTH) {
-    throw new Error(
-      `Password must be at least ${MIN_PASSWORD_LENGTH} characters long. Current length: ${password.length}`
-    );
-  }
-
-  if (hasRepeatedCharacters(password)) {
-    throw new Error(
-      `Password contains too many repeated characters (more than ${MAX_CONSECUTIVE_REPEATED} identical in a row)`
-    );
-  }
-
-  const characterClasses = countCharacterClasses(password);
-  if (characterClasses < MIN_CHARACTER_CLASSES) {
-    throw new Error(
-      `Password must contain at least ${MIN_CHARACTER_CLASSES} of: uppercase letters, lowercase letters, digits, special characters. Found: ${characterClasses}`
-    );
-  }
-
-  if (hasSequentialPattern(password)) {
-    throw new Error(
-      "Password contains sequential patterns (e.g., '1234', 'abcd'). Use a more random password"
-    );
-  }
-};
 
 export const getPasswordFromProvider = async (provider: PrivateStoragePasswordProvider): Promise<string> => {
   const password = await provider();

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -26,6 +26,7 @@ import {
   type SigningKeyExport,
   SigningKeyExportError
 } from '@midnight-ntwrk/midnight-js-types';
+import { PasswordValidationError } from '@midnight-ntwrk/midnight-js-utils';
 import * as crypto from 'crypto';
 import { Level } from 'level';
 import * as superjson from 'superjson';
@@ -463,6 +464,57 @@ describe('Level Private State Provider', (): void => {
       await expect(
         db.importPrivateStates(exportData, { password: 'short' })
       ).rejects.toThrow(PrivateStateExportError);
+    });
+
+    describe('strict password policy on export/import', () => {
+      const captureError = async (action: () => Promise<unknown>): Promise<unknown> => {
+        try {
+          await action();
+        } catch (error) {
+          return error;
+        }
+        return undefined;
+      };
+
+      test.each([
+        ['too_short', 'short'],
+        ['repeated_characters', 'aaaaaaaaaaaaaaaa'],
+        ['insufficient_classes', 'abcdefghjkmnpqrs'],
+        ['sequential_pattern', 'Password-123456!']
+      ])('exportPrivateStates rejects weak password (%s)', async (reason, weakPassword) => {
+        const db = levelPrivateStateProvider<PID, PS>(testConfig);
+        db.setContractAddress(TEST_CONTRACT_ADDRESS);
+        await db.set('stringValue', testStates.stringValue);
+
+        const error = await captureError(() =>
+          db.exportPrivateStates({ password: weakPassword })
+        );
+
+        expect(error).toBeInstanceOf(PrivateStateExportError);
+        expect((error as PrivateStateExportError).cause).toBeInstanceOf(PasswordValidationError);
+        expect(((error as PrivateStateExportError).cause as PasswordValidationError).reason).toBe(reason);
+      });
+
+      test.each([
+        ['too_short', 'short'],
+        ['repeated_characters', 'aaaaaaaaaaaaaaaa'],
+        ['insufficient_classes', 'abcdefghjkmnpqrs'],
+        ['sequential_pattern', 'Password-123456!']
+      ])('importPrivateStates rejects weak password (%s)', async (reason, weakPassword) => {
+        const db = levelPrivateStateProvider<PID, PS>(testConfig);
+        db.setContractAddress(TEST_CONTRACT_ADDRESS);
+        await db.set('stringValue', testStates.stringValue);
+        const exportData = await db.exportPrivateStates({ password: EXPORT_PASSWORD });
+        await db.clear();
+
+        const error = await captureError(() =>
+          db.importPrivateStates(exportData, { password: weakPassword })
+        );
+
+        expect(error).toBeInstanceOf(PrivateStateExportError);
+        expect((error as PrivateStateExportError).cause).toBeInstanceOf(PasswordValidationError);
+        expect(((error as PrivateStateExportError).cause as PasswordValidationError).reason).toBe(reason);
+      });
     });
 
     test('throws ImportConflictError when conflict strategy is error (default)', async () => {
@@ -907,7 +959,7 @@ describe('Level Private State Provider', (): void => {
   });
 
   describe('Signing Key Export/Import', () => {
-    const EXPORT_PASSWORD = 'export-test-password-1234';
+    const EXPORT_PASSWORD = 'Sk-Export-Test-Pass9!';
     const CONTRACT_ADDRESS_1 = 'contract-address-1' as ContractAddress;
     const CONTRACT_ADDRESS_2 = 'contract-address-2' as ContractAddress;
 
@@ -965,7 +1017,7 @@ describe('Level Private State Provider', (): void => {
       await db.clearSigningKeys();
 
       await expect(
-        db.importSigningKeys(exportData, { password: 'wrong-password-12345' })
+        db.importSigningKeys(exportData, { password: 'Wrong-Pass8-Test!!' })
       ).rejects.toThrow(ExportDecryptionError);
     });
 
@@ -996,6 +1048,55 @@ describe('Level Private State Provider', (): void => {
       await expect(
         db.importSigningKeys(exportData, { password: 'short' })
       ).rejects.toThrow(SigningKeyExportError);
+    });
+
+    describe('strict password policy on signing keys export/import', () => {
+      const captureError = async (action: () => Promise<unknown>): Promise<unknown> => {
+        try {
+          await action();
+        } catch (error) {
+          return error;
+        }
+        return undefined;
+      };
+
+      test.each([
+        ['too_short', 'short'],
+        ['repeated_characters', 'aaaaaaaaaaaaaaaa'],
+        ['insufficient_classes', 'abcdefghjkmnpqrs'],
+        ['sequential_pattern', 'Password-123456!']
+      ])('exportSigningKeys rejects weak password (%s)', async (reason, weakPassword) => {
+        const db = levelPrivateStateProvider<PID, PS>(testConfig);
+        await db.setSigningKey(CONTRACT_ADDRESS_1, sampleSigningKey());
+
+        const error = await captureError(() =>
+          db.exportSigningKeys({ password: weakPassword })
+        );
+
+        expect(error).toBeInstanceOf(SigningKeyExportError);
+        expect((error as SigningKeyExportError).cause).toBeInstanceOf(PasswordValidationError);
+        expect(((error as SigningKeyExportError).cause as PasswordValidationError).reason).toBe(reason);
+      });
+
+      test.each([
+        ['too_short', 'short'],
+        ['repeated_characters', 'aaaaaaaaaaaaaaaa'],
+        ['insufficient_classes', 'abcdefghjkmnpqrs'],
+        ['sequential_pattern', 'Password-123456!']
+      ])('importSigningKeys rejects weak password (%s)', async (reason, weakPassword) => {
+        const db = levelPrivateStateProvider<PID, PS>(testConfig);
+        await db.setSigningKey(CONTRACT_ADDRESS_1, sampleSigningKey());
+        const exportData = await db.exportSigningKeys({ password: EXPORT_PASSWORD });
+        await db.clearSigningKeys();
+
+        const error = await captureError(() =>
+          db.importSigningKeys(exportData, { password: weakPassword })
+        );
+
+        expect(error).toBeInstanceOf(SigningKeyExportError);
+        expect((error as SigningKeyExportError).cause).toBeInstanceOf(PasswordValidationError);
+        expect(((error as SigningKeyExportError).cause as PasswordValidationError).reason).toBe(reason);
+      });
     });
 
     test('throws ImportConflictError when conflict strategy is error (default)', async () => {
@@ -1168,7 +1269,7 @@ describe('Level Private State Provider', (): void => {
     });
 
     describe('malformed data edge cases', () => {
-      const VALID_PASSWORD = 'valid-password-for-test';
+      const VALID_PASSWORD = 'Valid-Pass9-Test!@';
 
       test('throws ExportDecryptionError for garbage base64 payload', async () => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -26,7 +26,7 @@ import {
   type SigningKeyExport,
   SigningKeyExportError
 } from '@midnight-ntwrk/midnight-js-types';
-import { PasswordValidationError } from '@midnight-ntwrk/midnight-js-utils';
+import { PasswordValidationError,type PasswordValidationFailure } from '@midnight-ntwrk/midnight-js-utils';
 import * as crypto from 'crypto';
 import { Level } from 'level';
 import * as superjson from 'superjson';
@@ -34,6 +34,28 @@ import { vi } from 'vitest';
 
 import { type DatabaseLevel, levelPrivateStateProvider, migrateToAccountScoped } from '../index';
 import { StorageEncryption } from '../storage-encryption';
+
+const captureError = async (action: () => Promise<unknown>): Promise<unknown> => {
+  try {
+    await action();
+  } catch (error) {
+    return error;
+  }
+  return undefined;
+};
+
+const expectPasswordValidationCause = (
+  error: unknown,
+  reason: PasswordValidationFailure
+): void => {
+  expect(error).toBeInstanceOf(Error);
+  if (error instanceof Error) {
+    expect(error.cause).toBeInstanceOf(PasswordValidationError);
+    if (error.cause instanceof PasswordValidationError) {
+      expect(error.cause.reason).toBe(reason);
+    }
+  }
+};
 
 describe('Level Private State Provider', (): void => {
   const TEST_PASSWORD = 'Test-Storage-Pass8!';
@@ -467,16 +489,7 @@ describe('Level Private State Provider', (): void => {
     });
 
     describe('strict password policy on export/import', () => {
-      const captureError = async (action: () => Promise<unknown>): Promise<unknown> => {
-        try {
-          await action();
-        } catch (error) {
-          return error;
-        }
-        return undefined;
-      };
-
-      test.each([
+      test.each<[PasswordValidationFailure, string]>([
         ['too_short', 'short'],
         ['repeated_characters', 'aaaaaaaaaaaaaaaa'],
         ['insufficient_classes', 'abcdefghjkmnpqrs'],
@@ -491,11 +504,10 @@ describe('Level Private State Provider', (): void => {
         );
 
         expect(error).toBeInstanceOf(PrivateStateExportError);
-        expect((error as PrivateStateExportError).cause).toBeInstanceOf(PasswordValidationError);
-        expect(((error as PrivateStateExportError).cause as PasswordValidationError).reason).toBe(reason);
+        expectPasswordValidationCause(error, reason);
       });
 
-      test.each([
+      test.each<[PasswordValidationFailure, string]>([
         ['too_short', 'short'],
         ['repeated_characters', 'aaaaaaaaaaaaaaaa'],
         ['insufficient_classes', 'abcdefghjkmnpqrs'],
@@ -512,8 +524,7 @@ describe('Level Private State Provider', (): void => {
         );
 
         expect(error).toBeInstanceOf(PrivateStateExportError);
-        expect((error as PrivateStateExportError).cause).toBeInstanceOf(PasswordValidationError);
-        expect(((error as PrivateStateExportError).cause as PasswordValidationError).reason).toBe(reason);
+        expectPasswordValidationCause(error, reason);
       });
     });
 
@@ -1051,16 +1062,7 @@ describe('Level Private State Provider', (): void => {
     });
 
     describe('strict password policy on signing keys export/import', () => {
-      const captureError = async (action: () => Promise<unknown>): Promise<unknown> => {
-        try {
-          await action();
-        } catch (error) {
-          return error;
-        }
-        return undefined;
-      };
-
-      test.each([
+      test.each<[PasswordValidationFailure, string]>([
         ['too_short', 'short'],
         ['repeated_characters', 'aaaaaaaaaaaaaaaa'],
         ['insufficient_classes', 'abcdefghjkmnpqrs'],
@@ -1074,11 +1076,10 @@ describe('Level Private State Provider', (): void => {
         );
 
         expect(error).toBeInstanceOf(SigningKeyExportError);
-        expect((error as SigningKeyExportError).cause).toBeInstanceOf(PasswordValidationError);
-        expect(((error as SigningKeyExportError).cause as PasswordValidationError).reason).toBe(reason);
+        expectPasswordValidationCause(error, reason);
       });
 
-      test.each([
+      test.each<[PasswordValidationFailure, string]>([
         ['too_short', 'short'],
         ['repeated_characters', 'aaaaaaaaaaaaaaaa'],
         ['insufficient_classes', 'abcdefghjkmnpqrs'],
@@ -1094,8 +1095,7 @@ describe('Level Private State Provider', (): void => {
         );
 
         expect(error).toBeInstanceOf(SigningKeyExportError);
-        expect((error as SigningKeyExportError).cause).toBeInstanceOf(PasswordValidationError);
-        expect(((error as SigningKeyExportError).cause as PasswordValidationError).reason).toBe(reason);
+        expectPasswordValidationCause(error, reason);
       });
     });
 

--- a/packages/level-private-state-provider/src/test/storage-encryption.test.ts
+++ b/packages/level-private-state-provider/src/test/storage-encryption.test.ts
@@ -15,9 +15,26 @@
 
 import { createHash } from 'node:crypto';
 
+import { PasswordValidationError,type PasswordValidationFailure } from '@midnight-ntwrk/midnight-js-utils';
 import { Buffer } from 'buffer';
 
 import { decryptValue, getPasswordFromProvider, StorageEncryption, timingSafeEqual } from '../storage-encryption';
+
+const expectPasswordValidationFailure = async (
+  provider: () => string | Promise<string>,
+  reason: PasswordValidationFailure
+): Promise<void> => {
+  let caught: unknown;
+  try {
+    await getPasswordFromProvider(provider);
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(PasswordValidationError);
+  if (caught instanceof PasswordValidationError) {
+    expect(caught.reason).toBe(reason);
+  }
+};
 
 const getInstanceFieldValues = (encryption: StorageEncryption): unknown[] =>
   Object.values(encryption as unknown as Record<string, unknown>);
@@ -334,16 +351,12 @@ describe('StorageEncryption', () => {
   });
 
   describe('getPasswordFromProvider', () => {
-    test('throws error when password provider returns empty string', async () => {
-      const provider = () => '';
-
-      await expect(getPasswordFromProvider(provider)).rejects.toThrow('Password is required');
+    test('propagates PasswordValidationError when provider returns empty string', async () => {
+      await expectPasswordValidationFailure(() => '', 'missing');
     });
 
-    test('throws error when password is too short', async () => {
-      const provider = () => 'short';
-
-      await expect(getPasswordFromProvider(provider)).rejects.toThrow('must be at least 16 characters long');
+    test('propagates PasswordValidationError when password is too short', async () => {
+      await expectPasswordValidationFailure(() => 'short', 'too_short');
     });
 
     test('returns password when valid', async () => {
@@ -365,130 +378,53 @@ describe('StorageEncryption', () => {
     });
 
     describe('character class requirements', () => {
-      test('rejects password with only lowercase letters', async () => {
-        const provider = () => 'abcdefghijklmnopqr';
-
-        await expect(getPasswordFromProvider(provider)).rejects.toThrow(
-          'Password must contain at least 3 of: uppercase letters, lowercase letters, digits, special characters'
-        );
+      test.each([
+        'abcdefghijklmnopqr',
+        'ABCDEFGHIJKLMNOPQR',
+        '1234567890123456',
+        'abcdefgh12345678'
+      ])('rejects password "%s" with reason insufficient_classes', async (password) => {
+        await expectPasswordValidationFailure(() => password, 'insufficient_classes');
       });
 
-      test('rejects password with only uppercase letters', async () => {
-        const provider = () => 'ABCDEFGHIJKLMNOPQR';
-
-        await expect(getPasswordFromProvider(provider)).rejects.toThrow(
-          'Password must contain at least 3 of: uppercase letters, lowercase letters, digits, special characters'
-        );
-      });
-
-      test('rejects password with only digits', async () => {
-        const provider = () => '1234567890123456';
-
-        await expect(getPasswordFromProvider(provider)).rejects.toThrow(
-          'Password must contain at least 3 of: uppercase letters, lowercase letters, digits, special characters'
-        );
-      });
-
-      test('rejects password with only two character classes (lowercase + digits)', async () => {
-        const provider = () => 'abcdefgh12345678';
-
-        await expect(getPasswordFromProvider(provider)).rejects.toThrow(
-          'Password must contain at least 3 of: uppercase letters, lowercase letters, digits, special characters'
-        );
-      });
-
-      test('accepts password with three character classes (lowercase + uppercase + digits)', async () => {
-        const provider = () => 'aXbYcZ1m2n3p4q5r';
-
-        const result = await getPasswordFromProvider(provider);
-        expect(result).toBe('aXbYcZ1m2n3p4q5r');
-      });
-
-      test('accepts password with three character classes (lowercase + uppercase + special)', async () => {
-        const provider = () => 'aXbYcZ!@mNpQ#$rS';
-
-        const result = await getPasswordFromProvider(provider);
-        expect(result).toBe('aXbYcZ!@mNpQ#$rS');
-      });
-
-      test('accepts password with all four character classes', async () => {
-        const provider = () => 'aX1!bY2@cZ3#mN4$';
-
-        const result = await getPasswordFromProvider(provider);
-        expect(result).toBe('aX1!bY2@cZ3#mN4$');
+      test.each([
+        'aXbYcZ1m2n3p4q5r',
+        'aXbYcZ!@mNpQ#$rS',
+        'aX1!bY2@cZ3#mN4$'
+      ])('accepts password "%s"', async (password) => {
+        expect(await getPasswordFromProvider(() => password)).toBe(password);
       });
     });
 
     describe('repeated character requirements', () => {
-      test('rejects password with more than 3 consecutive identical characters', async () => {
-        const provider = () => 'Paaaa-ssword-1!!';
-
-        await expect(getPasswordFromProvider(provider)).rejects.toThrow(
-          'Password contains too many repeated characters'
-        );
-      });
-
-      test('rejects password of all identical characters', async () => {
-        const provider = () => '1111111111111111';
-
-        await expect(getPasswordFromProvider(provider)).rejects.toThrow(
-          'Password contains too many repeated characters'
-        );
+      test.each([
+        'Paaaa-ssword-1!!',
+        '1111111111111111'
+      ])('rejects password "%s" with reason repeated_characters', async (password) => {
+        await expectPasswordValidationFailure(() => password, 'repeated_characters');
       });
 
       test('accepts password with exactly 3 consecutive identical characters', async () => {
-        const provider = () => 'Paaa-ssword-123!';
-
-        const result = await getPasswordFromProvider(provider);
-        expect(result).toBe('Paaa-ssword-123!');
+        const password = 'Paaa-ssword-123!';
+        expect(await getPasswordFromProvider(() => password)).toBe(password);
       });
     });
 
     describe('sequential pattern requirements', () => {
-      test('rejects password with ascending numeric sequence', async () => {
-        const provider = () => 'Password-123456!';
-
-        await expect(getPasswordFromProvider(provider)).rejects.toThrow(
-          'Password contains sequential patterns'
-        );
+      test.each([
+        'Password-123456!',
+        'Password-654321!',
+        'Password-abcdef!',
+        'Password-fedcba!'
+      ])('rejects password "%s" with reason sequential_pattern', async (password) => {
+        await expectPasswordValidationFailure(() => password, 'sequential_pattern');
       });
 
-      test('rejects password with descending numeric sequence', async () => {
-        const provider = () => 'Password-654321!';
-
-        await expect(getPasswordFromProvider(provider)).rejects.toThrow(
-          'Password contains sequential patterns'
-        );
-      });
-
-      test('rejects password with ascending letter sequence', async () => {
-        const provider = () => 'Password-abcdef!';
-
-        await expect(getPasswordFromProvider(provider)).rejects.toThrow(
-          'Password contains sequential patterns'
-        );
-      });
-
-      test('rejects password with descending letter sequence', async () => {
-        const provider = () => 'Password-fedcba!';
-
-        await expect(getPasswordFromProvider(provider)).rejects.toThrow(
-          'Password contains sequential patterns'
-        );
-      });
-
-      test('accepts password with non-sequential characters', async () => {
-        const provider = () => 'Xk9$mP2!qR7@nL4#';
-
-        const result = await getPasswordFromProvider(provider);
-        expect(result).toBe('Xk9$mP2!qR7@nL4#');
-      });
-
-      test('accepts password with short sequences (3 chars is ok)', async () => {
-        const provider = () => 'Pass-abc-XYZ-12!';
-
-        const result = await getPasswordFromProvider(provider);
-        expect(result).toBe('Pass-abc-XYZ-12!');
+      test.each([
+        'Xk9$mP2!qR7@nL4#',
+        'Pass-abc-XYZ-12!'
+      ])('accepts password "%s" (no 4+ char sequences)', async (password) => {
+        expect(await getPasswordFromProvider(() => password)).toBe(password);
       });
     });
   });

--- a/packages/level-private-state-provider/src/test/storage-encryption.test.ts
+++ b/packages/level-private-state-provider/src/test/storage-encryption.test.ts
@@ -15,7 +15,6 @@
 
 import { createHash } from 'node:crypto';
 
-import { PasswordValidationError, validatePassword } from '@midnight-ntwrk/midnight-js-utils';
 import { Buffer } from 'buffer';
 
 import { decryptValue, getPasswordFromProvider, StorageEncryption, timingSafeEqual } from '../storage-encryption';
@@ -491,62 +490,6 @@ describe('StorageEncryption', () => {
         const result = await getPasswordFromProvider(provider);
         expect(result).toBe('Pass-abc-XYZ-12!');
       });
-    });
-  });
-
-  describe('validatePassword', () => {
-    test('throws PasswordValidationError with reason "missing" for empty password', () => {
-      try {
-        validatePassword('');
-        expect.fail('Expected throw');
-      } catch (error) {
-        expect(error).toBeInstanceOf(PasswordValidationError);
-        expect((error as PasswordValidationError).reason).toBe('missing');
-      }
-    });
-
-    test('throws PasswordValidationError with reason "too_short"', () => {
-      try {
-        validatePassword('short');
-        expect.fail('Expected throw');
-      } catch (error) {
-        expect(error).toBeInstanceOf(PasswordValidationError);
-        expect((error as PasswordValidationError).reason).toBe('too_short');
-      }
-    });
-
-    test('throws PasswordValidationError with reason "repeated_characters"', () => {
-      try {
-        validatePassword('aaaaaaaaaaaaaaaa');
-        expect.fail('Expected throw');
-      } catch (error) {
-        expect(error).toBeInstanceOf(PasswordValidationError);
-        expect((error as PasswordValidationError).reason).toBe('repeated_characters');
-      }
-    });
-
-    test('throws PasswordValidationError with reason "insufficient_classes"', () => {
-      try {
-        validatePassword('abcdefghjkmnpqrs');
-        expect.fail('Expected throw');
-      } catch (error) {
-        expect(error).toBeInstanceOf(PasswordValidationError);
-        expect((error as PasswordValidationError).reason).toBe('insufficient_classes');
-      }
-    });
-
-    test('throws PasswordValidationError with reason "sequential_pattern"', () => {
-      try {
-        validatePassword('Password-123456!');
-        expect.fail('Expected throw');
-      } catch (error) {
-        expect(error).toBeInstanceOf(PasswordValidationError);
-        expect((error as PasswordValidationError).reason).toBe('sequential_pattern');
-      }
-    });
-
-    test('accepts a compliant password', () => {
-      expect(() => validatePassword('Xk9$mP2!qR7@nL4#')).not.toThrow();
     });
   });
 });

--- a/packages/level-private-state-provider/src/test/storage-encryption.test.ts
+++ b/packages/level-private-state-provider/src/test/storage-encryption.test.ts
@@ -15,6 +15,7 @@
 
 import { createHash } from 'node:crypto';
 
+import { PasswordValidationError, validatePassword } from '@midnight-ntwrk/midnight-js-utils';
 import { Buffer } from 'buffer';
 
 import { decryptValue, getPasswordFromProvider, StorageEncryption, timingSafeEqual } from '../storage-encryption';
@@ -490,6 +491,62 @@ describe('StorageEncryption', () => {
         const result = await getPasswordFromProvider(provider);
         expect(result).toBe('Pass-abc-XYZ-12!');
       });
+    });
+  });
+
+  describe('validatePassword', () => {
+    test('throws PasswordValidationError with reason "missing" for empty password', () => {
+      try {
+        validatePassword('');
+        expect.fail('Expected throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(PasswordValidationError);
+        expect((error as PasswordValidationError).reason).toBe('missing');
+      }
+    });
+
+    test('throws PasswordValidationError with reason "too_short"', () => {
+      try {
+        validatePassword('short');
+        expect.fail('Expected throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(PasswordValidationError);
+        expect((error as PasswordValidationError).reason).toBe('too_short');
+      }
+    });
+
+    test('throws PasswordValidationError with reason "repeated_characters"', () => {
+      try {
+        validatePassword('aaaaaaaaaaaaaaaa');
+        expect.fail('Expected throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(PasswordValidationError);
+        expect((error as PasswordValidationError).reason).toBe('repeated_characters');
+      }
+    });
+
+    test('throws PasswordValidationError with reason "insufficient_classes"', () => {
+      try {
+        validatePassword('abcdefghjkmnpqrs');
+        expect.fail('Expected throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(PasswordValidationError);
+        expect((error as PasswordValidationError).reason).toBe('insufficient_classes');
+      }
+    });
+
+    test('throws PasswordValidationError with reason "sequential_pattern"', () => {
+      try {
+        validatePassword('Password-123456!');
+        expect.fail('Expected throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(PasswordValidationError);
+        expect((error as PasswordValidationError).reason).toBe('sequential_pattern');
+      }
+    });
+
+    test('accepts a compliant password', () => {
+      expect(() => validatePassword('Xk9$mP2!qR7@nL4#')).not.toThrow();
     });
   });
 });

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -33,8 +33,8 @@ export class InvalidProtocolSchemeError extends Error {
  * An error thrown when exporting private states fails.
  */
 export class PrivateStateExportError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'PrivateStateExportError';
   }
 }
@@ -43,8 +43,8 @@ export class PrivateStateExportError extends Error {
  * An error thrown when exporting signing keys fails.
  */
 export class SigningKeyExportError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'SigningKeyExportError';
   }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -16,5 +16,6 @@
 export * from './assertion-utils';
 export * from './date-utils';
 export * from './hex-utils';
+export * from './password-validation';
 export * from './security-utils';
 export * from './type-utils';

--- a/packages/utils/src/password-validation.ts
+++ b/packages/utils/src/password-validation.ts
@@ -1,0 +1,141 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const MIN_PASSWORD_LENGTH = 16;
+export const MIN_CHARACTER_CLASSES = 3;
+export const MAX_CONSECUTIVE_REPEATED = 3;
+export const MIN_SEQUENTIAL_LENGTH = 4;
+
+/**
+ * Reason categories for password validation failures.
+ */
+export type PasswordValidationFailure =
+  | 'missing'
+  | 'too_short'
+  | 'insufficient_classes'
+  | 'repeated_characters'
+  | 'sequential_pattern';
+
+/**
+ * Thrown when a password does not satisfy the strength policy applied to
+ * private storage and export/import operations.
+ */
+export class PasswordValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly reason: PasswordValidationFailure
+  ) {
+    super(message);
+    this.name = 'PasswordValidationError';
+  }
+}
+
+const countCharacterClasses = (password: string): number => {
+  let count = 0;
+  if (/[a-z]/.test(password)) count++;
+  if (/[A-Z]/.test(password)) count++;
+  if (/[0-9]/.test(password)) count++;
+  if (/[^a-zA-Z0-9]/.test(password)) count++;
+  return count;
+};
+
+const hasRepeatedCharacters = (password: string): boolean => {
+  let consecutiveCount = 1;
+  for (let i = 1; i < password.length; i++) {
+    if (password[i] === password[i - 1]) {
+      consecutiveCount++;
+      if (consecutiveCount > MAX_CONSECUTIVE_REPEATED) {
+        return true;
+      }
+    } else {
+      consecutiveCount = 1;
+    }
+  }
+  return false;
+};
+
+const hasSequentialPattern = (password: string): boolean => {
+  const lowerPassword = password.toLowerCase();
+
+  for (let i = 0; i <= lowerPassword.length - MIN_SEQUENTIAL_LENGTH; i++) {
+    let ascendingCount = 1;
+    let descendingCount = 1;
+
+    for (let j = 1; j < MIN_SEQUENTIAL_LENGTH; j++) {
+      const currentCode = lowerPassword.charCodeAt(i + j);
+      const prevCode = lowerPassword.charCodeAt(i + j - 1);
+
+      if (currentCode === prevCode + 1) {
+        ascendingCount++;
+      } else {
+        ascendingCount = 1;
+      }
+
+      if (currentCode === prevCode - 1) {
+        descendingCount++;
+      } else {
+        descendingCount = 1;
+      }
+
+      if (ascendingCount >= MIN_SEQUENTIAL_LENGTH || descendingCount >= MIN_SEQUENTIAL_LENGTH) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+/**
+ * Shared password strength policy for private storage and export/import operations.
+ * Throws {@link PasswordValidationError} on the first violated rule.
+ */
+export const validatePassword = (password: string): void => {
+  if (!password) {
+    throw new PasswordValidationError(
+      'Password is required for private state encryption.\n' +
+        'Please provide a password via privateStoragePasswordProvider in the configuration.',
+      'missing'
+    );
+  }
+
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    throw new PasswordValidationError(
+      `Password must be at least ${MIN_PASSWORD_LENGTH} characters long. Current length: ${password.length}`,
+      'too_short'
+    );
+  }
+
+  if (hasRepeatedCharacters(password)) {
+    throw new PasswordValidationError(
+      `Password contains too many repeated characters (more than ${MAX_CONSECUTIVE_REPEATED} identical in a row)`,
+      'repeated_characters'
+    );
+  }
+
+  const characterClasses = countCharacterClasses(password);
+  if (characterClasses < MIN_CHARACTER_CLASSES) {
+    throw new PasswordValidationError(
+      `Password must contain at least ${MIN_CHARACTER_CLASSES} of: uppercase letters, lowercase letters, digits, special characters. Found: ${characterClasses}`,
+      'insufficient_classes'
+    );
+  }
+
+  if (hasSequentialPattern(password)) {
+    throw new PasswordValidationError(
+      "Password contains sequential patterns (e.g., '1234', 'abcd'). Use a more random password",
+      'sequential_pattern'
+    );
+  }
+};

--- a/packages/utils/src/password-validation.ts
+++ b/packages/utils/src/password-validation.ts
@@ -112,7 +112,7 @@ export const validatePassword = (password: string): void => {
 
   if (password.length < MIN_PASSWORD_LENGTH) {
     throw new PasswordValidationError(
-      `Password must be at least ${MIN_PASSWORD_LENGTH} characters long. Current length: ${password.length}`,
+      `Password is shorter than ${MIN_PASSWORD_LENGTH} characters`,
       'too_short'
     );
   }

--- a/packages/utils/src/test/password-validation.test.ts
+++ b/packages/utils/src/test/password-validation.test.ts
@@ -37,14 +37,15 @@ describe('validatePassword', () => {
       }
     });
 
-    it('reports the actual password length for "too_short"', () => {
+    it('does not leak actual password length in the "too_short" message', () => {
       try {
         validatePassword('short');
         expect.fail('Expected PasswordValidationError to be thrown');
       } catch (error) {
         expect(error).toBeInstanceOf(PasswordValidationError);
         if (error instanceof PasswordValidationError) {
-          expect(error.message).toContain('Current length: 5');
+          expect(error.message).not.toMatch(/length/i);
+          expect(error.message).not.toContain('5');
         }
       }
     });

--- a/packages/utils/src/test/password-validation.test.ts
+++ b/packages/utils/src/test/password-validation.test.ts
@@ -1,0 +1,63 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { PasswordValidationError, type PasswordValidationFailure, validatePassword } from '../password-validation';
+
+describe('validatePassword', () => {
+  describe('rejects passwords with PasswordValidationError', () => {
+    it.each<[PasswordValidationFailure, string]>([
+      ['missing', ''],
+      ['too_short', 'short'],
+      ['repeated_characters', 'aaaaaaaaaaaaaaaa'],
+      ['insufficient_classes', 'abcdefghjkmnpqrs'],
+      ['sequential_pattern', 'Password-123456!']
+    ])('throws with reason "%s"', (reason, password) => {
+      try {
+        validatePassword(password);
+        expect.fail('Expected PasswordValidationError to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(PasswordValidationError);
+        if (error instanceof PasswordValidationError) {
+          expect(error.reason).toBe(reason);
+        }
+      }
+    });
+
+    it('reports the actual password length for "too_short"', () => {
+      try {
+        validatePassword('short');
+        expect.fail('Expected PasswordValidationError to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(PasswordValidationError);
+        if (error instanceof PasswordValidationError) {
+          expect(error.message).toContain('Current length: 5');
+        }
+      }
+    });
+  });
+
+  describe('accepts strong passwords', () => {
+    it.each([
+      'Xk9$mP2!qR7@nL4#',
+      'aX1!bY2@cZ3#mN4$',
+      'Pass-abc-XYZ-12!',
+      'Paaa-ssword-123!'
+    ])('accepts %s', (password) => {
+      expect(() => validatePassword(password)).not.toThrow();
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1859,6 +1859,7 @@ __metadata:
   dependencies:
     "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
+    "@midnight-ntwrk/midnight-js-utils": "workspace:*"
     "@noble/ciphers": "npm:^2.0.0"
     "@noble/hashes": "npm:^2.0.0"
     abstract-level: "npm:^3.0.0"


### PR DESCRIPTION
# Overview

Closes #819.

Export/import password validation in `level-private-state-provider` only enforced the 16-char minimum, while storage password additionally required character-class diversity, no excessive repeated characters, and no sequential patterns. A user could `exportPrivateStates({ password: 'aaaaaaaaaaaaaaaa' })` but could not use the same password for storage. This PR harmonises the two policies.

**Changes:**

- New shared module `packages/utils/src/password-validation.ts` — single source of truth for `validatePassword`, `PasswordValidationError`, and the strength policy (min length, ≥3 character classes, no >3 consecutive repeats, no sequential patterns of length 4+).
- `PasswordValidationError` carries a typed `reason` discriminator (`'missing' | 'too_short' | 'insufficient_classes' | 'repeated_characters' | 'sequential_pattern'`) for programmatic inspection.
- Provider export/import wrappers re-throw `PasswordValidationError` as `PrivateStateExportError` / `SigningKeyExportError` with `{ cause }`, preserving the public interface contract.
- `PrivateStateExportError` / `SigningKeyExportError` now accept `ErrorOptions` (strict-additive — existing single-arg callers in `testkit-js/in-memory-private-state-provider.ts` continue to work).
- Updated `LevelPrivateStateProviderConfig.privateStoragePasswordProvider` JSDoc to reference the full policy.
- Test fixtures that previously used weak passwords (`'export-test-password-1234'`, `'valid-password-for-test'`, `'wrong-password-12345'`) were strengthened — the fact that they were accepted before is itself evidence of the bug being fixed.

**Note on overlap with #897:**

Open PR #897 (`BossChaos:fix/http-warn-export-password`) targets #819 with a shallower fix — it adds the existing length-only validator to the storage-password fallback path. This PR replaces that validator with the full policy and shares it across implementations via `packages/utils`. Coordination with that PR's author may be needed before merge.

**Out of scope:**

`testkit-js/.../in-memory-private-state-provider.ts` has the same length-only validation, kept unchanged as the testkit is a barebones implementation used only by integration tests.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README.md file (if relevant) — n/a
- [x] Update documentation (if relevant) — JSDoc updated
- [x] No new todos introduced

## Test plan

- [x] Tests written first (TDD); failing → green cycle confirmed
- [x] Direct unit tests for `validatePassword` (each `reason` branch) in `packages/utils`
- [x] Integration tests for 4 provider paths (`export`/`import` × `PrivateStates`/`SigningKeys`) — every weak-password branch surfaces correct domain error with `cause: PasswordValidationError`
- [x] All existing tests pass (utils: 90, provider: 259)
- [x] ESLint clean
- [x] Build succeeds (turbo, all affected packages)

## Links

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)