### PR TITLE
fix(midnight-js): validate signing key value on import

### DIFF
--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -645,6 +645,17 @@ const validateSalt = (salt: string): void => {
   }
 };
 
+const SIGNING_KEY_MIN_HEX_LENGTH = 6;
+
+const validateSigningKeyValue = (value: unknown): void => {
+  if (typeof value !== 'string'
+    || value.length < SIGNING_KEY_MIN_HEX_LENGTH
+    || value.length % 2 !== 0
+    || !/^[0-9a-fA-F]+$/.test(value)) {
+    throw new InvalidExportFormatError('Invalid signing key value');
+  }
+};
+
 const BROWSER_WARNING_KEY = '__midnight_browser_warning_shown__';
 
 const isBrowserEnvironment = (): boolean => {
@@ -1117,6 +1128,10 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
         throw new InvalidExportFormatError(
           `Too many keys in export (${addresses.length}). Maximum allowed: ${maxKeys}`
         );
+      }
+
+      for (const address of addresses) {
+        validateSigningKeyValue(payload.keys[address]);
       }
 
       if (conflictStrategy === 'error') {

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -1414,6 +1414,90 @@ describe('Level Private State Provider', (): void => {
         await expect(db.importSigningKeys(tamperedExport)).rejects.toThrow(ExportDecryptionError);
       });
     });
+
+    describe('signingKey value validation', () => {
+      const VALID_PASSWORD = 'Valid-Pass9-Test!@';
+
+      const buildBadExport = async (keys: Record<string, unknown>): Promise<SigningKeyExport> => {
+        const salt = Buffer.from('0'.repeat(64), 'hex');
+        const encryption = await StorageEncryption.create(VALID_PASSWORD, { existingSalt: salt });
+        const encryptedPayload = await encryption.encrypt(JSON.stringify({
+          version: 1,
+          exportedAt: new Date().toISOString(),
+          keyCount: Object.keys(keys).length,
+          keys
+        }));
+        return {
+          format: 'midnight-signing-key-export',
+          encryptedPayload,
+          salt: salt.toString('hex')
+        };
+      };
+
+      test.each([
+        ['null',            { [CONTRACT_ADDRESS_1]: null }],
+        ['object',          { [CONTRACT_ADDRESS_1]: { sk: 'deadbeef' } }],
+        ['number',          { [CONTRACT_ADDRESS_1]: 12345 }],
+        ['boolean',         { [CONTRACT_ADDRESS_1]: true }],
+        ['array',           { [CONTRACT_ADDRESS_1]: ['deadbeef'] }],
+        ['empty string',    { [CONTRACT_ADDRESS_1]: '' }],
+        ['non-hex chars',   { [CONTRACT_ADDRESS_1]: 'zz'.repeat(8) }],
+        ['odd hex length',  { [CONTRACT_ADDRESS_1]: 'abcde' }],
+        ['shorter than version prefix', { [CONTRACT_ADDRESS_1]: 'ab' }]
+      ])('importSigningKeys rejects %s signingKey value with InvalidExportFormatError', async (_reason, keys) => {
+        const db = levelPrivateStateProvider<PID, PS>(testConfig);
+        const badExport = await buildBadExport(keys as Record<string, unknown>);
+
+        await expect(
+          db.importSigningKeys(badExport, { password: VALID_PASSWORD })
+        ).rejects.toThrow(InvalidExportFormatError);
+      });
+
+      test.each([
+        ['invalid value last',  { [CONTRACT_ADDRESS_1]: sampleSigningKey(), [CONTRACT_ADDRESS_2]: null }],
+        ['invalid value first', { [CONTRACT_ADDRESS_1]: null,               [CONTRACT_ADDRESS_2]: sampleSigningKey() }]
+      ])('importSigningKeys is atomic: %s leaves all keys unwritten', async (_reason, keys) => {
+        const db = levelPrivateStateProvider<PID, PS>(testConfig);
+        const badExport = await buildBadExport(keys as Record<string, unknown>);
+
+        await expect(
+          db.importSigningKeys(badExport, { password: VALID_PASSWORD })
+        ).rejects.toThrow(InvalidExportFormatError);
+
+        expect(await db.getSigningKey(CONTRACT_ADDRESS_1)).toBeNull();
+        expect(await db.getSigningKey(CONTRACT_ADDRESS_2)).toBeNull();
+      });
+
+      test('importSigningKeys atomicity: existing keys are not overwritten when a later value is invalid', async () => {
+        const db = levelPrivateStateProvider<PID, PS>(testConfig);
+        const original = sampleSigningKey();
+        await db.setSigningKey(CONTRACT_ADDRESS_1, original);
+
+        const replacement = sampleSigningKey();
+        const badExport = await buildBadExport({
+          [CONTRACT_ADDRESS_1]: replacement,
+          [CONTRACT_ADDRESS_2]: { sk: 'not-a-string' }
+        });
+
+        await expect(
+          db.importSigningKeys(badExport, { password: VALID_PASSWORD, conflictStrategy: 'overwrite' })
+        ).rejects.toThrow(InvalidExportFormatError);
+
+        expect(await db.getSigningKey(CONTRACT_ADDRESS_1)).toEqual(original);
+        expect(await db.getSigningKey(CONTRACT_ADDRESS_2)).toBeNull();
+      });
+
+      test('importSigningKeys accepts well-formed lowercase hex with version prefix', async () => {
+        const db = levelPrivateStateProvider<PID, PS>(testConfig);
+        const wellFormed = '0102030a1b2c3d4e5f';
+        const goodExport = await buildBadExport({ [CONTRACT_ADDRESS_1]: wellFormed });
+
+        const result = await db.importSigningKeys(goodExport, { password: VALID_PASSWORD });
+
+        expect(result.imported).toBe(1);
+        expect(await db.getSigningKey(CONTRACT_ADDRESS_1)).toEqual(wellFormed);
+      });
+    });
   });
 
   describe('Browser Warning', () => {

--- a/testkit-js/testkit-js/src/contract/in-memory-private-state-provider.ts
+++ b/testkit-js/testkit-js/src/contract/in-memory-private-state-provider.ts
@@ -134,6 +134,17 @@ const validateSalt = (salt: string): void => {
   }
 };
 
+const SIGNING_KEY_MIN_HEX_LENGTH = 6;
+
+const validateSigningKeyValue = (value: unknown): void => {
+  if (typeof value !== 'string'
+    || value.length < SIGNING_KEY_MIN_HEX_LENGTH
+    || value.length % 2 !== 0
+    || !/^[0-9a-fA-F]+$/.test(value)) {
+    throw new InvalidExportFormatError('Invalid signing key value');
+  }
+};
+
 /**
  * A simple in-memory implementation of private state provider. Makes it easy to capture and rewrite private state from deploy.
  *
@@ -490,6 +501,10 @@ export const inMemoryPrivateStateProvider = <
         throw new InvalidExportFormatError(
           `Too many keys in export (${addresses.length}). Maximum allowed: ${maxKeys}`
         );
+      }
+
+      for (const address of addresses) {
+        validateSigningKeyValue(payload.keys[address]);
       }
 
       if (conflictStrategy === 'error') {

--- a/testkit-js/testkit-js/test/in-memory-private-state-provider.ut.test.ts
+++ b/testkit-js/testkit-js/test/in-memory-private-state-provider.ut.test.ts
@@ -1,0 +1,113 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import {
+  InvalidExportFormatError,
+  type SigningKeyExport
+} from '@midnight-ntwrk/midnight-js-types';
+import { createCipheriv, pbkdf2Sync, randomBytes } from 'crypto';
+
+import { inMemoryPrivateStateProvider } from '@/contract/in-memory-private-state-provider';
+
+const ALGORITHM = 'aes-256-gcm';
+const KEY_LENGTH = 32;
+const IV_LENGTH = 12;
+const SALT_LENGTH = 32;
+const PBKDF2_ITERATIONS = 100000;
+const ENCRYPTION_VERSION = 1;
+const VALID_PASSWORD = 'Valid-Pass9-Test!@';
+
+const CONTRACT_ADDRESS_1 = 'contract-address-1' as ContractAddress;
+const CONTRACT_ADDRESS_2 = 'contract-address-2' as ContractAddress;
+const VALID_SIGNING_KEY = '0102030a1b2c3d4e5f';
+
+const encryptPayload = (data: string, password: string, salt: Buffer): string => {
+  const key = pbkdf2Sync(password, salt, PBKDF2_ITERATIONS, KEY_LENGTH, 'sha256');
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(Buffer.from(data, 'utf-8')), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([Buffer.from([ENCRYPTION_VERSION]), salt, iv, authTag, encrypted]).toString('base64');
+};
+
+const buildExport = (keys: Record<string, unknown>): SigningKeyExport => {
+  const salt = randomBytes(SALT_LENGTH);
+  const payload = JSON.stringify({
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    keyCount: Object.keys(keys).length,
+    keys
+  });
+  return {
+    format: 'midnight-signing-key-export',
+    encryptedPayload: encryptPayload(payload, VALID_PASSWORD, salt),
+    salt: salt.toString('hex')
+  };
+};
+
+type PSI = 'state';
+type PS = Contract.PrivateState<Contract.Any>;
+
+describe('[Unit tests] inMemoryPrivateStateProvider importSigningKeys validation', () => {
+  describe('rejects malformed signingKey values with InvalidExportFormatError', () => {
+    it.each([
+      ['null',                         { [CONTRACT_ADDRESS_1]: null }],
+      ['object',                       { [CONTRACT_ADDRESS_1]: { sk: 'deadbeef' } }],
+      ['number',                       { [CONTRACT_ADDRESS_1]: 12345 }],
+      ['boolean',                      { [CONTRACT_ADDRESS_1]: true }],
+      ['array',                        { [CONTRACT_ADDRESS_1]: ['deadbeef'] }],
+      ['empty string',                 { [CONTRACT_ADDRESS_1]: '' }],
+      ['non-hex chars',                { [CONTRACT_ADDRESS_1]: 'zz'.repeat(8) }],
+      ['odd hex length',               { [CONTRACT_ADDRESS_1]: 'abcde' }],
+      ['shorter than version prefix',  { [CONTRACT_ADDRESS_1]: 'ab' }]
+    ])('%s value is rejected', async (_reason, keys) => {
+      const provider = inMemoryPrivateStateProvider<PSI, PS>();
+      const badExport = buildExport(keys as Record<string, unknown>);
+
+      await expect(
+        provider.importSigningKeys(badExport, { password: VALID_PASSWORD })
+      ).rejects.toThrow(InvalidExportFormatError);
+    });
+  });
+
+  describe('atomicity', () => {
+    it.each([
+      ['invalid value last',  { [CONTRACT_ADDRESS_1]: VALID_SIGNING_KEY, [CONTRACT_ADDRESS_2]: null }],
+      ['invalid value first', { [CONTRACT_ADDRESS_1]: null,              [CONTRACT_ADDRESS_2]: VALID_SIGNING_KEY }]
+    ])('%s leaves all keys unwritten', async (_reason, keys) => {
+      const provider = inMemoryPrivateStateProvider<PSI, PS>();
+      const badExport = buildExport(keys as Record<string, unknown>);
+
+      await expect(
+        provider.importSigningKeys(badExport, { password: VALID_PASSWORD })
+      ).rejects.toThrow(InvalidExportFormatError);
+
+      expect(await provider.getSigningKey(CONTRACT_ADDRESS_1)).toBeNull();
+      expect(await provider.getSigningKey(CONTRACT_ADDRESS_2)).toBeNull();
+    });
+  });
+
+  it('accepts a well-formed hex signing key', async () => {
+    const provider = inMemoryPrivateStateProvider<PSI, PS>();
+    const goodExport = buildExport({ [CONTRACT_ADDRESS_1]: VALID_SIGNING_KEY });
+
+    const result = await provider.importSigningKeys(goodExport, { password: VALID_PASSWORD });
+
+    expect(result.imported).toBe(1);
+    expect(await provider.getSigningKey(CONTRACT_ADDRESS_1)).toEqual(VALID_SIGNING_KEY);
+  });
+});


### PR DESCRIPTION
# Overview

Resolves #824. Adds a structural check on each signing key value before it is persisted by `importSigningKeys`. Without this, a crafted export could inject `null`, an object, a number, or a malformed string into the encrypted store, only to surface later as opaque transaction failures.

## Summary

- New `validateSigningKeyValue` helper rejects values that are not a hex-encoded string of even length and at least 6 hex chars (BIP-340 version prefix minimum). Rejection throws `InvalidExportFormatError` with a static message (no oracle).
- Pre-validation runs over the entire payload before any `setSigningKey` call, so a single invalid entry aborts the import with **no partial writes** — preserving any pre-existing keys under `overwrite` strategy too.
- Same logic mirrored in the in-memory provider used by `testkit-js` so test paths share the same invariants.

## Test plan

- [x] Tests written first (TDD), verified they fail before the fix
- [x] Level provider: 13 new tests under `signingKey value validation`, including 10 parameterized rejection cases (null, object, number, boolean, array, empty string, non-hex, odd length, too-short) and 2 atomicity variants (invalid first / invalid last) + happy-path acceptance. 272 / 272 pass.
- [x] In-memory provider: new `test/in-memory-private-state-provider.ut.test.ts` with mirrored rejection + atomicity coverage. 74 / 74 testkit-js tests pass.
- [x] `yarn lint` clean on all changed files
- [x] `yarn turbo run build` succeeds for both packages

## Links

Closes #824
Related: #526 (introduced export/import API without value-shape validation)