### PR TITLE
chore(release): bump version to 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,84 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
-## [4.1.0](https://github.com/midnightntwrk/midnight-js/compare/v4.0.4...v4.1.0) (2026-05-20)
+## [4.1.1](https://github.com/midnightntwrk/midnight-js/compare/v4.1.0...v4.1.1) (2026-06-02)
+
+
+### ⚠ BREAKING CHANGES
+
+* **midnight-js:** IndexerFormattedError.cause is renamed to .errors.
+
+The ES2022 Error.cause slot is contractually a single underlying error,
+not a peer collection of GraphQL errors. Shadowing it broke Node's
+util.inspect causal chain, Sentry grouping, and structured loggers.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+
+* refactor(midnight-js): extract correlateDeployTxId for cast-free tests
+
+Pulls the contract-action / identifier correlation into a small pure
+helper that takes narrow structural types. Eliminates the
+'as unknown as RegularTransaction' fixture cast that violated the
+project rule, and shrinks the public API: toFinalizedDeployTxData is
+now a file-local const, with only the focused helper exported for tests.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+
+* refactor(midnight-js): replace non-null assertions on contractAction with type predicate
+
+Lines 410 and 449 used Rx.filter + ! assertions to satisfy the type
+
+### Features
+
+* **testkit-js:** parameterize compose image versions + nightly e2e matrix ([#917](https://github.com/midnightntwrk/midnight-js/pull/917)) ([1621524](https://github.com/midnightntwrk/midnight-js/commit/16215240e02f738374aa644c43039ae5c90f962f))
+* **testkit-js:** support qanet via NIGHT/dust faucet flow ([73a3fd5](https://github.com/midnightntwrk/midnight-js/commit/73a3fd59a549ff09940ab85f5ad3995288b5063a))
+
+
+### Bug Fixes
+
+* **midnight-js:** apply full password policy to export operations ([#922](https://github.com/midnightntwrk/midnight-js/pull/922)) ([c6f43dd](https://github.com/midnightntwrk/midnight-js/commit/c6f43dda1f5f1cf7cc124baa37f7417fe919ef1d)), closes [#819](https://github.com/midnightntwrk/midnight-js/pull/819)
+* **midnight-js:** emit contract state for blockHeight/blockHash configs ([#911](https://github.com/midnightntwrk/midnight-js/pull/911)) ([f8d2e48](https://github.com/midnightntwrk/midnight-js/commit/f8d2e48ba026f21597f9a634b4b87874dc0b7bec)), closes [#805](https://github.com/midnightntwrk/midnight-js/pull/805)
+* **midnight-js:** harden error handling in indexer-public-data-provider ([#937](https://github.com/midnightntwrk/midnight-js/pull/937)) ([28c840a](https://github.com/midnightntwrk/midnight-js/commit/28c840a33efbdc6f3b93756d981baeb82382251c)), closes [#823](https://github.com/midnightntwrk/midnight-js/pull/823) [#822](https://github.com/midnightntwrk/midnight-js/pull/822) [#821](https://github.com/midnightntwrk/midnight-js/pull/821) [#821](https://github.com/midnightntwrk/midnight-js/pull/821)
+* **midnight-js:** validate signing key value on import ([#926](https://github.com/midnightntwrk/midnight-js/pull/926)) ([9fa41f4](https://github.com/midnightntwrk/midnight-js/commit/9fa41f43a63031a1f04e325818762c9413cb6790)), closes [#824](https://github.com/midnightntwrk/midnight-js/pull/824)
+* **midnight-js:** warn on plain http/ws for non-loopback provider URLs ([#920](https://github.com/midnightntwrk/midnight-js/pull/920)) ([dc6a3c6](https://github.com/midnightntwrk/midnight-js/commit/dc6a3c6360cca87d51a62b563863f403439e99c9)), closes [#818](https://github.com/midnightntwrk/midnight-js/pull/818)
+* **testkit-js:** derive waitForFunds address from keystore ([f1b980b](https://github.com/midnightntwrk/midnight-js/commit/f1b980b51962a924e28d11ca1c27dc0054bc6584))
+
+
+### Documentation
+
+* API documentation update ([#910](https://github.com/midnightntwrk/midnight-js/pull/910)) ([96146e5](https://github.com/midnightntwrk/midnight-js/commit/96146e53107417d5361133d6e342d92eb1b3e45f))
+* API documentation update ([#924](https://github.com/midnightntwrk/midnight-js/pull/924)) ([092257c](https://github.com/midnightntwrk/midnight-js/commit/092257cb9bc4210de2171c1ed3aba08543ad6e1c))
+* API documentation update ([#934](https://github.com/midnightntwrk/midnight-js/pull/934)) ([7370b65](https://github.com/midnightntwrk/midnight-js/commit/7370b6506dcab281df61233bd104babb825133db))
+* API documentation update ([#939](https://github.com/midnightntwrk/midnight-js/pull/939)) ([5251bce](https://github.com/midnightntwrk/midnight-js/commit/5251bce03e0825f42848d735583635356e9b2ebd))
+* **midnight-js:** clarify provider semantics and tx privacy ([#918](https://github.com/midnightntwrk/midnight-js/pull/918)) ([cc9312e](https://github.com/midnightntwrk/midnight-js/commit/cc9312e4f7081db13db5193a12e121b96b11c03b)), closes [#870](https://github.com/midnightntwrk/midnight-js/pull/870) [#871](https://github.com/midnightntwrk/midnight-js/pull/871) [#872](https://github.com/midnightntwrk/midnight-js/pull/872)
+
+
+### Code Refactoring
+
+* co-locate contracts governance code under src/governance/ ([#909](https://github.com/midnightntwrk/midnight-js/pull/909)) ([0199119](https://github.com/midnightntwrk/midnight-js/commit/01991194c589257e762c75c0a01b029a164babf8))
+
+
+### Tests
+
+* **testkit-js-e2e:** add regression test for shielded segment routing ([#876](https://github.com/midnightntwrk/midnight-js/pull/876)) ([#903](https://github.com/midnightntwrk/midnight-js/pull/903)) ([3e93cc5](https://github.com/midnightntwrk/midnight-js/commit/3e93cc588f9b6775f79f4d78ac3c668e6cec0376))
+
+
+### Continuous Integration
+
+* bump pinned GitHub Actions to latest versions ([#927](https://github.com/midnightntwrk/midnight-js/pull/927)) ([150ecd4](https://github.com/midnightntwrk/midnight-js/commit/150ecd42952198d708ae1c9ef0289ff76d109793))
+* **testkit-js:** scope concurrency group by docker env ([#935](https://github.com/midnightntwrk/midnight-js/pull/935)) ([af794ca](https://github.com/midnightntwrk/midnight-js/commit/af794ca99673e7640ba2e2892aa1d6249b6a2858))
+
+
+### Improvements
+
+* **deps:** bump @midnight-ntwrk/wallet-sdk to 1.1.0 ([#919](https://github.com/midnightntwrk/midnight-js/pull/919)) ([0c59c4b](https://github.com/midnightntwrk/midnight-js/commit/0c59c4b960f9c14063cc9a0eeea1ff4635b56b98))
+* **deps:** bump dependencies to address security advisories ([#925](https://github.com/midnightntwrk/midnight-js/pull/925)) ([36d5aee](https://github.com/midnightntwrk/midnight-js/commit/36d5aeeb806af9416e5afc6cc25150c3f91038f6)), closes [#134](https://github.com/midnightntwrk/midnight-js/pull/134)
+* **deps:** bump testcontainers from 11.13.0 to 12.0.0 ([#928](https://github.com/midnightntwrk/midnight-js/pull/928)) ([ec14840](https://github.com/midnightntwrk/midnight-js/commit/ec148403b15bc7ac989c2830fa94e8910e9309a6))
+* **deps:** declare missing dependencies and enforce via ESLint ([#913](https://github.com/midnightntwrk/midnight-js/pull/913)) ([75cbc75](https://github.com/midnightntwrk/midnight-js/commit/75cbc7556b3abe504083c8365bc0e42ffee76987))
+* **deps:** enforce consistent dependency versions via Yarn Constraints ([#914](https://github.com/midnightntwrk/midnight-js/pull/914)) ([75085d3](https://github.com/midnightntwrk/midnight-js/commit/75085d391d527c78daef1ab60c8a8eaf84b12afc))
+* **deps:** remove unused root devDependencies, scope build-time deps to packages ([#916](https://github.com/midnightntwrk/midnight-js/pull/916)) ([b24283f](https://github.com/midnightntwrk/midnight-js/commit/b24283f32bd64dd540ef3206c1568c7cf4b1fac3))
+
+## [4.1.0](https://github.com/midnightntwrk/midnight-js/compare/v4.0.4...v4.1.0) (2026-05-21)
 
 
 ### Features
@@ -79,6 +156,7 @@ All notable changes to this project will be documented in this file. See [commit
 * **midnight-js:** add protocol as dependency of barrel package ([#842](https://github.com/midnightntwrk/midnight-js/pull/842)) ([05c6b0f](https://github.com/midnightntwrk/midnight-js/commit/05c6b0f0e3aa015c8a37574587cb2b5adea11417))
 * **midnight-js:** remove unused deps ([#800](https://github.com/midnightntwrk/midnight-js/pull/800)) ([886a86e](https://github.com/midnightntwrk/midnight-js/commit/886a86e37d05f24d86adee5aa9735c600ff602b5))
 * **midnight-js:** update yarn.lock for protocol and compact devDeps ([04774fd](https://github.com/midnightntwrk/midnight-js/commit/04774fde5b341aa7451ed7c1e7d5b0fc3439dd41))
+* **release:** bump version to 4.1.0 ([#907](https://github.com/midnightntwrk/midnight-js/pull/907)) ([e96cc2f](https://github.com/midnightntwrk/midnight-js/commit/e96cc2f9aedd62837194bd0922f5e334c20c6567))
 * update compactc to 0.31.0 and dependencies ([#902](https://github.com/midnightntwrk/midnight-js/pull/902)) ([42324f2](https://github.com/midnightntwrk/midnight-js/commit/42324f215a55a230cdf597db4a33d96940e50bb1))
 * update indexer and node images to match current preview ([#879](https://github.com/midnightntwrk/midnight-js/pull/879)) ([c9e96d1](https://github.com/midnightntwrk/midnight-js/commit/c9e96d1de41fe8f5ea3657006777471c96151a61))
 * update yarn to 4.14.1 ([#878](https://github.com/midnightntwrk/midnight-js/pull/878)) ([60e2e56](https://github.com/midnightntwrk/midnight-js/commit/60e2e565714e27193850d9331f87ea6c64f7eb2f))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@midnight-ntwrk/midnight-js-monorepo",
   "description": "Midnight application development framework",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "packageManager": "yarn@4.14.1",
   "repository": "git@github.com:midnight-ntwrk/artifacts",
   "engines": {

--- a/packages/compact/package.json
+++ b/packages/compact/package.json
@@ -10,7 +10,7 @@
     "node": ">=22.0.0"
   },
   "license": "Apache-2.0",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "type": "module",
   "bin": {
     "fetch-compactc": "dist/fetch-compact.mjs",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/midnight-js-contracts",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "MidnightJS module for interacting with contracts",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/dapp-connector-proof-provider/package.json
+++ b/packages/dapp-connector-proof-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/midnight-js-dapp-connector-proof-provider",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Implementation of proof provider leveraging the DApp Connector's proving API",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/fetch-zk-config-provider/package.json
+++ b/packages/fetch-zk-config-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/midnight-js-fetch-zk-config-provider",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "MidnightJS module for retrieving proving and verifying keys and ZK intermediate representation",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/http-client-proof-provider/package.json
+++ b/packages/http-client-proof-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/midnight-js-http-client-proof-provider",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Implementation of proof provider based on the Midnight ledger proof server",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/indexer-public-data-provider/package.json
+++ b/packages/indexer-public-data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/midnight-js-indexer-public-data-provider",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Implementation of public data provider based on the Midnight Pub-sub indexer",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/level-private-state-provider/package.json
+++ b/packages/level-private-state-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/midnight-js-level-private-state-provider",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Private state provider implementation that uses browser localStorage or Node.js file storage",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/logger-provider/package.json
+++ b/packages/logger-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/midnight-js-logger-provider",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "MidnightJS module for configuring an application specific pino logger",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/midnight-js/package.json
+++ b/packages/midnight-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/midnight-js",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Barrel package for Midnight.js core framework",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/network-id/package.json
+++ b/packages/network-id/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/midnight-js-network-id",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Package for setting the network ID of runtime and ledger WASM API",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/node-zk-config-provider/package.json
+++ b/packages/node-zk-config-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/midnight-js-node-zk-config-provider",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "MidnightJS module for reading proving and verifying keys and ZK intermediate representation",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/midnight-js-protocol",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Protocol type re-exports for midnight-js framework",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/midnight-js-types",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Shared data types and interfaces for MidnightJS modules",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/midnight-js-utils",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Shared utilities for MidnightJS modules",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/testkit-js/testkit-js-e2e/package.json
+++ b/testkit-js/testkit-js-e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/testkit-js-e2e",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "E2E tests for Midnight JS packages",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/testkit-js/testkit-js/package.json
+++ b/testkit-js/testkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/testkit-js",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Testing kit for Midnight JS packages",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## Summary
- Bump all package versions to 4.1.1
- Update CHANGELOG.md with 4.1.1 release notes

Replaces #945 — original release/v4.1.1 branch is protected and cannot be updated against main. Cherry-picked the version bump commit (5f8a5d14) onto a fresh branch from main.

## Test plan
- [x] Version bump only — no code changes
- [x] CHANGELOG.md reflects 4.1.1 release contents
- [x] Branch is up to date with main