### PR TITLE
fix(testkit-js): stretch indexer SPO reconnect delay to keep it alive

### DIFF
--- a/testkit-js/compose.yml
+++ b/testkit-js/compose.yml
@@ -28,6 +28,12 @@ services:
       APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD: 'indexer'
       APP__INFRA__SECRET: '303132333435363738393031323334353637383930313233343536373839303132'
       APP__INFRA__SPO_NODE__BLOCKFROST_ID: 'dummy-not-using-spo'
+      # Standalone stack has no SPO node. Indexer 4.3.x spawns spo-indexer
+      # unconditionally and exits the whole process when it gives up
+      # reconnecting (default 30 × 10s ≈ 5 min). Stretching the delay to 24h
+      # keeps the indexer alive for the entire test run without disabling
+      # the subtask (no flag exists to opt out).
+      APP__INFRA__SPO_NODE__RECONNECT_MAX_DELAY: '24h'
 
     healthcheck:
       test: ['CMD-SHELL', 'cat /var/run/indexer-standalone/running']


### PR DESCRIPTION
# Overview

Nightly e2e on `preview`, `qanet`, and `devnet` started failing the tail end of `contracts.it.test.ts` and `contracts.snarkupgrade.singlecontract.it.test.ts` with `ECONNREFUSED` on the indexer port partway through the suite (run [26795736284](https://github.com/midnightntwrk/midnight-js/actions/runs/26795736284)). Earlier tests in the same files pass; the indexer dies mid-suite.

Root cause is in upstream indexer 4.3.x (used by `preview`/`qanet`/`devnet` image sets), not in our CI wiring:

- `indexer-standalone` unconditionally spawns a `spo-indexer` subtask alongside the main tasks and joins them with `select!`. Any branch returning kills the whole process via `std::process::exit(1)`.
- In the standalone test stack there is no SPO node at `ws://localhost:9944`, so `spo-indexer` retries `30 × 10s` (≈ 5 min) and then exits, taking the indexer with it.
- The `SpoNodeConfig` struct has no `enabled`/`disabled` field, and there is no feature flag — `spo-indexer` cannot be opted out without patching the image.

Preprod/mainnet are unaffected because they pin indexer `4.0.1`, which doesn't have this subtask.

Stretching `APP__INFRA__SPO_NODE__RECONNECT_MAX_DELAY` from the default `10s` to `24h` keeps the retry loop sleeping for effectively the whole test run (1 attempt per day × 30 attempts ≈ 30 days) without code changes in the image. The job's 30-minute timeout caps any test run well below the new retry interval, so `select!` never picks the `spo-indexer` branch during a test. Preprod/mainnet ignore the new env var, so there's no behavior change there.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible) — covered by existing nightly e2e matrix; affected tests will exercise the fix on the next nightly run
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant)
- [ ] Update documentation (if relevant)
- [x] No new todos introduced

## Test plan

- [ ] Trigger a manual run of `Nightly E2E` on this branch and verify `contracts.it.test.ts` and `contracts.snarkupgrade.singlecontract.it.test.ts` pass on `preview`, `qanet`, and `devnet`.
- [ ] Verify `preprod` and `mainnet` jobs are unchanged (no regression on indexer 4.0.1).
- [ ] Inspect the indexer container logs to confirm only a single SPO reconnect attempt is logged early in the run, then silence.

## Follow-up

Worth opening an upstream issue against `midnightntwrk/midnight-indexer` asking for a proper opt-out (e.g. `spo.enabled: bool` or `#[cfg(feature = "spo")]`) so this workaround can be retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)