### PR TITLE
ci(testkit-js): scope e2e artifacts per env and render summaries

### DIFF
--- a/.github/scripts/render-e2e-summary.sh
+++ b/.github/scripts/render-e2e-summary.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# This file is part of midnight-js.
+# Copyright (C) 2025-2026 Midnight Foundation
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Render a markdown summary table for E2E test results to stdout.
+# Reads CTRF JSON for pass/fail/duration and testkit-js/env/<env>.env for image versions.
+#
+# Usage:
+#   render-e2e-summary.sh <env> <ctrf-path-or-empty> [<env> <ctrf-path-or-empty> ...]
+#
+# Pass an empty string as ctrf-path when the artifact is missing (job failed early).
+
+set -euo pipefail
+
+if [ $# -lt 2 ] || [ $(($# % 2)) -ne 0 ]; then
+  echo "Usage: $0 <env> <ctrf-path-or-empty> [<env> <ctrf-path-or-empty> ...]" >&2
+  exit 1
+fi
+
+REPO_ROOT="${GITHUB_WORKSPACE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+ENV_DIR="$REPO_ROOT/testkit-js/env"
+
+read_env_var() {
+  local file="$1" key="$2"
+  if [ -f "$file" ]; then
+    grep -E "^${key}=" "$file" | head -n1 | cut -d= -f2- || true
+  fi
+}
+
+format_duration() {
+  local ms="$1"
+  awk -v ms="$ms" 'BEGIN {
+    if (ms <= 0) { print "-"; exit }
+    s = int(ms / 1000)
+    h = int(s / 3600); s = s % 3600
+    m = int(s / 60); s = s % 60
+    if (h > 0) printf "%dh%02dm", h, m
+    else printf "%dm%02ds", m, s
+  }'
+}
+
+echo "| Env | Status | Passed | Failed | Skipped | Duration | Proof Server | Indexer | Node |"
+echo "|-----|--------|-------:|-------:|--------:|---------:|--------------|---------|------|"
+
+while [ $# -gt 0 ]; do
+  env="$1"
+  ctrf="$2"
+  shift 2
+
+  env_file="$ENV_DIR/$env.env"
+  proof=$(read_env_var "$env_file" PROOF_SERVER_VERSION)
+  indexer=$(read_env_var "$env_file" INDEXER_VERSION)
+  node=$(read_env_var "$env_file" MIDNIGHT_NODE_VERSION)
+  proof="${proof:-?}"
+  indexer="${indexer:-?}"
+  node="${node:-?}"
+
+  if [ -z "$ctrf" ] || [ ! -f "$ctrf" ]; then
+    printf "| %s | :warning: no results | - | - | - | - | %s | %s | %s |\n" \
+      "$env" "$proof" "$indexer" "$node"
+    continue
+  fi
+
+  passed=$(jq -r '.results.summary.passed // 0' "$ctrf")
+  failed=$(jq -r '.results.summary.failed // 0' "$ctrf")
+  skipped=$(jq -r '(.results.summary.skipped // 0) + (.results.summary.pending // 0)' "$ctrf")
+  start=$(jq -r '.results.summary.start // 0' "$ctrf")
+  stop=$(jq -r '.results.summary.stop // 0' "$ctrf")
+  duration=$(format_duration "$((stop - start))")
+
+  if [ "$failed" -gt 0 ]; then
+    status=":x:"
+  elif [ "$passed" -eq 0 ]; then
+    status=":warning:"
+  else
+    status=":white_check_mark:"
+  fi
+
+  printf "| %s | %s | %d | %d | %d | %s | %s | %s | %s |\n" \
+    "$env" "$status" "$passed" "$failed" "$skipped" "$duration" "$proof" "$indexer" "$node"
+done

--- a/.github/workflows/ci-testkit-js.yml
+++ b/.github/workflows/ci-testkit-js.yml
@@ -315,7 +315,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7.0.1
         if: always()
         with:
-          name: test-results-${{ matrix.test-file }}
+          name: test-results-${{ inputs.testkit_docker_env || 'default' }}-${{ matrix.test-file }}
           path: testkit-js/testkit-js-e2e/reports/
 
   e2e_tests_reports:
@@ -331,7 +331,7 @@ jobs:
       - name: Download Test Results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8.0.1
         with:
-          pattern: test-results-*
+          pattern: test-results-${{ inputs.testkit_docker_env || 'default' }}-*
           path: test-results
 
       - name: Generate Allure Report
@@ -349,7 +349,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7.0.1
         if: always()
         with:
-          name: allure-report
+          name: allure-report-${{ inputs.testkit_docker_env || 'default' }}
           path: allure-report/
 
       - name: Merge CTRF Results
@@ -363,8 +363,23 @@ jobs:
             echo "No CTRF results found"
           fi
 
-      - name: Publish Test Report
+      - name: Write per-env step summary
         if: always()
+        env:
+          TESTKIT_ENV: ${{ inputs.testkit_docker_env || 'default' }}
+        run: |
+          CTRF_PATH=""
+          if [ -f ./ctrf-report-merged.json ]; then
+            CTRF_PATH="./ctrf-report-merged.json"
+          fi
+          {
+            echo "### E2E Tests — \`${TESTKIT_ENV}\`"
+            echo ""
+            ./.github/scripts/render-e2e-summary.sh "${TESTKIT_ENV}" "${CTRF_PATH}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish Test Report
+        if: always() && github.event_name != 'schedule'
         uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # ratchet:ctrf-io/github-test-reporter@v1.0.28
         with:
           title: 'E2E Tests Results'
@@ -382,7 +397,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7.0.1
         if: always()
         with:
-          name: test-results-ctrf-summary
+          name: test-results-ctrf-summary-${{ inputs.testkit_docker_env || 'default' }}
           path: ctrf-results
 
       - name: Publish Test Summary Results
@@ -401,5 +416,5 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7.0.1
         if: always()
         with:
-          name: test-results-junit-summary
+          name: test-results-junit-summary-${{ inputs.testkit_docker_env || 'default' }}
           path: junit-test-results.xml

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -38,3 +38,32 @@ jobs:
       network: 'undeployed'
       testkit_docker_env: ${{ matrix.image_versions }}
     secrets: inherit
+
+  summary:
+    name: Nightly Summary
+    runs-on: ubuntu-latest
+    needs: e2e
+    if: always()
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+
+      - name: Download CTRF summaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8.0.1
+        with:
+          pattern: test-results-ctrf-summary-*
+          path: ctrf-by-env
+
+      - name: Render cross-env summary
+        run: |
+          ARGS=()
+          for env in qanet preview preprod mainnet devnet; do
+            ctrf=$(find "ctrf-by-env/test-results-ctrf-summary-${env}" -name "ctrf-*.json" 2>/dev/null | head -n1 || true)
+            ARGS+=("$env" "${ctrf:-}")
+          done
+          {
+            echo "## Nightly E2E — all environments"
+            echo ""
+            ./.github/scripts/render-e2e-summary.sh "${ARGS[@]}"
+            echo ""
+            echo "_Reports per environment available as run artifacts._"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
# Overview

Nightly E2E invokes `ci-testkit-js.yml` five times (qanet/preview/preprod/mainnet/devnet), but artifacts were uploaded under identical names. Result:
- Every env's `e2e_tests_reports` job downloaded `test-results-*` with a pattern that matched **all five envs**, then merged their CTRF outputs into a single per-env report. Every "per-env" report was actually a five-env mix.
- No visible summary on the nightly run page — to assess "is preview OK?" you had to click into ~25 individual matrix jobs.

## Changes

**Artifact scoping (`ci-testkit-js.yml`)** — suffix every test-results / allure-report / ctrf-summary / junit-summary artifact with `${{ inputs.testkit_docker_env || 'default' }}`. PR/CD flows that don't pass a docker env fall back to `default` and behave as before. Also tightens the download pattern so each env's report job only pulls its own results.

**Per-env step summary (`ci-testkit-js.yml`)** — after CTRF merge, render a markdown table to ` $GITHUB_STEP_SUMMARY` containing: status, passed/failed/skipped counts, duration, and proof-server/indexer/midnight-node versions read from `testkit-js/env/<env>.env`.

**Cross-env aggregator (`nightly-e2e.yml`)** — new `summary` job that runs after the matrix, downloads `test-results-ctrf-summary-*` artifacts and produces one table covering all five envs at the top of the nightly run. Survives env-level failures with a `⚠️ no results` row.

**Helper (`.github/scripts/render-e2e-summary.sh`)** — shared markdown renderer used by both summaries. Tested locally against a real CTRF from run 26795736284.

**Skip PR comment on schedule** — the CTRF reporter's `pull-request: true` is a no-op (and a logged error) for `schedule` triggers since there's no PR.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible) — script tested locally against real CTRF; full workflow validation via `workflow_dispatch` after merge
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README.md file (if relevant) — n/a
- [x] Update documentation (if relevant) — n/a
- [x] No new todos introduced

