### PR TITLE
fix(midnight-js): harden error handling in indexer-public-data-provider

### DIFF
--- a/packages/indexer-public-data-provider/src/errors.ts
+++ b/packages/indexer-public-data-provider/src/errors.ts
@@ -35,3 +35,15 @@ export class IndexerFormattedError extends IndexerError {
     this.name = 'IndexerFormattedError';
   }
 }
+
+/**
+ * An error raised when an Apollo query or fetch returns a transport-level or
+ * GraphQL-level error. Preserves the original Apollo error via {@link Error.cause}
+ * so consumers can inspect network details, GraphQL errors, and the original stack.
+ */
+export class IndexerQueryError extends IndexerError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'IndexerQueryError';
+  }
+}

--- a/packages/indexer-public-data-provider/src/errors.ts
+++ b/packages/indexer-public-data-provider/src/errors.ts
@@ -40,9 +40,14 @@ export class IndexerFormattedError extends IndexerError {
 }
 
 /**
- * An error raised when an Apollo query or fetch returns a transport-level or
- * GraphQL-level error. Preserves the original Apollo error via `Error.cause`
- * so consumers can inspect network details, GraphQL errors, and the original stack.
+ * An error raised when an Apollo query or fetch fails at the transport layer
+ * (network failure, malformed response, Apollo client error) — distinct from
+ * the case where the server returns a well-formed response containing
+ * `GraphQLFormattedError` entries, which is reported via
+ * {@link IndexerFormattedError}.
+ *
+ * Preserves the original Apollo error via `Error.cause` so consumers can
+ * inspect network details and the original stack.
  */
 export class IndexerQueryError extends IndexerError {
   constructor(message: string, options?: ErrorOptions) {
@@ -52,19 +57,76 @@ export class IndexerQueryError extends IndexerError {
 }
 
 /**
+ * Discriminated context describing the specific way indexer-returned data
+ * failed to satisfy the provider's expectations. The `kind` tag lets
+ * consumers branch on the failure mode without parsing the error message.
+ */
+export type IndexerDataErrorContext =
+  | { kind: 'unknown-status'; value: string }
+  | { kind: 'missing-contract-action'; contractAddress: string }
+  | {
+      kind: 'missing-identifier';
+      contractAddress: string;
+      actionIndex: number;
+      identifiersLength: number;
+    };
+
+/**
  * An error raised when indexer-returned data is structurally inconsistent
  * with the provider's expectations: unknown enum values, broken referential
  * integrity between related rows, or missing relations the schema implies
  * should be present.
  *
- * Distinct from {@link IndexerSubscriptionDataError} (which reports a missing
- * top-level field on a subscription payload) and {@link IndexerFormattedError}
- * (which reports errors the server explicitly returned).
+ * Distinct from:
+ * - {@link IndexerSubscriptionDataError} — missing top-level field on a
+ *   subscription payload (server returned `null`/`undefined` for a field).
+ * - {@link IndexerFormattedError} — errors the server explicitly returned
+ *   as `GraphQLFormattedError` entries.
+ * - {@link IndexerQueryError} — transport / Apollo failure before data is
+ *   parsed.
+ *
+ * Construct via the static factory methods to ensure the message and
+ * {@link context} stay in sync.
  */
 export class IndexerDataError extends IndexerError {
-  constructor(message: string) {
-    super(message);
+  constructor(public readonly context: IndexerDataErrorContext) {
+    super(IndexerDataError.formatMessage(context));
     this.name = 'IndexerDataError';
+  }
+
+  static unknownStatus(value: string): IndexerDataError {
+    return new IndexerDataError({ kind: 'unknown-status', value });
+  }
+
+  static missingContractAction(contractAddress: string): IndexerDataError {
+    return new IndexerDataError({ kind: 'missing-contract-action', contractAddress });
+  }
+
+  static missingIdentifier(
+    contractAddress: string,
+    actionIndex: number,
+    identifiersLength: number
+  ): IndexerDataError {
+    return new IndexerDataError({
+      kind: 'missing-identifier',
+      contractAddress,
+      actionIndex,
+      identifiersLength
+    });
+  }
+
+  private static formatMessage(context: IndexerDataErrorContext): string {
+    switch (context.kind) {
+      case 'unknown-status':
+        return `Unexpected transaction status value: ${context.value}`;
+      case 'missing-contract-action':
+        return `Deploy transaction does not contain a contract action for address ${context.contractAddress}`;
+      case 'missing-identifier':
+        return (
+          `Transaction missing identifier for contract action at address ${context.contractAddress}` +
+          ` (actionIndex=${context.actionIndex}, identifiers.length=${context.identifiersLength})`
+        );
+    }
   }
 }
 

--- a/packages/indexer-public-data-provider/src/errors.ts
+++ b/packages/indexer-public-data-provider/src/errors.ts
@@ -16,14 +16,22 @@
 import type { GraphQLFormattedError } from 'graphql';
 
 /**
+ * Base class for all errors raised by the indexer public data provider.
+ * Consumers can catch any indexer error with a single `instanceof IndexerError` check.
+ */
+export abstract class IndexerError extends Error {}
+
+/**
  * An error describing the causes of error that occurred during server-side execution of
  * a query against the Indexer.
  */
-export class IndexerFormattedError extends Error {
+export class IndexerFormattedError extends IndexerError {
   /**
    * @param cause An array of GraphQL errors that occurred during the server-side execution.
    */
   constructor(public readonly cause: readonly GraphQLFormattedError[]) {
-    super(`Indexer GraphQL error(s):\n${cause.reduce((acc, c, idx) => `${idx + 1}. ${c.message}:\n\t${acc}`, '')}`);
+    const formatted = cause.map((c, idx) => `${idx + 1}. ${c.message}`).join('\n\t');
+    super(`Indexer GraphQL error(s):\n\t${formatted}`);
+    this.name = 'IndexerFormattedError';
   }
 }

--- a/packages/indexer-public-data-provider/src/errors.ts
+++ b/packages/indexer-public-data-provider/src/errors.ts
@@ -22,12 +22,15 @@ import type { GraphQLFormattedError } from 'graphql';
 export abstract class IndexerError extends Error {}
 
 /**
- * An error describing the causes of error that occurred during server-side execution of
- * a query against the Indexer.
+ * Raised when a GraphQL response includes one or more `GraphQLFormattedError`
+ * entries. Aggregates all server-side errors into a single numbered message
+ * and exposes the original array via {@link cause}.
+ *
+ * Transport-level and other Apollo failures are reported via {@link IndexerQueryError}.
  */
 export class IndexerFormattedError extends IndexerError {
   /**
-   * @param cause An array of GraphQL errors that occurred during the server-side execution.
+   * @param cause The GraphQL errors reported by the server.
    */
   constructor(public readonly cause: readonly GraphQLFormattedError[]) {
     const formatted = cause.map((c, idx) => `${idx + 1}. ${c.message}`).join('\n\t');
@@ -38,7 +41,7 @@ export class IndexerFormattedError extends IndexerError {
 
 /**
  * An error raised when an Apollo query or fetch returns a transport-level or
- * GraphQL-level error. Preserves the original Apollo error via {@link Error.cause}
+ * GraphQL-level error. Preserves the original Apollo error via `Error.cause`
  * so consumers can inspect network details, GraphQL errors, and the original stack.
  */
 export class IndexerQueryError extends IndexerError {
@@ -49,11 +52,18 @@ export class IndexerQueryError extends IndexerError {
 }
 
 /**
+ * Subscription payload fields the indexer provider depends on.
+ * Narrowing this to a literal union prevents typos at throw sites and
+ * documents the exhaustive set of fields the provider currently reads.
+ */
+export type IndexerSubscriptionField = 'blocks' | 'contractActions';
+
+/**
  * An error raised when an indexer subscription payload is missing a field
  * the provider relies on. Carries the missing field name for diagnostics.
  */
 export class IndexerSubscriptionDataError extends IndexerError {
-  constructor(public readonly missingField: string) {
+  constructor(public readonly missingField: IndexerSubscriptionField) {
     super(`Expected '${missingField}' in indexer subscription data, got null/undefined`);
     this.name = 'IndexerSubscriptionDataError';
   }

--- a/packages/indexer-public-data-provider/src/errors.ts
+++ b/packages/indexer-public-data-provider/src/errors.ts
@@ -47,3 +47,14 @@ export class IndexerQueryError extends IndexerError {
     this.name = 'IndexerQueryError';
   }
 }
+
+/**
+ * An error raised when an indexer subscription payload is missing a field
+ * the provider relies on. Carries the missing field name for diagnostics.
+ */
+export class IndexerSubscriptionDataError extends IndexerError {
+  constructor(public readonly missingField: string) {
+    super(`Expected '${missingField}' in indexer subscription data, got null/undefined`);
+    this.name = 'IndexerSubscriptionDataError';
+  }
+}

--- a/packages/indexer-public-data-provider/src/errors.ts
+++ b/packages/indexer-public-data-provider/src/errors.ts
@@ -52,6 +52,23 @@ export class IndexerQueryError extends IndexerError {
 }
 
 /**
+ * An error raised when indexer-returned data is structurally inconsistent
+ * with the provider's expectations: unknown enum values, broken referential
+ * integrity between related rows, or missing relations the schema implies
+ * should be present.
+ *
+ * Distinct from {@link IndexerSubscriptionDataError} (which reports a missing
+ * top-level field on a subscription payload) and {@link IndexerFormattedError}
+ * (which reports errors the server explicitly returned).
+ */
+export class IndexerDataError extends IndexerError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'IndexerDataError';
+  }
+}
+
+/**
  * Subscription payload fields the indexer provider depends on.
  * Narrowing this to a literal union prevents typos at throw sites and
  * documents the exhaustive set of fields the provider currently reads.

--- a/packages/indexer-public-data-provider/src/errors.ts
+++ b/packages/indexer-public-data-provider/src/errors.ts
@@ -24,16 +24,21 @@ export abstract class IndexerError extends Error {}
 /**
  * Raised when a GraphQL response includes one or more `GraphQLFormattedError`
  * entries. Aggregates all server-side errors into a single numbered message
- * and exposes the original array via {@link cause}.
+ * and exposes the original array via {@link errors}.
+ *
+ * The field is named `errors` (not `cause`) because the standard ES2022
+ * `Error.cause` slot is contractually a single underlying error, not a
+ * peer collection. Reusing `cause` would confuse Node's `util.inspect`
+ * causal chain, Sentry, and other structured loggers.
  *
  * Transport-level and other Apollo failures are reported via {@link IndexerQueryError}.
  */
 export class IndexerFormattedError extends IndexerError {
   /**
-   * @param cause The GraphQL errors reported by the server.
+   * @param errors The GraphQL errors reported by the server.
    */
-  constructor(public readonly cause: readonly GraphQLFormattedError[]) {
-    const formatted = cause.map((c, idx) => `${idx + 1}. ${c.message}`).join('\n\t');
+  constructor(public readonly errors: readonly GraphQLFormattedError[]) {
+    const formatted = errors.map((e, idx) => `${idx + 1}. ${e.message}`).join('\n\t');
     super(`Indexer GraphQL error(s):\n\t${formatted}`);
     this.name = 'IndexerFormattedError';
   }

--- a/packages/indexer-public-data-provider/src/errors.ts
+++ b/packages/indexer-public-data-provider/src/errors.ts
@@ -85,3 +85,16 @@ export class IndexerSubscriptionDataError extends IndexerError {
     this.name = 'IndexerSubscriptionDataError';
   }
 }
+
+/**
+ * An error raised when the consumer passes a configuration that the indexer
+ * provider does not support (e.g. an observable mode that cannot be served
+ * by the indexer's query surface). Signals API misuse, not server-side
+ * issues — separate semantic category from {@link IndexerDataError}.
+ */
+export class IndexerProviderConfigError extends IndexerError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'IndexerProviderConfigError';
+  }
+}

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -283,6 +283,50 @@ const transformContractBalanceToUnshieldedBalance = (contractBalance: ContractBa
 export const toUnshieldedBalances = (contractBalances: readonly ContractBalance[]): UnshieldedBalances =>
   contractBalances.map(transformContractBalanceToUnshieldedBalance);
 
+/**
+ * Builds a {@link FinalizedTxData} for a deploy transaction by correlating
+ * the contract action at {@link contractAddress} with the transaction's
+ * identifier at the same index. Throws an {@link IndexerDataError} if the
+ * deploy lacks an action for the address, or if the action's identifier
+ * slot is missing — both indicate that the indexer's contract-action /
+ * identifier rows are out of sync for this transaction.
+ */
+export const toFinalizedDeployTxData = (
+  contractAddress: ContractAddress,
+  transaction: RegularTransaction
+): FinalizedTxData => {
+  const actionIndex = transaction.contractActions.findIndex(
+    ({ address }) => address === contractAddress
+  );
+  const txId = actionIndex >= 0 ? transaction.identifiers[actionIndex] : undefined;
+  if (txId === undefined) {
+    throw IndexerDataError.missingIdentifier(
+      contractAddress,
+      actionIndex,
+      transaction.identifiers.length
+    );
+  }
+  return {
+    tx: deserializeTransaction(transaction.raw),
+    status: toTxStatus(transaction.transactionResult),
+    txId,
+    identifiers: transaction.identifiers,
+    txHash: transaction.hash,
+    blockHeight: transaction.block.height,
+    blockHash: transaction.block.hash,
+    blockTimestamp: transaction.block.timestamp,
+    blockAuthor: transaction.block.author,
+    segmentStatusMap: toSegmentStatusMap(transaction.transactionResult),
+    unshielded: toUnshieldedUtxos(transaction.unshieldedCreatedOutputs, transaction.unshieldedSpentOutputs),
+    indexerId: transaction.id,
+    protocolVersion: transaction.protocolVersion,
+    fees: {
+      estimatedFees: transaction.fees.estimatedFees,
+      paidFees: transaction.fees.paidFees
+    }
+  };
+};
+
 const blockToContractState$ = (contractAddress: ContractAddress) => (block: Block) =>
   Rx.from(block.transactions).pipe(
     Rx.concatMap(({ contractActions }) => Rx.from(contractActions)),
@@ -645,38 +689,9 @@ const indexerPublicDataProviderInternal = (
               return 'deploy' in contract ? contract.deploy.transaction : contract.transaction;
             }),
             Rx.filter(isRegularTransaction),
-            Rx.map((transaction: RegularTransaction): FinalizedTxData => {
-              const actionIndex = transaction.contractActions.findIndex(
-                ({ address }) => address === contractAddress
-              );
-              const txId = actionIndex >= 0 ? transaction.identifiers[actionIndex] : undefined;
-              if (txId === undefined) {
-                throw IndexerDataError.missingIdentifier(
-                  contractAddress,
-                  actionIndex,
-                  transaction.identifiers.length
-                );
-              }
-              return {
-                tx: deserializeTransaction(transaction.raw),
-                status: toTxStatus(transaction.transactionResult),
-                txId,
-                identifiers: transaction.identifiers,
-                txHash: transaction.hash,
-                blockHeight: transaction.block.height,
-                blockHash: transaction.block.hash,
-                blockTimestamp: transaction.block.timestamp,
-                blockAuthor: transaction.block.author,
-                segmentStatusMap: toSegmentStatusMap(transaction.transactionResult),
-                unshielded: toUnshieldedUtxos(transaction.unshieldedCreatedOutputs, transaction.unshieldedSpentOutputs),
-                indexerId: transaction.id,
-                protocolVersion: transaction.protocolVersion,
-                fees: {
-                  estimatedFees: transaction.fees.estimatedFees,
-                  paidFees: transaction.fees.paidFees
-                },
-              };
-            })
+            Rx.map((transaction: RegularTransaction) =>
+              toFinalizedDeployTxData(contractAddress, transaction)
+            )
           )
       );
     },

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -55,7 +55,7 @@ import { createClient } from 'graphql-ws';
 import * as ws from 'isomorphic-ws';
 import * as Rx from 'rxjs';
 
-import { IndexerFormattedError, IndexerQueryError } from './errors';
+import { IndexerFormattedError, IndexerQueryError, IndexerSubscriptionDataError } from './errors';
 import {
   type BlockOffset,
   type ContractActionOffset,
@@ -163,7 +163,10 @@ const blockOffsetToBlock$ = (apolloClient: ApolloClient) => (offset: InputMaybe<
     .pipe(
       withValidFetchData(),
       Rx.map((data) => {
-        const blocks = data.blocks!;
+        const blocks = data.blocks;
+        if (!blocks) {
+          throw new IndexerSubscriptionDataError('blocks');
+        }
         return {
           hash: blocks.hash,
           height: blocks.height,
@@ -323,7 +326,13 @@ const blockOffsetToContractState$ =
       })
       .pipe(
         withValidFetchData(),
-        Rx.map((data) => data.contractActions!.state),
+        Rx.map((data) => {
+          const contractActions = data.contractActions;
+          if (!contractActions) {
+            throw new IndexerSubscriptionDataError('contractActions');
+          }
+          return contractActions.state;
+        }),
         Rx.map(deserializeContractState)
       );
 
@@ -413,7 +422,10 @@ const blockOffsetToUnshieldedBalances$ =
       .pipe(
         withValidFetchData(),
         Rx.map((data) => {
-          const contractAction = data.contractActions!;
+          const contractAction = data.contractActions;
+          if (!contractAction) {
+            throw new IndexerSubscriptionDataError('contractActions');
+          }
           if ('unshieldedBalances' in contractAction) {
             return contractAction.unshieldedBalances;
           }

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -284,48 +284,50 @@ export const toUnshieldedBalances = (contractBalances: readonly ContractBalance[
   contractBalances.map(transformContractBalanceToUnshieldedBalance);
 
 /**
- * Builds a {@link FinalizedTxData} for a deploy transaction by correlating
- * the contract action at {@link contractAddress} with the transaction's
- * identifier at the same index. Throws an {@link IndexerDataError} if the
- * deploy lacks an action for the address, or if the action's identifier
- * slot is missing — both indicate that the indexer's contract-action /
- * identifier rows are out of sync for this transaction.
+ * Correlates a contract action at `contractAddress` with the transaction's
+ * identifier at the same positional index. Throws {@link IndexerDataError}
+ * when the deploy lacks an action for the address, or when the
+ * corresponding identifier slot is missing — both indicate that the
+ * indexer's contract-action / identifier rows are out of sync.
+ *
+ * Exported for unit testing the correlation in isolation. Production
+ * callers should go through {@link PublicDataProvider.watchForDeployTxData}.
  */
-export const toFinalizedDeployTxData = (
+export const correlateDeployTxId = (
+  contractAddress: ContractAddress,
+  contractActions: readonly { readonly address: string }[],
+  identifiers: readonly string[]
+): string => {
+  const actionIndex = contractActions.findIndex(({ address }) => address === contractAddress);
+  const txId = actionIndex >= 0 ? identifiers[actionIndex] : undefined;
+  if (txId === undefined) {
+    throw IndexerDataError.missingIdentifier(contractAddress, actionIndex, identifiers.length);
+  }
+  return txId;
+};
+
+const toFinalizedDeployTxData = (
   contractAddress: ContractAddress,
   transaction: RegularTransaction
-): FinalizedTxData => {
-  const actionIndex = transaction.contractActions.findIndex(
-    ({ address }) => address === contractAddress
-  );
-  const txId = actionIndex >= 0 ? transaction.identifiers[actionIndex] : undefined;
-  if (txId === undefined) {
-    throw IndexerDataError.missingIdentifier(
-      contractAddress,
-      actionIndex,
-      transaction.identifiers.length
-    );
+): FinalizedTxData => ({
+  tx: deserializeTransaction(transaction.raw),
+  status: toTxStatus(transaction.transactionResult),
+  txId: correlateDeployTxId(contractAddress, transaction.contractActions, transaction.identifiers),
+  identifiers: transaction.identifiers,
+  txHash: transaction.hash,
+  blockHeight: transaction.block.height,
+  blockHash: transaction.block.hash,
+  blockTimestamp: transaction.block.timestamp,
+  blockAuthor: transaction.block.author,
+  segmentStatusMap: toSegmentStatusMap(transaction.transactionResult),
+  unshielded: toUnshieldedUtxos(transaction.unshieldedCreatedOutputs, transaction.unshieldedSpentOutputs),
+  indexerId: transaction.id,
+  protocolVersion: transaction.protocolVersion,
+  fees: {
+    estimatedFees: transaction.fees.estimatedFees,
+    paidFees: transaction.fees.paidFees
   }
-  return {
-    tx: deserializeTransaction(transaction.raw),
-    status: toTxStatus(transaction.transactionResult),
-    txId,
-    identifiers: transaction.identifiers,
-    txHash: transaction.hash,
-    blockHeight: transaction.block.height,
-    blockHash: transaction.block.hash,
-    blockTimestamp: transaction.block.timestamp,
-    blockAuthor: transaction.block.author,
-    segmentStatusMap: toSegmentStatusMap(transaction.transactionResult),
-    unshielded: toUnshieldedUtxos(transaction.unshieldedCreatedOutputs, transaction.unshieldedSpentOutputs),
-    indexerId: transaction.id,
-    protocolVersion: transaction.protocolVersion,
-    fees: {
-      estimatedFees: transaction.fees.estimatedFees,
-      paidFees: transaction.fees.paidFees
-    }
-  };
-};
+});
 
 const blockToContractState$ = (contractAddress: ContractAddress) => (block: Block) =>
   Rx.from(block.transactions).pipe(

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -93,7 +93,7 @@ export const isRegularTransaction = (
   return 'identifiers' in tx && 'hash' in tx && Array.isArray(tx.identifiers);
 };
 
-const maybeThrowQueryError = <R extends { error?: Error & { message: string } }>(result: R): R => {
+const maybeThrowQueryError = <R extends { error?: { message: string } }>(result: R): R => {
   if (result.error) {
     throw new IndexerQueryError(result.error.message, { cause: result.error });
   }

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -58,6 +58,7 @@ import * as Rx from 'rxjs';
 import {
   IndexerDataError,
   IndexerFormattedError,
+  IndexerProviderConfigError,
   IndexerQueryError,
   IndexerSubscriptionDataError
 } from './errors';
@@ -756,7 +757,9 @@ const indexerPublicDataProviderInternal = (
       config: ContractStateObservableConfig = { type: 'latest' }
     ): Rx.Observable<UnshieldedBalances> {
       if (config.type === 'txId') {
-        throw new Error('txId configuration not supported for unshielded balances observable');
+        throw new IndexerProviderConfigError(
+          'txId configuration not supported for unshielded balances observable'
+        );
       }
       if (config.type === 'latest') {
         return contractAddressToLatestBlockOffset$(apolloClient)(contractAddress).pipe(

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -236,7 +236,7 @@ export const toTxStatus = (transactionResult: TransactionResult): TxStatus => {
   if (result === 'FAILURE' || result === 'PARTIAL_SUCCESS' || result === 'SUCCESS') {
     return map[result];
   }
-  throw new IndexerDataError(`Unexpected transaction status value: ${result}`);
+  throw IndexerDataError.unknownStatus(result);
 };
 
 export const toSegmentStatus = (success: boolean): SegmentStatus =>
@@ -603,9 +603,7 @@ const indexerPublicDataProviderInternal = (
               ({ address }) => address === contractAddress
             );
             if (!deployAction) {
-              throw new IndexerDataError(
-                `Deploy transaction does not contain a contract action for address ${contractAddress}`
-              );
+              throw IndexerDataError.missingContractAction(contractAddress);
             }
             return deployAction.state;
           }
@@ -653,8 +651,10 @@ const indexerPublicDataProviderInternal = (
               );
               const txId = actionIndex >= 0 ? transaction.identifiers[actionIndex] : undefined;
               if (txId === undefined) {
-                throw new IndexerDataError(
-                  `Transaction missing identifier for contract action at address ${contractAddress}`
+                throw IndexerDataError.missingIdentifier(
+                  contractAddress,
+                  actionIndex,
+                  transaction.identifiers.length
                 );
               }
               return {

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -55,7 +55,12 @@ import { createClient } from 'graphql-ws';
 import * as ws from 'isomorphic-ws';
 import * as Rx from 'rxjs';
 
-import { IndexerFormattedError, IndexerQueryError, IndexerSubscriptionDataError } from './errors';
+import {
+  IndexerDataError,
+  IndexerFormattedError,
+  IndexerQueryError,
+  IndexerSubscriptionDataError
+} from './errors';
 import {
   type BlockOffset,
   type ContractActionOffset,
@@ -230,7 +235,7 @@ export const toTxStatus = (transactionResult: TransactionResult): TxStatus => {
   if (result === 'FAILURE' || result === 'PARTIAL_SUCCESS' || result === 'SUCCESS') {
     return map[result];
   }
-  throw new Error(`Unexpected 'status' value ${result}`);
+  throw new IndexerDataError(`Unexpected transaction status value: ${result}`);
 };
 
 export const toSegmentStatus = (success: boolean): SegmentStatus =>
@@ -590,9 +595,18 @@ const indexerPublicDataProviderInternal = (
             const contract = queryResult.data.contractAction as ExcludeEmptyAndNull<
               DeployContractStateTxQueryQuery['contractAction']
             >;
-            return 'deploy' in contract
-              ? contract.deploy.transaction.contractActions.find(({ address }) => address === contractAddress)!.state
-              : contract.state;
+            if (!('deploy' in contract)) {
+              return contract.state;
+            }
+            const deployAction = contract.deploy.transaction.contractActions.find(
+              ({ address }) => address === contractAddress
+            );
+            if (!deployAction) {
+              throw new IndexerDataError(
+                `Deploy transaction does not contain a contract action for address ${contractAddress}`
+              );
+            }
+            return deployAction.state;
           }
           return null;
         })
@@ -632,13 +646,20 @@ const indexerPublicDataProviderInternal = (
               return 'deploy' in contract ? contract.deploy.transaction : contract.transaction;
             }),
             Rx.filter(isRegularTransaction),
-            Rx.map(
-              (transaction: RegularTransaction): FinalizedTxData => ({
+            Rx.map((transaction: RegularTransaction): FinalizedTxData => {
+              const actionIndex = transaction.contractActions.findIndex(
+                ({ address }) => address === contractAddress
+              );
+              const txId = actionIndex >= 0 ? transaction.identifiers[actionIndex] : undefined;
+              if (txId === undefined) {
+                throw new IndexerDataError(
+                  `Transaction missing identifier for contract action at address ${contractAddress}`
+                );
+              }
+              return {
                 tx: deserializeTransaction(transaction.raw),
                 status: toTxStatus(transaction.transactionResult),
-                txId: transaction.identifiers[
-                  transaction.contractActions.findIndex(({ address }) => address === contractAddress)
-                ]!,
+                txId,
                 identifiers: transaction.identifiers,
                 txHash: transaction.hash,
                 blockHeight: transaction.block.height,
@@ -653,8 +674,8 @@ const indexerPublicDataProviderInternal = (
                   estimatedFees: transaction.fees.estimatedFees,
                   paidFees: transaction.fees.paidFees
                 },
-              })
-            )
+              };
+            })
           )
       );
     },

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -291,12 +291,13 @@ export const toUnshieldedBalances = (contractBalances: readonly ContractBalance[
 /**
  * Correlates a contract action at `contractAddress` with the transaction's
  * identifier at the same positional index. Throws {@link IndexerDataError}
- * when the deploy lacks an action for the address, or when the
- * corresponding identifier slot is missing — both indicate that the
- * indexer's contract-action / identifier rows are out of sync.
+ * when the deploy lacks an action for the address, when the corresponding
+ * identifier slot is missing, or when the identifier is not a non-empty
+ * string — all indicate that the indexer's contract-action / identifier
+ * rows are out of sync.
  *
- * Exported for unit testing the correlation in isolation. Production
- * callers should go through {@link PublicDataProvider.watchForDeployTxData}.
+ * @internal Exported for unit testing the correlation in isolation.
+ * Production callers should go through `PublicDataProvider.watchForDeployTxData`.
  */
 export const correlateDeployTxId = (
   contractAddress: ContractAddress,
@@ -305,7 +306,7 @@ export const correlateDeployTxId = (
 ): string => {
   const actionIndex = contractActions.findIndex(({ address }) => address === contractAddress);
   const txId = actionIndex >= 0 ? identifiers[actionIndex] : undefined;
-  if (txId === undefined) {
+  if (typeof txId !== 'string' || txId.length === 0) {
     throw IndexerDataError.missingIdentifier(contractAddress, actionIndex, identifiers.length);
   }
   return txId;

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -99,6 +99,11 @@ export const isRegularTransaction = (
   return 'identifiers' in tx && 'hash' in tx && Array.isArray(tx.identifiers);
 };
 
+const hasContractAction = <T extends { contractAction?: unknown }>(
+  data: T
+): data is T & { contractAction: NonNullable<T['contractAction']> } =>
+  data.contractAction != null;
+
 const maybeThrowQueryError = <R extends { error?: { message: string } }>(result: R): R => {
   if (result.error) {
     throw new IndexerQueryError(result.error.message, { cause: result.error });
@@ -406,8 +411,8 @@ const waitForContractToAppear =
       })
       .pipe(
         withCompleteQueryData(),
-        Rx.filter((data) => data.contractAction !== null),
-        Rx.map((data) => data.contractAction!.state),
+        Rx.filter(hasContractAction),
+        Rx.map((data) => data.contractAction.state),
         Rx.take(1)
       );
 
@@ -444,9 +449,9 @@ const waitForUnshieldedBalancesToAppear =
       })
       .pipe(
         withCompleteQueryData(),
-        Rx.filter((data) => data.contractAction !== null),
+        Rx.filter(hasContractAction),
         Rx.map((data) => {
-          const contractAction = data.contractAction!;
+          const { contractAction } = data;
           if ('unshieldedBalances' in contractAction) {
             return contractAction.unshieldedBalances;
           }

--- a/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
+++ b/packages/indexer-public-data-provider/src/indexer-public-data-provider.ts
@@ -55,7 +55,7 @@ import { createClient } from 'graphql-ws';
 import * as ws from 'isomorphic-ws';
 import * as Rx from 'rxjs';
 
-import { IndexerFormattedError } from './errors';
+import { IndexerFormattedError, IndexerQueryError } from './errors';
 import {
   type BlockOffset,
   type ContractActionOffset,
@@ -93,9 +93,9 @@ export const isRegularTransaction = (
   return 'identifiers' in tx && 'hash' in tx && Array.isArray(tx.identifiers);
 };
 
-const maybeThrowQueryError = <R extends { error?: { message: string } }>(result: R): R => {
+const maybeThrowQueryError = <R extends { error?: Error & { message: string } }>(result: R): R => {
   if (result.error) {
-    throw new Error(result.error.message);
+    throw new IndexerQueryError(result.error.message, { cause: result.error });
   }
   return result;
 };
@@ -103,7 +103,7 @@ const maybeThrowQueryError = <R extends { error?: { message: string } }>(result:
 const withCompleteQueryData = <A>(): Rx.OperatorFunction<ApolloQueryResult<A>, A> =>
   Rx.pipe(
     Rx.filter((result: ApolloQueryResult<A>) => {
-      if (result.error) throw new Error(result.error.message);
+      if (result.error) throw new IndexerQueryError(result.error.message, { cause: result.error });
       return result.dataState === 'complete';
     }),
     // Safe: dataState === 'complete' guarantees data is Complete<A> which defaults to A

--- a/packages/indexer-public-data-provider/src/test/indexer-public-data-provider.test.ts
+++ b/packages/indexer-public-data-provider/src/test/indexer-public-data-provider.test.ts
@@ -13,6 +13,9 @@
  * limitations under the License.
  */
 
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+
+import { IndexerProviderConfigError } from '../errors';
 import { indexerPublicDataProvider } from '../indexer-public-data-provider';
 
 describe('indexerPublicDataProvider', () => {
@@ -53,5 +56,14 @@ describe('indexerPublicDataProvider', () => {
   test('indexerPublicDataProvider should use the provided WebSocket implementation', () => {
     const provider = indexerPublicDataProvider(queryURL, subscriptionURL);
     expect(provider).toBeDefined();
+  });
+
+  test('unshieldedBalancesObservable rejects txId configuration with IndexerProviderConfigError', () => {
+    const provider = indexerPublicDataProvider(queryURL, subscriptionURL);
+    const address = '0'.repeat(64) as ContractAddress;
+
+    expect(() => provider.unshieldedBalancesObservable(address, { type: 'txId', txId: 'unused' })).toThrow(
+      IndexerProviderConfigError
+    );
   });
 });

--- a/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
+++ b/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
@@ -26,6 +26,7 @@ import {
   IndexerDataError,
   IndexerError,
   IndexerFormattedError,
+  IndexerProviderConfigError,
   IndexerQueryError,
   IndexerSubscriptionDataError
 } from '../errors';
@@ -283,5 +284,16 @@ describe('IndexerDataError', () => {
     expect(error).toBeInstanceOf(IndexerError);
     expect(error.name).toBe('IndexerDataError');
     expect(error.message).toBe('Indexer returned malformed payload');
+  });
+});
+
+describe('IndexerProviderConfigError', () => {
+  test('exposes message and name', () => {
+    const error = new IndexerProviderConfigError('Unsupported observable mode: txId');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(IndexerError);
+    expect(error.name).toBe('IndexerProviderConfigError');
+    expect(error.message).toBe('Unsupported observable mode: txId');
   });
 });

--- a/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
+++ b/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
@@ -240,12 +240,13 @@ describe('IndexerFormattedError', () => {
     );
   });
 
-  test('preserves cause array', () => {
-    const causes = [{ message: 'err1' }, { message: 'err2' }];
+  test('exposes the underlying errors array', () => {
+    const graphqlErrors = [{ message: 'err1' }, { message: 'err2' }];
 
-    const error = new IndexerFormattedError(causes);
+    const error = new IndexerFormattedError(graphqlErrors);
 
-    expect(error.cause).toBe(causes);
+    expect(error.errors).toBe(graphqlErrors);
+    expect(error.cause).toBeUndefined();
   });
 });
 

--- a/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
+++ b/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
@@ -22,7 +22,7 @@ import {
 } from '@midnight-ntwrk/midnight-js-types';
 import { describe, expect, test } from 'vitest';
 
-import { IndexerError, IndexerFormattedError } from '../errors';
+import { IndexerError, IndexerFormattedError, IndexerQueryError } from '../errors';
 import type { TransactionResult } from '../gen/graphql';
 import {
   type IndexerUtxo,
@@ -231,5 +231,25 @@ describe('IndexerFormattedError', () => {
     const error = new IndexerFormattedError(causes);
 
     expect(error.cause).toBe(causes);
+  });
+});
+
+describe('IndexerQueryError', () => {
+  test('exposes message and name', () => {
+    const error = new IndexerQueryError('Query failed');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(IndexerError);
+    expect(error.name).toBe('IndexerQueryError');
+    expect(error.message).toBe('Query failed');
+  });
+
+  test('preserves original error via cause', () => {
+    const originalError = new Error('Network unreachable');
+
+    const error = new IndexerQueryError(originalError.message, { cause: originalError });
+
+    expect(error.cause).toBe(originalError);
+    expect(error.message).toBe('Network unreachable');
   });
 });

--- a/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
+++ b/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import {
   FailEntirely,
   FailFallible,
@@ -30,10 +31,11 @@ import {
   IndexerQueryError,
   IndexerSubscriptionDataError
 } from '../errors';
-import type { TransactionResult } from '../gen/graphql';
+import type { RegularTransaction, TransactionResult } from '../gen/graphql';
 import {
   type IndexerUtxo,
   isRegularTransaction,
+  toFinalizedDeployTxData,
   toSegmentStatus,
   toSegmentStatusMap,
   toTxStatus,
@@ -278,6 +280,54 @@ describe('IndexerSubscriptionDataError', () => {
     expect(error.message).toBe(
       "Expected 'blocks' in indexer subscription data, got null/undefined"
     );
+  });
+});
+
+describe('toFinalizedDeployTxData', () => {
+  const targetAddress = '0xdeadbeef' as ContractAddress;
+
+  // Tests exercise only the contractActions/identifiers correlation; other
+  // RegularTransaction fields are unreachable from the throw path so the
+  // helper accepts a loose shape and narrows once at the return.
+  const minimalTx = (fields: { contractActions: { address: string }[]; identifiers: string[] }): RegularTransaction =>
+    fields as unknown as RegularTransaction;
+
+  test('throws missing-identifier with actionIndex=-1 when no contract action matches', () => {
+    const transaction = minimalTx({
+      contractActions: [{ address: '0xaaaa' }, { address: '0xbbbb' }],
+      identifiers: ['id-a', 'id-b']
+    });
+
+    let thrown: unknown;
+    try { toFinalizedDeployTxData(targetAddress, transaction); } catch (e) { thrown = e; }
+
+    expect(thrown).toBeInstanceOf(IndexerDataError);
+    const error = thrown as IndexerDataError;
+    expect(error.context).toEqual({
+      kind: 'missing-identifier',
+      contractAddress: targetAddress,
+      actionIndex: -1,
+      identifiersLength: 2
+    });
+  });
+
+  test('throws missing-identifier when contractAction matches but identifier slot is undefined', () => {
+    const transaction = minimalTx({
+      contractActions: [{ address: '0xaaaa' }, { address: targetAddress }],
+      identifiers: ['id-a']
+    });
+
+    let thrown: unknown;
+    try { toFinalizedDeployTxData(targetAddress, transaction); } catch (e) { thrown = e; }
+
+    expect(thrown).toBeInstanceOf(IndexerDataError);
+    const error = thrown as IndexerDataError;
+    expect(error.context).toEqual({
+      kind: 'missing-identifier',
+      contractAddress: targetAddress,
+      actionIndex: 1,
+      identifiersLength: 1
+    });
   });
 });
 

--- a/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
+++ b/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
@@ -336,6 +336,26 @@ describe('correlateDeployTxId', () => {
       identifiersLength: 1
     });
   });
+
+  test('throws missing-identifier when the identifier slot is an empty string', () => {
+    let thrown: unknown;
+    try {
+      correlateDeployTxId(
+        targetAddress,
+        [{ address: targetAddress }, { address: '0xaaaa' }],
+        ['', 'id-a']
+      );
+    } catch (e) { thrown = e; }
+
+    expect(thrown).toBeInstanceOf(IndexerDataError);
+    const error = thrown as IndexerDataError;
+    expect(error.context).toEqual({
+      kind: 'missing-identifier',
+      contractAddress: targetAddress,
+      actionIndex: 0,
+      identifiersLength: 2
+    });
+  });
 });
 
 describe('IndexerDataError', () => {

--- a/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
+++ b/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
@@ -99,8 +99,13 @@ describe('toTxStatus', () => {
   test('throws IndexerDataError for unknown status', () => {
     const result = { status: 'UNKNOWN', segments: null } as unknown as TransactionResult;
 
-    expect(() => toTxStatus(result)).toThrow(IndexerDataError);
-    expect(() => toTxStatus(result)).toThrow("Unexpected transaction status value: UNKNOWN");
+    let thrown: unknown;
+    try { toTxStatus(result); } catch (e) { thrown = e; }
+
+    expect(thrown).toBeInstanceOf(IndexerDataError);
+    const error = thrown as IndexerDataError;
+    expect(error.context).toEqual({ kind: 'unknown-status', value: 'UNKNOWN' });
+    expect(error.message).toBe('Unexpected transaction status value: UNKNOWN');
   });
 });
 
@@ -277,13 +282,37 @@ describe('IndexerSubscriptionDataError', () => {
 });
 
 describe('IndexerDataError', () => {
-  test('exposes message and name', () => {
-    const error = new IndexerDataError('Indexer returned malformed payload');
+  test('unknownStatus factory builds discriminated context and derived message', () => {
+    const error = IndexerDataError.unknownStatus('WEIRD');
 
     expect(error).toBeInstanceOf(Error);
     expect(error).toBeInstanceOf(IndexerError);
     expect(error.name).toBe('IndexerDataError');
-    expect(error.message).toBe('Indexer returned malformed payload');
+    expect(error.context).toEqual({ kind: 'unknown-status', value: 'WEIRD' });
+    expect(error.message).toBe('Unexpected transaction status value: WEIRD');
+  });
+
+  test('missingContractAction factory builds discriminated context and derived message', () => {
+    const error = IndexerDataError.missingContractAction('0xabc');
+
+    expect(error.context).toEqual({ kind: 'missing-contract-action', contractAddress: '0xabc' });
+    expect(error.message).toBe(
+      'Deploy transaction does not contain a contract action for address 0xabc'
+    );
+  });
+
+  test('missingIdentifier factory captures address, index and identifiers length', () => {
+    const error = IndexerDataError.missingIdentifier('0xabc', -1, 3);
+
+    expect(error.context).toEqual({
+      kind: 'missing-identifier',
+      contractAddress: '0xabc',
+      actionIndex: -1,
+      identifiersLength: 3
+    });
+    expect(error.message).toBe(
+      'Transaction missing identifier for contract action at address 0xabc (actionIndex=-1, identifiers.length=3)'
+    );
   });
 });
 

--- a/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
+++ b/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
@@ -31,11 +31,11 @@ import {
   IndexerQueryError,
   IndexerSubscriptionDataError
 } from '../errors';
-import type { RegularTransaction, TransactionResult } from '../gen/graphql';
+import type { TransactionResult } from '../gen/graphql';
 import {
+  correlateDeployTxId,
   type IndexerUtxo,
   isRegularTransaction,
-  toFinalizedDeployTxData,
   toSegmentStatus,
   toSegmentStatusMap,
   toTxStatus,
@@ -284,23 +284,28 @@ describe('IndexerSubscriptionDataError', () => {
   });
 });
 
-describe('toFinalizedDeployTxData', () => {
+describe('correlateDeployTxId', () => {
   const targetAddress = '0xdeadbeef' as ContractAddress;
 
-  // Tests exercise only the contractActions/identifiers correlation; other
-  // RegularTransaction fields are unreachable from the throw path so the
-  // helper accepts a loose shape and narrows once at the return.
-  const minimalTx = (fields: { contractActions: { address: string }[]; identifiers: string[] }): RegularTransaction =>
-    fields as unknown as RegularTransaction;
+  test('returns the identifier at the index of the matching contract action', () => {
+    const txId = correlateDeployTxId(
+      targetAddress,
+      [{ address: '0xaaaa' }, { address: targetAddress }, { address: '0xbbbb' }],
+      ['id-a', 'id-target', 'id-b']
+    );
+
+    expect(txId).toBe('id-target');
+  });
 
   test('throws missing-identifier with actionIndex=-1 when no contract action matches', () => {
-    const transaction = minimalTx({
-      contractActions: [{ address: '0xaaaa' }, { address: '0xbbbb' }],
-      identifiers: ['id-a', 'id-b']
-    });
-
     let thrown: unknown;
-    try { toFinalizedDeployTxData(targetAddress, transaction); } catch (e) { thrown = e; }
+    try {
+      correlateDeployTxId(
+        targetAddress,
+        [{ address: '0xaaaa' }, { address: '0xbbbb' }],
+        ['id-a', 'id-b']
+      );
+    } catch (e) { thrown = e; }
 
     expect(thrown).toBeInstanceOf(IndexerDataError);
     const error = thrown as IndexerDataError;
@@ -313,13 +318,14 @@ describe('toFinalizedDeployTxData', () => {
   });
 
   test('throws missing-identifier when contractAction matches but identifier slot is undefined', () => {
-    const transaction = minimalTx({
-      contractActions: [{ address: '0xaaaa' }, { address: targetAddress }],
-      identifiers: ['id-a']
-    });
-
     let thrown: unknown;
-    try { toFinalizedDeployTxData(targetAddress, transaction); } catch (e) { thrown = e; }
+    try {
+      correlateDeployTxId(
+        targetAddress,
+        [{ address: '0xaaaa' }, { address: targetAddress }],
+        ['id-a']
+      );
+    } catch (e) { thrown = e; }
 
     expect(thrown).toBeInstanceOf(IndexerDataError);
     const error = thrown as IndexerDataError;

--- a/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
+++ b/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
@@ -23,6 +23,7 @@ import {
 import { describe, expect, test } from 'vitest';
 
 import {
+  IndexerDataError,
   IndexerError,
   IndexerFormattedError,
   IndexerQueryError,
@@ -94,10 +95,11 @@ describe('toTxStatus', () => {
     expect(toTxStatus(result)).toBe(FailFallible);
   });
 
-  test('throws for unknown status', () => {
+  test('throws IndexerDataError for unknown status', () => {
     const result = { status: 'UNKNOWN', segments: null } as unknown as TransactionResult;
 
-    expect(() => toTxStatus(result)).toThrow("Unexpected 'status' value UNKNOWN");
+    expect(() => toTxStatus(result)).toThrow(IndexerDataError);
+    expect(() => toTxStatus(result)).toThrow("Unexpected transaction status value: UNKNOWN");
   });
 });
 
@@ -270,5 +272,16 @@ describe('IndexerSubscriptionDataError', () => {
     expect(error.message).toBe(
       "Expected 'blocks' in indexer subscription data, got null/undefined"
     );
+  });
+});
+
+describe('IndexerDataError', () => {
+  test('exposes message and name', () => {
+    const error = new IndexerDataError('Indexer returned malformed payload');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(IndexerError);
+    expect(error.name).toBe('IndexerDataError');
+    expect(error.message).toBe('Indexer returned malformed payload');
   });
 });

--- a/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
+++ b/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
@@ -22,7 +22,7 @@ import {
 } from '@midnight-ntwrk/midnight-js-types';
 import { describe, expect, test } from 'vitest';
 
-import { IndexerFormattedError } from '../errors';
+import { IndexerError, IndexerFormattedError } from '../errors';
 import type { TransactionResult } from '../gen/graphql';
 import {
   type IndexerUtxo,
@@ -204,22 +204,25 @@ describe('toUnshieldedBalances', () => {
 });
 
 describe('IndexerFormattedError', () => {
-  test('formats single GraphQL error', () => {
+  test('formats single GraphQL error with header and numbered prefix', () => {
     const error = new IndexerFormattedError([{ message: 'Something went wrong' }]);
 
     expect(error).toBeInstanceOf(Error);
-    expect(error.message).toContain('Indexer GraphQL error(s)');
-    expect(error.message).toContain('Something went wrong');
+    expect(error).toBeInstanceOf(IndexerError);
+    expect(error.name).toBe('IndexerFormattedError');
+    expect(error.message).toBe('Indexer GraphQL error(s):\n\t1. Something went wrong');
   });
 
-  test('formats multiple GraphQL errors', () => {
+  test('lists multiple GraphQL errors in original order separated by tab-newline', () => {
     const error = new IndexerFormattedError([
       { message: 'First error' },
-      { message: 'Second error' }
+      { message: 'Second error' },
+      { message: 'Third error' }
     ]);
 
-    expect(error.message).toContain('First error');
-    expect(error.message).toContain('Second error');
+    expect(error.message).toBe(
+      'Indexer GraphQL error(s):\n\t1. First error\n\t2. Second error\n\t3. Third error'
+    );
   });
 
   test('preserves cause array', () => {

--- a/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
+++ b/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
@@ -22,7 +22,12 @@ import {
 } from '@midnight-ntwrk/midnight-js-types';
 import { describe, expect, test } from 'vitest';
 
-import { IndexerError, IndexerFormattedError, IndexerQueryError } from '../errors';
+import {
+  IndexerError,
+  IndexerFormattedError,
+  IndexerQueryError,
+  IndexerSubscriptionDataError
+} from '../errors';
 import type { TransactionResult } from '../gen/graphql';
 import {
   type IndexerUtxo,
@@ -251,5 +256,19 @@ describe('IndexerQueryError', () => {
 
     expect(error.cause).toBe(originalError);
     expect(error.message).toBe('Network unreachable');
+  });
+});
+
+describe('IndexerSubscriptionDataError', () => {
+  test('describes the missing field in the message', () => {
+    const error = new IndexerSubscriptionDataError('blocks');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(IndexerError);
+    expect(error.name).toBe('IndexerSubscriptionDataError');
+    expect(error.missingField).toBe('blocks');
+    expect(error.message).toBe(
+      "Expected 'blocks' in indexer subscription data, got null/undefined"
+    );
   });
 });


### PR DESCRIPTION
# Overview

Hardens error handling across `packages/indexer-public-data-provider` with a coherent `IndexerError` hierarchy that preserves diagnostic context and eliminates silent failures.

A new abstract `IndexerError` base class is introduced so consumers can catch any provider error with a single `instanceof IndexerError` check (matching the `PrivateStateImportError` precedent in `packages/types`).

## ⚠ Breaking change

`IndexerFormattedError.cause` is renamed to `.errors`. The ES2022 `Error.cause` slot is contractually a single underlying error, not a peer collection of GraphQL errors. Shadowing it broke Node's `util.inspect` causal chain, Sentry grouping, and structured loggers. Consumers reading `err.cause` on this class must migrate to `err.errors`.

## Summary

### Issue fixes

- **#823** — `IndexerFormattedError` produced reversed, increasingly-nested error strings due to an accumulator bug in `reduce`. Replaced with `map().join('\n\t')` for an ordered numbered list. Existing tests used `toContain` which masked the regression — now strict `toBe` equality (per Common Mistake #3 in CLAUDE.md).
- **#822** — `maybeThrowQueryError` and `withCompleteQueryData` discarded the original Apollo error by re-wrapping in a plain `new Error(message)`. Replaced with `IndexerQueryError` carrying the original via `Error.cause`, preserving network details, GraphQL errors, and the original stack.
- **#821** — Three non-null assertions (`data.blocks!`, `data.contractActions!.state`, `data.contractActions!`) on subscription payloads replaced with explicit null checks raising `IndexerSubscriptionDataError`. The error names the missing field for actionable diagnostics. Field name typed as a literal union (`'blocks' | 'contractActions'`) for compile-time typo safety.

### Hardening (additional)

- **`IndexerDataError`** — class with discriminated `context` union for indexer-returned data that's structurally inconsistent. Static factories ensure message and context stay in sync. Applied at three sites previously throwing generic `Error` or hidden behind `!`:
  - `toTxStatus` — unknown transaction status enum value.
  - `queryDeployContractState` — `.find()` returning undefined when the deploy transaction lacks a contract action for the requested address (was `find(...)!.state`, would crash with cryptic TypeError).
  - `watchForDeployTxData` — `findIndex` returning -1, then `identifiers[-1]` silently becoming undefined and propagating into `FinalizedTxData.txId` (was `identifiers[findIndex(...)]!`, **worse** than #821 because it didn't crash — it returned `undefined` as a "valid" txId). Correlation extracted into `correlateDeployTxId` (`@internal`) with narrow types for cast-free testing. Guard rejects `undefined`, `null`, and empty-string identifier slots — the indexer cannot smuggle a blank txId through.
- **`IndexerProviderConfigError`** — class for consumer-side API misuse (config the provider can't serve). Applied at `unshieldedBalancesObservable`'s `txId` branch.
- **`hasContractAction` type predicate** — eliminates the remaining `data.contractAction!` non-null assertions in `waitForContractToAppear` and `waitForUnshieldedBalancesToAppear`. Same fragile pattern as #821 (`Rx.filter` guard + `!` lying to the type checker). Now the type narrows through the filter without an assertion; removing the filter becomes a compile error instead of a runtime crash.

## Error hierarchy

```
IndexerError (abstract)
├── IndexerFormattedError         GraphQL errors returned by server (errors[])
├── IndexerQueryError             Apollo transport / query failure (cause preserved)
├── IndexerSubscriptionDataError  Missing top-level field in subscription payload
├── IndexerDataError              Structurally inconsistent indexer response (discriminated context)
│     ├── kind: 'unknown-status'
│     ├── kind: 'missing-contract-action'
│     └── kind: 'missing-identifier'
└── IndexerProviderConfigError    Consumer passed unsupported configuration
```

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (unit tests for all new error classes, factories, and pure correlation helper)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff (`yarn check` clean across all 31 packages)
- [ ] Reviewer requested
- [x] No new todos introduced

## Test plan

- [x] Tests written first (TDD): RED → GREEN per commit
- [x] Strict-equality assertions for `IndexerFormattedError` message format
- [x] Unit tests for all 5 new error classes (`name`, message format, `cause` preservation, `instanceof IndexerError`, discriminated context where applicable)
- [x] `correlateDeployTxId` covers happy path + three silent-failure modes (missing contract action, missing identifier slot, empty-string identifier)
- [x] Behavioural test for `unshieldedBalancesObservable({ type: 'txId' })` throwing `IndexerProviderConfigError`
- [x] `yarn check` (build + lint + test across all 31 packages): clean

## Links

Closes #823
Closes #822
Closes #821