### PR TITLE
ci(testkit-js): scope concurrency group by docker env

### DIFF
--- a/.github/workflows/ci-testkit-js.yml
+++ b/.github/workflows/ci-testkit-js.yml
@@ -46,7 +46,7 @@ on:
         default: ''
 
 concurrency:
-  group: TK-JS-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: TK-JS-${{ github.workflow }}-${{ inputs.testkit_docker_env || 'default' }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
Nightly E2E (`nightly-e2e.yml`) runs the reusable `ci-testkit-js.yml` workflow once per environment (`qanet`/`preview`/`preprod`/`mainnet`/`devnet`). All five matrix legs inherited the same concurrency group (`TK-JS-${{ github.workflow }}-${{ github.ref }}`), so `cancel-in-progress: true` killed four of five legs as the next one queued — only `mainnet` survived in [run 26615385031](https://github.com/midnightntwrk/midnight-js/actions/runs/26615385031).

Fix: add `inputs.testkit_docker_env` to the concurrency group key so each environment gets its own group. Callers without that input (PR `ci.yml`, `cd.yml`) fall back to `'default'`, preserving existing single-group-per-branch behaviour.

## Test plan
- [x] Diff is a one-line concurrency key change; no runtime code touched
- [x] Verified non-nightly callers (`ci.yml`, `cd.yml`) don't pass `testkit_docker_env` → fall back to `'default'`, behaviour unchanged
- [ ] After merge: confirm next nightly run completes all 5 matrix legs without cancellation