### PR TITLE
refactor(midnight-js): wrapper consolidation, assertion hygiene, pollUntilPresent helper

### DIFF
--- a/packages/contracts/src/test/test-mocks.ts
+++ b/packages/contracts/src/test/test-mocks.ts
@@ -259,8 +259,7 @@ export const createMockProviders = (): ContractProviders<Contract.Any, AnyProvab
     watchForTxData: vi.fn(),
     contractStateObservable: vi.fn(),
     watchForUnshieldedBalances: vi.fn(),
-    unshieldedBalancesObservable: vi.fn(),
-    dispose: vi.fn().mockResolvedValue(undefined)
+    unshieldedBalancesObservable: vi.fn()
   },
   privateStateProvider: {
     setContractAddress: vi.fn(),

--- a/packages/indexer-public-data-provider/src/errors.ts
+++ b/packages/indexer-public-data-provider/src/errors.ts
@@ -165,3 +165,20 @@ export class IndexerProviderConfigError extends IndexerError {
     this.name = 'IndexerProviderConfigError';
   }
 }
+
+/**
+ * An error raised when an upstream invariant the provider relies on does
+ * not hold at runtime — for example, when an `Rx.filter` upstream is
+ * expected to guarantee a non-empty array but the downstream `.map` still
+ * sees an empty one. Distinct from {@link IndexerDataError} (well-formed
+ * indexer payload that violates protocol-level expectations) and from
+ * {@link IndexerSubscriptionDataError} (server returned a `null` for a
+ * top-level subscription field) — `IndexerInvariantError` flags a bug in
+ * the provider's pipeline composition, not in the data.
+ */
+export class IndexerInvariantError extends IndexerError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'IndexerInvariantError';
+  }
+}

--- a/packages/indexer-public-data-provider/src/index.ts
+++ b/packages/indexer-public-data-provider/src/index.ts
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import type { PublicDataProvider } from '@midnight-ntwrk/midnight-js-types';
 import type * as ws from 'isomorphic-ws';
 
 import { type IndexerProviderConfig, validateConfig } from './config';
@@ -37,29 +36,31 @@ export {
 export { DEFAULT_POLL_INTERVAL, type IndexerProviderConfig } from './config';
 export * from './errors';
 export { isRegularTransaction } from './mapping';
+export { IndexerPublicDataProvider } from './provider';
 
 /**
- * Constructs an indexer-backed {@link PublicDataProvider}.
+ * Constructs an indexer-backed `PublicDataProvider`.
  *
  * Two call forms:
  * 1. Object-config (preferred): `indexerPublicDataProvider({ queryURL, subscriptionURL, webSocket?, pollInterval? })`.
  * 2. Positional (deprecated, retained for backward compatibility): `indexerPublicDataProvider(queryURL, subscriptionURL, webSocket?)`.
  *
- * The returned provider exposes `dispose()` to release the WebSocket
- * connection and Apollo state. Always call it on long-running providers.
+ * The returned concrete `IndexerPublicDataProvider` exposes `dispose()` to
+ * release the WebSocket connection and Apollo state. Always call it on
+ * long-running providers.
  */
-export function indexerPublicDataProvider(config: IndexerProviderConfig): PublicDataProvider;
+export function indexerPublicDataProvider(config: IndexerProviderConfig): IndexerPublicDataProvider;
 /** @deprecated Use the `IndexerProviderConfig` overload. */
 export function indexerPublicDataProvider(
   queryURL: string,
   subscriptionURL: string,
   webSocket?: typeof ws.WebSocket
-): PublicDataProvider;
+): IndexerPublicDataProvider;
 export function indexerPublicDataProvider(
   configOrQueryURL: IndexerProviderConfig | string,
   subscriptionURL?: string,
   webSocket?: typeof ws.WebSocket
-): PublicDataProvider {
+): IndexerPublicDataProvider {
   let config: IndexerProviderConfig;
   if (typeof configOrQueryURL === 'string') {
     if (subscriptionURL === undefined) {

--- a/packages/indexer-public-data-provider/src/index.ts
+++ b/packages/indexer-public-data-provider/src/index.ts
@@ -13,24 +13,8 @@
  * limitations under the License.
  */
 
-import type { ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
-import type {
-  ContractAddress,
-  LedgerParameters,
-  TransactionId,
-  ZswapChainState
-} from '@midnight-ntwrk/midnight-js-protocol/ledger';
-import type {
-  BlockHashConfig,
-  BlockHeightConfig,
-  ContractStateObservableConfig,
-  FinalizedTxData,
-  PublicDataProvider,
-  UnshieldedBalances
-} from '@midnight-ntwrk/midnight-js-types';
-import { assertIsContractAddress } from '@midnight-ntwrk/midnight-js-utils';
+import type { PublicDataProvider } from '@midnight-ntwrk/midnight-js-types';
 import type * as ws from 'isomorphic-ws';
-import type * as Rx from 'rxjs';
 
 import { type IndexerProviderConfig, validateConfig } from './config';
 import { IndexerProviderConfigError } from './errors';
@@ -61,13 +45,8 @@ export { isRegularTransaction } from './mapping';
  * 1. Object-config (preferred): `indexerPublicDataProvider({ queryURL, subscriptionURL, webSocket?, pollInterval? })`.
  * 2. Positional (deprecated, retained for backward compatibility): `indexerPublicDataProvider(queryURL, subscriptionURL, webSocket?)`.
  *
- * The returned object exposes `dispose()` to release the WebSocket
+ * The returned provider exposes `dispose()` to release the WebSocket
  * connection and Apollo state. Always call it on long-running providers.
- *
- * The current implementation wraps the inner class with
- * `assertIsContractAddress` calls on every method that accepts a
- * `ContractAddress`. The wrapper is removed in Phase 3 by moving the
- * assertions into the class methods themselves.
  */
 export function indexerPublicDataProvider(config: IndexerProviderConfig): PublicDataProvider;
 /** @deprecated Use the `IndexerProviderConfig` overload. */
@@ -95,65 +74,5 @@ export function indexerPublicDataProvider(
 
   const validated = validateConfig(config);
   const handle = createApolloClient(validated);
-  const inner = new IndexerPublicDataProvider(handle, validated.pollInterval);
-
-  return {
-    contractStateObservable(
-      contractAddress: ContractAddress,
-      contractStateConfig: ContractStateObservableConfig
-    ): Rx.Observable<ContractState> {
-      assertIsContractAddress(contractAddress);
-      return inner.contractStateObservable(contractAddress, contractStateConfig);
-    },
-    queryContractState(
-      contractAddress: ContractAddress,
-      queryConfig?: BlockHeightConfig | BlockHashConfig
-    ): Promise<ContractState | null> {
-      assertIsContractAddress(contractAddress);
-      return inner.queryContractState(contractAddress, queryConfig);
-    },
-    queryDeployContractState(contractAddress: ContractAddress): Promise<ContractState | null> {
-      assertIsContractAddress(contractAddress);
-      return inner.queryDeployContractState(contractAddress);
-    },
-    queryZSwapAndContractState(
-      contractAddress: ContractAddress,
-      queryConfig?: BlockHeightConfig | BlockHashConfig
-    ): Promise<[ZswapChainState, ContractState, LedgerParameters] | null> {
-      assertIsContractAddress(contractAddress);
-      return inner.queryZSwapAndContractState(contractAddress, queryConfig);
-    },
-    queryUnshieldedBalances(
-      contractAddress: ContractAddress,
-      queryConfig?: BlockHeightConfig | BlockHashConfig
-    ): Promise<UnshieldedBalances | null> {
-      assertIsContractAddress(contractAddress);
-      return inner.queryUnshieldedBalances(contractAddress, queryConfig);
-    },
-    watchForContractState(contractAddress: ContractAddress): Promise<ContractState> {
-      assertIsContractAddress(contractAddress);
-      return inner.watchForContractState(contractAddress);
-    },
-    watchForUnshieldedBalances(contractAddress: ContractAddress): Promise<UnshieldedBalances> {
-      assertIsContractAddress(contractAddress);
-      return inner.watchForUnshieldedBalances(contractAddress);
-    },
-    watchForDeployTxData(contractAddress: ContractAddress): Promise<FinalizedTxData> {
-      assertIsContractAddress(contractAddress);
-      return inner.watchForDeployTxData(contractAddress);
-    },
-    watchForTxData(txId: TransactionId): Promise<FinalizedTxData> {
-      return inner.watchForTxData(txId);
-    },
-    unshieldedBalancesObservable(
-      contractAddress: ContractAddress,
-      contractStateConfig: ContractStateObservableConfig
-    ): Rx.Observable<UnshieldedBalances> {
-      assertIsContractAddress(contractAddress);
-      return inner.unshieldedBalancesObservable(contractAddress, contractStateConfig);
-    },
-    dispose(): Promise<void> {
-      return inner.dispose();
-    }
-  };
+  return new IndexerPublicDataProvider(handle, validated.pollInterval);
 }

--- a/packages/indexer-public-data-provider/src/mapping.ts
+++ b/packages/indexer-public-data-provider/src/mapping.ts
@@ -34,10 +34,11 @@ export const hasContractAction = <T extends { contractAction?: unknown }>(
   data.contractAction != null;
 
 export const isRegularTransaction = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  tx: any
+  tx: unknown
 ): tx is RegularTransaction & { hash: string; identifiers: string[] } => {
-  return 'identifiers' in tx && 'hash' in tx && Array.isArray(tx.identifiers);
+  if (typeof tx !== 'object' || tx === null) return false;
+  if (!('identifiers' in tx) || !('hash' in tx)) return false;
+  return Array.isArray((tx as { identifiers: unknown }).identifiers);
 };
 
 export const toFinalizedDeployTxData = (

--- a/packages/indexer-public-data-provider/src/mapping.ts
+++ b/packages/indexer-public-data-provider/src/mapping.ts
@@ -24,7 +24,7 @@ import {
   toUnshieldedUtxos
 } from './codec';
 import { IndexerInvariantError } from './errors';
-import type { ContractBalance, RegularTransaction } from './gen/graphql';
+import type { ContractBalance, DeployTxQueryQuery, RegularTransaction } from './gen/graphql';
 
 type IsEmptyObject<T> = keyof T extends never ? true : false;
 export type ExcludeEmptyAndNull<T> = T extends null ? never : IsEmptyObject<T> extends true ? never : T;
@@ -68,6 +68,26 @@ export const isRegularTransaction = (
   if (typeof tx !== 'object' || tx === null) return false;
   if (!('identifiers' in tx) || !('hash' in tx)) return false;
   return Array.isArray((tx as { identifiers: unknown }).identifiers);
+};
+
+/**
+ * Walks a `DeployTxQueryQuery.contractAction` payload to the underlying
+ * transaction and returns it iff it is a regular (non-system) transaction.
+ * Returns `null` for two distinct cases:
+ * 1. `contractAction === null` — indexer hasn't produced data yet; callers
+ *    use this as the "keep polling" signal.
+ * 2. The contract action carries a non-regular (system) transaction shape.
+ *
+ * `ContractCall` reaches the transaction via `deploy.transaction`;
+ * `ContractDeploy` / `ContractUpdate` expose it directly as `transaction`.
+ */
+export const extractRegularDeployTransaction = (
+  contractAction: DeployTxQueryQuery['contractAction']
+): (RegularTransaction & { hash: string; identifiers: string[] }) | null => {
+  if (contractAction === null) return null;
+  const contract = contractAction as ExcludeEmptyAndNull<DeployTxQueryQuery['contractAction']>;
+  const transaction = 'deploy' in contract ? contract.deploy.transaction : contract.transaction;
+  return isRegularTransaction(transaction) ? transaction : null;
 };
 
 export const toFinalizedDeployTxData = (

--- a/packages/indexer-public-data-provider/src/mapping.ts
+++ b/packages/indexer-public-data-provider/src/mapping.ts
@@ -23,7 +23,8 @@ import {
   toTxStatus,
   toUnshieldedUtxos
 } from './codec';
-import type { RegularTransaction } from './gen/graphql';
+import { IndexerInvariantError } from './errors';
+import type { ContractBalance, RegularTransaction } from './gen/graphql';
 
 type IsEmptyObject<T> = keyof T extends never ? true : false;
 export type ExcludeEmptyAndNull<T> = T extends null ? never : IsEmptyObject<T> extends true ? never : T;
@@ -32,6 +33,34 @@ export const hasContractAction = <T extends { contractAction?: unknown }>(
   data: T
 ): data is T & { contractAction: NonNullable<T['contractAction']> } =>
   data.contractAction != null;
+
+/**
+ * Structural shape of a `contractAction` payload (or `contractActions` on the
+ * subscription variant) that carries unshielded balances. `ContractDeploy` /
+ * `ContractUpdate` expose them directly; `ContractCall` reaches them via
+ * `deploy.unshieldedBalances`.
+ */
+export type UnshieldedBalanceContractAction =
+  | { readonly deploy: { readonly unshieldedBalances: readonly ContractBalance[] } }
+  | { readonly unshieldedBalances: readonly ContractBalance[] };
+
+/**
+ * Returns the `ContractBalance[]` carried by a contract action regardless of
+ * which variant produced it. Throws {@link IndexerInvariantError} when the
+ * payload has neither shape — surfaces indexer schema drift loudly rather
+ * than silently degrading to `[]`. `callerName` is embedded in the error
+ * message so the throw site is preserved in diagnostics.
+ */
+export const extractUnshieldedBalances = (
+  action: UnshieldedBalanceContractAction,
+  callerName: string
+): readonly ContractBalance[] => {
+  if ('unshieldedBalances' in action) return action.unshieldedBalances;
+  if ('deploy' in action) return action.deploy.unshieldedBalances;
+  throw new IndexerInvariantError(
+    `${callerName}: contractAction has neither unshieldedBalances nor deploy field`
+  );
+};
 
 export const isRegularTransaction = (
   tx: unknown

--- a/packages/indexer-public-data-provider/src/observables.ts
+++ b/packages/indexer-public-data-provider/src/observables.ts
@@ -18,7 +18,12 @@ import type { ContractAddress, TransactionId } from '@midnight-ntwrk/midnight-js
 import * as Rx from 'rxjs';
 
 import { parseHexContractState, toUnshieldedBalances } from './codec';
-import { IndexerFormattedError, IndexerQueryError, IndexerSubscriptionDataError } from './errors';
+import {
+  IndexerFormattedError,
+  IndexerInvariantError,
+  IndexerQueryError,
+  IndexerSubscriptionDataError
+} from './errors';
 import type {
   BlockOffset,
   ContractActionOffset,
@@ -131,9 +136,15 @@ export const transactionIdToTransaction$ =
       .pipe(
         withCompleteQueryData(),
         Rx.filter((data) => data.transactions.length !== 0),
-        Rx.map((data) => ({
-          height: data.transactions[0]!.block.height
-        })),
+        Rx.map((data) => {
+          const first = data.transactions[0];
+          if (first === undefined) {
+            throw new IndexerInvariantError(
+              'transactionIdToTransaction$: empty transactions array passed the non-empty filter'
+            );
+          }
+          return { height: first.block.height };
+        }),
         Rx.concatMap(blockOffsetToBlock$(apolloClient)),
         Rx.concatMap(({ transactions }) => Rx.from(transactions))
       );

--- a/packages/indexer-public-data-provider/src/observables.ts
+++ b/packages/indexer-public-data-provider/src/observables.ts
@@ -29,10 +29,9 @@ import type {
   BlockOffset,
   ContractActionOffset,
   InputMaybe,
-  LatestContractTxBlockHeightQueryQuery,
   RegularTransaction
 } from './gen/graphql';
-import { type ExcludeEmptyAndNull, hasContractAction } from './mapping';
+import { hasContractAction } from './mapping';
 import {
   BLOCK_QUERY,
   CONTRACT_STATE_QUERY,
@@ -89,25 +88,45 @@ export const withValidFetchData = <A>(): Rx.OperatorFunction<FetchResult<A>, Non
   );
 
 /**
- * Polls `query` at `pollInterval` ms until `predicate(data)` holds, then
- * emits `mapFn(data)` once and completes. Centralizes the cache policy
- * (`no-cache` on initial/next/fetch), the `withCompleteQueryData` unwrap,
- * and the `take(1)` semantics that every poll-until-first-match call site
- * previously hand-rolled.
+ * Polls `query` immediately and then every `pollInterval` ms until
+ * `predicate(data)` holds, then emits `mapFn(data)` once and completes.
+ * Centralizes the cache policy (`no-cache` on initial/next/fetch), the
+ * `withCompleteQueryData` unwrap, and the `take(1)` semantics that every
+ * poll-until-first-match call site previously hand-rolled.
  *
- * The `predicate` is plain `boolean`-returning, not a type guard — `Rx.filter`
- * does not narrow through generic predicates, so `mapFn` should cast or
- * guard inside its body (the established `ExcludeEmptyAndNull<>` pattern).
+ * Two forms:
+ * 1. Type-guard `predicate` — `mapFn` receives the narrowed type and may
+ *    access fields the predicate proved present without a cast.
+ * 2. Plain `boolean` `predicate` — `mapFn` receives the un-narrowed
+ *    `TQuery` and must cast or guard inside its body (the established
+ *    `ExcludeEmptyAndNull<>` pattern at sites where the codegen union
+ *    includes empty-object members).
  */
-export const pollUntilPresent = <TQuery, TVars extends OperationVariables, TResult>(
+export function pollUntilPresent<TQuery, TVars extends OperationVariables, TNarrowed extends TQuery, TResult>(
+  apolloClient: ApolloClient,
+  query: TypedDocumentNode<TQuery, TVars>,
+  variables: TVars,
+  predicate: (data: TQuery) => data is TNarrowed,
+  mapFn: (data: TNarrowed) => TResult,
+  pollInterval: number
+): Rx.Observable<TResult>;
+export function pollUntilPresent<TQuery, TVars extends OperationVariables, TResult>(
   apolloClient: ApolloClient,
   query: TypedDocumentNode<TQuery, TVars>,
   variables: TVars,
   predicate: (data: TQuery) => boolean,
   mapFn: (data: TQuery) => TResult,
   pollInterval: number
-): Rx.Observable<TResult> =>
-  apolloClient
+): Rx.Observable<TResult>;
+export function pollUntilPresent<TQuery, TVars extends OperationVariables, TResult>(
+  apolloClient: ApolloClient,
+  query: TypedDocumentNode<TQuery, TVars>,
+  variables: TVars,
+  predicate: (data: TQuery) => boolean,
+  mapFn: (data: TQuery) => TResult,
+  pollInterval: number
+): Rx.Observable<TResult> {
+  return apolloClient
     .watchQuery({
       query,
       variables,
@@ -122,6 +141,7 @@ export const pollUntilPresent = <TQuery, TVars extends OperationVariables, TResu
       Rx.map(mapFn),
       Rx.take(1)
     );
+}
 
 // Assumes that the block exists.
 export const blockOffsetToBlock$ = (apolloClient: ApolloClient) => (offset: InputMaybe<BlockOffset>) =>
@@ -199,13 +219,8 @@ export const contractAddressToLatestBlockOffset$ =
       apolloClient,
       LATEST_CONTRACT_TX_BLOCK_HEIGHT_QUERY,
       { address: contractAddress },
-      (data) => data.contractAction !== null,
-      (data) => {
-        const contract = data.contractAction as ExcludeEmptyAndNull<
-          LatestContractTxBlockHeightQueryQuery['contractAction']
-        >;
-        return { height: contract.transaction.block.height };
-      },
+      hasContractAction,
+      (data) => ({ height: data.contractAction.transaction.block.height }),
       pollInterval
     );
 
@@ -244,10 +259,7 @@ export const waitForContractToAppear =
       CONTRACT_STATE_QUERY,
       { address: contractAddress, offset },
       hasContractAction,
-      (data) => {
-        const action = data.contractAction as ExcludeEmptyAndNull<typeof data.contractAction>;
-        return action.state;
-      },
+      (data) => data.contractAction.state,
       pollInterval
     );
 
@@ -270,14 +282,16 @@ export const waitForUnshieldedBalancesToAppear =
       { address: contractAddress },
       hasContractAction,
       (data) => {
-        const action = data.contractAction as ExcludeEmptyAndNull<typeof data.contractAction>;
+        const action = data.contractAction;
         if ('unshieldedBalances' in action) {
           return action.unshieldedBalances;
         }
         if ('deploy' in action) {
           return action.deploy.unshieldedBalances;
         }
-        return [];
+        throw new IndexerInvariantError(
+          'waitForUnshieldedBalancesToAppear: contractAction has neither unshieldedBalances nor deploy field'
+        );
       },
       pollInterval
     );
@@ -308,7 +322,9 @@ export const blockOffsetToUnshieldedBalances$ =
           if ('deploy' in contractAction) {
             return contractAction.deploy.unshieldedBalances;
           }
-          return [];
+          throw new IndexerInvariantError(
+            'blockOffsetToUnshieldedBalances$: contractActions has neither unshieldedBalances nor deploy field'
+          );
         }),
         Rx.map(toUnshieldedBalances)
       );

--- a/packages/indexer-public-data-provider/src/observables.ts
+++ b/packages/indexer-public-data-provider/src/observables.ts
@@ -31,7 +31,7 @@ import type {
   InputMaybe,
   RegularTransaction
 } from './gen/graphql';
-import { hasContractAction } from './mapping';
+import { extractUnshieldedBalances, hasContractAction } from './mapping';
 import {
   BLOCK_QUERY,
   CONTRACT_STATE_QUERY,
@@ -317,18 +317,7 @@ export const waitForUnshieldedBalancesToAppear =
       UNSHIELDED_BALANCE_QUERY,
       { address: contractAddress },
       hasContractAction,
-      (data) => {
-        const action = data.contractAction;
-        if ('unshieldedBalances' in action) {
-          return action.unshieldedBalances;
-        }
-        if ('deploy' in action) {
-          return action.deploy.unshieldedBalances;
-        }
-        throw new IndexerInvariantError(
-          'waitForUnshieldedBalancesToAppear: contractAction has neither unshieldedBalances nor deploy field'
-        );
-      },
+      (data) => extractUnshieldedBalances(data.contractAction, 'waitForUnshieldedBalancesToAppear'),
       pollInterval
     );
 
@@ -360,15 +349,7 @@ export const blockOffsetToUnshieldedBalances$ =
           if (!contractAction) {
             throw new IndexerSubscriptionDataError('contractActions');
           }
-          if ('unshieldedBalances' in contractAction) {
-            return contractAction.unshieldedBalances;
-          }
-          if ('deploy' in contractAction) {
-            return contractAction.deploy.unshieldedBalances;
-          }
-          throw new IndexerInvariantError(
-            'blockOffsetToUnshieldedBalances$: contractActions has neither unshieldedBalances nor deploy field'
-          );
+          return extractUnshieldedBalances(contractAction, 'blockOffsetToUnshieldedBalances$');
         }),
         Rx.map(toUnshieldedBalances)
       );

--- a/packages/indexer-public-data-provider/src/observables.ts
+++ b/packages/indexer-public-data-provider/src/observables.ts
@@ -13,7 +13,8 @@
  * limitations under the License.
  */
 
-import type { ApolloClient, ApolloQueryResult, FetchResult } from '@apollo/client/core';
+import type { ApolloClient, ApolloQueryResult, FetchResult, OperationVariables } from '@apollo/client/core';
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import type { ContractAddress, TransactionId } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import * as Rx from 'rxjs';
 
@@ -87,6 +88,41 @@ export const withValidFetchData = <A>(): Rx.OperatorFunction<FetchResult<A>, Non
     Rx.filter((data): data is NonNullable<A> => data != null)
   );
 
+/**
+ * Polls `query` at `pollInterval` ms until `predicate(data)` holds, then
+ * emits `mapFn(data)` once and completes. Centralizes the cache policy
+ * (`no-cache` on initial/next/fetch), the `withCompleteQueryData` unwrap,
+ * and the `take(1)` semantics that every poll-until-first-match call site
+ * previously hand-rolled.
+ *
+ * The `predicate` is plain `boolean`-returning, not a type guard — `Rx.filter`
+ * does not narrow through generic predicates, so `mapFn` should cast or
+ * guard inside its body (the established `ExcludeEmptyAndNull<>` pattern).
+ */
+export const pollUntilPresent = <TQuery, TVars extends OperationVariables, TResult>(
+  apolloClient: ApolloClient,
+  query: TypedDocumentNode<TQuery, TVars>,
+  variables: TVars,
+  predicate: (data: TQuery) => boolean,
+  mapFn: (data: TQuery) => TResult,
+  pollInterval: number
+): Rx.Observable<TResult> =>
+  apolloClient
+    .watchQuery({
+      query,
+      variables,
+      pollInterval,
+      fetchPolicy: 'no-cache',
+      initialFetchPolicy: 'no-cache',
+      nextFetchPolicy: 'no-cache'
+    })
+    .pipe(
+      withCompleteQueryData<TQuery>(),
+      Rx.filter(predicate),
+      Rx.map(mapFn),
+      Rx.take(1)
+    );
+
 // Assumes that the block exists.
 export const blockOffsetToBlock$ = (apolloClient: ApolloClient) => (offset: InputMaybe<BlockOffset>) =>
   apolloClient
@@ -122,32 +158,25 @@ export const blockOffsetToBlock$ = (apolloClient: ApolloClient) => (offset: Inpu
 
 export const transactionIdToTransaction$ =
   (apolloClient: ApolloClient, pollInterval: number) => (identifier: TransactionId) =>
-    apolloClient
-      .watchQuery({
-        query: TX_ID_QUERY,
-        variables: {
-          offset: { identifier }
-        },
-        pollInterval,
-        fetchPolicy: 'no-cache',
-        initialFetchPolicy: 'no-cache',
-        nextFetchPolicy: 'no-cache'
-      })
-      .pipe(
-        withCompleteQueryData(),
-        Rx.filter((data) => data.transactions.length !== 0),
-        Rx.map((data) => {
-          const first = data.transactions[0];
-          if (first === undefined) {
-            throw new IndexerInvariantError(
-              'transactionIdToTransaction$: empty transactions array passed the non-empty filter'
-            );
-          }
-          return { height: first.block.height };
-        }),
-        Rx.concatMap(blockOffsetToBlock$(apolloClient)),
-        Rx.concatMap(({ transactions }) => Rx.from(transactions))
-      );
+    pollUntilPresent(
+      apolloClient,
+      TX_ID_QUERY,
+      { offset: { identifier } },
+      (data) => data.transactions.length !== 0,
+      (data) => {
+        const first = data.transactions[0];
+        if (first === undefined) {
+          throw new IndexerInvariantError(
+            'transactionIdToTransaction$: empty transactions array passed the non-empty filter'
+          );
+        }
+        return { height: first.block.height };
+      },
+      pollInterval
+    ).pipe(
+      Rx.concatMap(blockOffsetToBlock$(apolloClient)),
+      Rx.concatMap(({ transactions }) => Rx.from(transactions))
+    );
 
 export const transactionToContractState$ =
   (transactionId: TransactionId) =>
@@ -166,29 +195,19 @@ export const blockToContractState$ = (contractAddress: ContractAddress) => (bloc
 
 export const contractAddressToLatestBlockOffset$ =
   (apolloClient: ApolloClient, pollInterval: number) => (contractAddress: ContractAddress) =>
-    apolloClient
-      .watchQuery({
-        query: LATEST_CONTRACT_TX_BLOCK_HEIGHT_QUERY,
-        variables: {
-          address: contractAddress
-        },
-        pollInterval,
-        fetchPolicy: 'no-cache',
-        initialFetchPolicy: 'no-cache',
-        nextFetchPolicy: 'no-cache'
-      })
-      .pipe(
-        withCompleteQueryData(),
-        Rx.filter((data) => data.contractAction !== null),
-        Rx.map((data) => {
-          const contract = data.contractAction as ExcludeEmptyAndNull<
-            LatestContractTxBlockHeightQueryQuery['contractAction']
-          >;
-          return contract.transaction.block.height;
-        }),
-        Rx.take(1),
-        Rx.map((height) => ({ height }))
-      );
+    pollUntilPresent(
+      apolloClient,
+      LATEST_CONTRACT_TX_BLOCK_HEIGHT_QUERY,
+      { address: contractAddress },
+      (data) => data.contractAction !== null,
+      (data) => {
+        const contract = data.contractAction as ExcludeEmptyAndNull<
+          LatestContractTxBlockHeightQueryQuery['contractAction']
+        >;
+        return { height: contract.transaction.block.height };
+      },
+      pollInterval
+    );
 
 // Assumes block already exists
 export const blockOffsetToContractState$ =
@@ -220,72 +239,48 @@ export const waitForContractToAppear =
   (apolloClient: ApolloClient, pollInterval: number) =>
   (contractAddress: ContractAddress) =>
   (offset: InputMaybe<ContractActionOffset>) =>
-    apolloClient
-      .watchQuery({
-        query: CONTRACT_STATE_QUERY,
-        variables: {
-          address: contractAddress,
-          offset
-        },
-        pollInterval,
-        fetchPolicy: 'no-cache',
-        initialFetchPolicy: 'no-cache',
-        nextFetchPolicy: 'no-cache'
-      })
-      .pipe(
-        withCompleteQueryData(),
-        Rx.filter(hasContractAction),
-        Rx.map((data) => data.contractAction.state),
-        Rx.take(1)
-      );
+    pollUntilPresent(
+      apolloClient,
+      CONTRACT_STATE_QUERY,
+      { address: contractAddress, offset },
+      hasContractAction,
+      (data) => {
+        const action = data.contractAction as ExcludeEmptyAndNull<typeof data.contractAction>;
+        return action.state;
+      },
+      pollInterval
+    );
 
 export const waitForBlockToAppear =
   (apolloClient: ApolloClient, pollInterval: number) => (offset: InputMaybe<BlockOffset>) =>
-    apolloClient
-      .watchQuery({
-        query: BLOCK_QUERY,
-        variables: {
-          offset
-        },
-        pollInterval,
-        fetchPolicy: 'no-cache',
-        initialFetchPolicy: 'no-cache',
-        nextFetchPolicy: 'no-cache'
-      })
-      .pipe(
-        withCompleteQueryData(),
-        Rx.filter((data) => data.block !== null),
-        Rx.take(1)
-      );
+    pollUntilPresent(
+      apolloClient,
+      BLOCK_QUERY,
+      { offset },
+      (data) => data.block !== null,
+      (data) => data,
+      pollInterval
+    );
 
 export const waitForUnshieldedBalancesToAppear =
   (apolloClient: ApolloClient, pollInterval: number) => (contractAddress: ContractAddress) =>
-    apolloClient
-      .watchQuery({
-        query: UNSHIELDED_BALANCE_QUERY,
-        variables: {
-          address: contractAddress
-        },
-        pollInterval,
-        fetchPolicy: 'no-cache',
-        initialFetchPolicy: 'no-cache',
-        nextFetchPolicy: 'no-cache'
-      })
-      .pipe(
-        withCompleteQueryData(),
-        Rx.filter(hasContractAction),
-        Rx.map((data) => {
-          const { contractAction } = data;
-          if ('unshieldedBalances' in contractAction) {
-            return contractAction.unshieldedBalances;
-          }
-          if ('deploy' in contractAction) {
-            return contractAction.deploy.unshieldedBalances;
-          }
-          return [];
-        }),
-        Rx.take(1)
-      );
+    pollUntilPresent(
+      apolloClient,
+      UNSHIELDED_BALANCE_QUERY,
+      { address: contractAddress },
+      hasContractAction,
+      (data) => {
+        const action = data.contractAction as ExcludeEmptyAndNull<typeof data.contractAction>;
+        if ('unshieldedBalances' in action) {
+          return action.unshieldedBalances;
+        }
+        if ('deploy' in action) {
+          return action.deploy.unshieldedBalances;
+        }
+        return [];
+      },
+      pollInterval
+    );
 
 export const blockOffsetToUnshieldedBalances$ =
   (apolloClient: ApolloClient) =>

--- a/packages/indexer-public-data-provider/src/observables.ts
+++ b/packages/indexer-public-data-provider/src/observables.ts
@@ -143,7 +143,19 @@ export function pollUntilPresent<TQuery, TVars extends OperationVariables, TResu
     );
 }
 
-// Assumes that the block exists.
+/**
+ * Subscribes to `TXS_FROM_BLOCK_SUB`, which emits every block on the
+ * indexer from `offset` onward. **Heavy wire traffic** — no server-side
+ * filter by address; every block on chain flows through the WebSocket.
+ *
+ * Use when the caller needs the block-grouped "states-at-this-block"
+ * view (typically paired with {@link blockToContractState$} to extract
+ * contract states from each block's transactions). For a continuous
+ * change feed of a single contract, prefer {@link blockOffsetToContractState$}
+ * — it's server-side filtered (light).
+ *
+ * Assumes that the block at `offset` exists.
+ */
 export const blockOffsetToBlock$ = (apolloClient: ApolloClient) => (offset: InputMaybe<BlockOffset>) =>
   apolloClient
     .subscribe({
@@ -206,6 +218,16 @@ export const transactionToContractState$ =
       Rx.map((pair) => parseHexContractState(pair[1].state))
     );
 
+/**
+ * Walks a block's transactions and emits one {@link ContractState} per
+ * `contractAction` whose `address` matches `contractAddress`. Client-side
+ * filter. Paired with {@link blockOffsetToBlock$} to produce the
+ * block-grouped "states-at-this-block" view used by `contractStateObservable`
+ * for the `latest`, `blockHeight`, and `blockHash` branches.
+ *
+ * Multiple states can come from a single block (every matching contract
+ * action in every transaction of that block emits one).
+ */
 export const blockToContractState$ = (contractAddress: ContractAddress) => (block: Block) =>
   Rx.from(block.transactions).pipe(
     Rx.concatMap(({ contractActions }) => Rx.from(contractActions)),
@@ -224,7 +246,21 @@ export const contractAddressToLatestBlockOffset$ =
       pollInterval
     );
 
-// Assumes block already exists
+/**
+ * Subscribes to `CONTRACT_STATE_SUB($address, $offset)`. **Light wire
+ * traffic** — server-side filtered by `contractAddress`; only state
+ * changes for this contract flow through the WebSocket.
+ *
+ * Emits one {@link ContractState} per state change (per-change feed,
+ * not per-block snapshot). Used by `contractStateObservable.all` where
+ * the change-feed semantics fit. Not used by `latest`/`blockHeight`/`blockHash`
+ * — those need the per-block view from {@link blockOffsetToBlock$} +
+ * {@link blockToContractState$} because `Rx.skip(1)` on a per-change
+ * stream would skip a single change rather than a single block, giving
+ * `inclusive: false` a subtly different meaning.
+ *
+ * Assumes block already exists.
+ */
 export const blockOffsetToContractState$ =
   (apolloClient: ApolloClient) =>
   (contractAddress: ContractAddress) =>
@@ -296,6 +332,14 @@ export const waitForUnshieldedBalancesToAppear =
       pollInterval
     );
 
+/**
+ * Subscribes to `UNSHIELDED_BALANCE_SUB($address, $offset)`. **Light wire
+ * traffic** — server-side filtered by `contractAddress`. The indexer has
+ * no `BALANCES_FROM_BLOCK_SUB` analogue, so this is the only subscription
+ * for balances regardless of config branch. `unshieldedBalancesObservable`
+ * uses it uniformly across `latest`/`all`/`blockHeight`/`blockHash` —
+ * no light/heavy asymmetry analogous to {@link contractStateObservable}.
+ */
 export const blockOffsetToUnshieldedBalances$ =
   (apolloClient: ApolloClient) =>
   (contractAddress: ContractAddress) =>

--- a/packages/indexer-public-data-provider/src/observables.ts
+++ b/packages/indexer-public-data-provider/src/observables.ts
@@ -199,7 +199,7 @@ export const transactionIdToTransaction$ =
         const first = data.transactions[0];
         if (first === undefined) {
           throw new IndexerInvariantError(
-            'transactionIdToTransaction$: empty transactions array passed the non-empty filter'
+            'transactionIdToTransaction$: transactions array unexpectedly empty after predicate'
           );
         }
         return { height: first.block.height };

--- a/packages/indexer-public-data-provider/src/provider.ts
+++ b/packages/indexer-public-data-provider/src/provider.ts
@@ -49,7 +49,12 @@ import type {
   InputMaybe,
   RegularTransaction
 } from './gen/graphql';
-import { type ExcludeEmptyAndNull, isRegularTransaction, toFinalizedDeployTxData } from './mapping';
+import {
+  type ExcludeEmptyAndNull,
+  extractUnshieldedBalances,
+  isRegularTransaction,
+  toFinalizedDeployTxData
+} from './mapping';
 import {
   blockOffsetToBlock$,
   blockOffsetToContractState$,
@@ -188,18 +193,8 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
       .then(maybeThrowQueryError)
       .then((queryResult) => {
         const contractAction = queryResult.data?.contractAction;
-        if (!contractAction) {
-          return null;
-        }
-        if ('unshieldedBalances' in contractAction) {
-          return contractAction.unshieldedBalances;
-        }
-        if ('deploy' in contractAction) {
-          return contractAction.deploy.unshieldedBalances;
-        }
-        throw new IndexerInvariantError(
-          'queryUnshieldedBalances: contractAction has neither unshieldedBalances nor deploy field'
-        );
+        if (!contractAction) return null;
+        return extractUnshieldedBalances(contractAction, 'queryUnshieldedBalances');
       })
       .then((maybeUnshieldedBalances) =>
         maybeUnshieldedBalances ? toUnshieldedBalances(maybeUnshieldedBalances) : null

--- a/packages/indexer-public-data-provider/src/provider.ts
+++ b/packages/indexer-public-data-provider/src/provider.ts
@@ -320,6 +320,37 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
     );
   }
 
+  /**
+   * Creates a stream of contract states for `contractAddress`.
+   *
+   * **Wire-traffic asymmetry by branch:**
+   *
+   * | Branch                                 | Pipeline                                                                                            | Wire traffic |
+   * |----------------------------------------|-----------------------------------------------------------------------------------------------------|--------------|
+   * | `latest` / `blockHeight` / `blockHash` | poll for block-presence → `TXS_FROM_BLOCK_SUB` + client-side address filter                          | **Heavy** — every block on chain flows over WS; client extracts states for this contract. |
+   * | `txId`                                 | poll `TX_ID_QUERY` → `TXS_FROM_BLOCK_SUB` from the tx's block → walk states matching the identifier  | **Heavy** — same `TXS_FROM_BLOCK_SUB` subscription as above, opened once the tx is located. |
+   * | `all`                                  | poll for contract-presence → `CONTRACT_STATE_SUB($address, offset: null)`                            | **Light** — server-side filter; only this contract's state changes flow over WS. |
+   *
+   * The heavy path emits one observable value per matching contract action
+   * in each block — a per-block "states-at-this-block" view. It is used
+   * everywhere a block-level anchor matters (latest block, specific block
+   * with `inclusive`, transaction → containing-block). The light path
+   * (`all`) emits one value per state change directly from the
+   * server-filtered subscription — bandwidth scales with state changes
+   * rather than chain activity.
+   *
+   * Why not unify: `CONTRACT_STATE_SUB` is per-change, so a downstream
+   * `Rx.skip(1)` would skip the first state change rather than the first
+   * block — `inclusive: false` on `blockHeight`/`blockHash` would have a
+   * subtly different meaning. `TXS_FROM_BLOCK_SUB` for `all` would stream
+   * every block on chain (orders of magnitude more bytes on a busy chain).
+   *
+   * See {@link blockOffsetToBlock$}, {@link blockOffsetToContractState$},
+   * and {@link blockToContractState$} for per-subscription docs.
+   *
+   * @param contractAddress The address of the contract of interest.
+   * @param config The configuration of the stream. Defaults to `latest`.
+   */
   contractStateObservable(
     contractAddress: ContractAddress,
     config: ContractStateObservableConfig = { type: 'latest' }
@@ -354,6 +385,26 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
     return maybeShortenedBlocks.pipe(Rx.concatMap(blockToContractState$(contractAddress)));
   }
 
+  /**
+   * Creates a stream of unshielded balances for `contractAddress`.
+   *
+   * All three non-`txId` branches (`latest`/`all`/`blockHeight`/`blockHash`)
+   * use `UNSHIELDED_BALANCE_SUB($address, $offset)` as the terminal
+   * subscription. **Wire traffic is uniformly light** — server-side
+   * filtered by `contractAddress`. The indexer has no per-block
+   * subscription analogue for balances, so there is no light/heavy
+   * asymmetry comparable to {@link contractStateObservable}.
+   *
+   * The `txId` configuration is not supported and throws
+   * {@link IndexerProviderConfigError}. Tx-anchored balance streams are
+   * not exposed by the indexer's subscription surface — for the related
+   * contract-state stream see {@link contractStateObservable}.
+   *
+   * See {@link blockOffsetToUnshieldedBalances$} for the per-subscription doc.
+   *
+   * @param contractAddress The address of the contract of interest.
+   * @param config The configuration of the stream. Defaults to `latest`.
+   */
   unshieldedBalancesObservable(
     contractAddress: ContractAddress,
     config: ContractStateObservableConfig = { type: 'latest' }

--- a/packages/indexer-public-data-provider/src/provider.ts
+++ b/packages/indexer-public-data-provider/src/provider.ts
@@ -197,7 +197,9 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
         if ('deploy' in contractAction) {
           return contractAction.deploy.unshieldedBalances;
         }
-        return [];
+        throw new IndexerInvariantError(
+          'queryUnshieldedBalances: contractAction has neither unshieldedBalances nor deploy field'
+        );
       })
       .then((maybeUnshieldedBalances) =>
         maybeUnshieldedBalances ? toUnshieldedBalances(maybeUnshieldedBalances) : null

--- a/packages/indexer-public-data-provider/src/provider.ts
+++ b/packages/indexer-public-data-provider/src/provider.ts
@@ -28,6 +28,7 @@ import type {
   PublicDataProvider,
   UnshieldedBalances
 } from '@midnight-ntwrk/midnight-js-types';
+import { assertIsContractAddress } from '@midnight-ntwrk/midnight-js-utils';
 import * as Rx from 'rxjs';
 
 import {
@@ -40,7 +41,7 @@ import {
   toUnshieldedBalances,
   toUnshieldedUtxos
 } from './codec';
-import { IndexerDataError, IndexerProviderConfigError } from './errors';
+import { IndexerDataError, IndexerInvariantError, IndexerProviderConfigError } from './errors';
 import type {
   ContractActionOffset,
   DeployContractStateTxQueryQuery,
@@ -74,15 +75,10 @@ import {
 import type { ApolloHandle } from './transport';
 
 /**
- * Class form of the indexer-backed `PublicDataProvider`. Carries the
- * Apollo handle and the resolved poll interval. Does **not** call
- * `assertIsContractAddress` — the outer wrapper in `index.ts` retains that
- * responsibility until Phase 3.
- *
- * Phase 2 introduces this class for two reasons:
- *  1. To carry a `dispose()` lifecycle method (fix #820).
- *  2. To establish the `(handle, pollInterval)` constructor shape that
- *     maps directly onto `Layer.scoped` in the future Effect migration (#843).
+ * Indexer-backed `PublicDataProvider`. Every method that takes a
+ * `ContractAddress` validates the input up front via
+ * `assertIsContractAddress`. The constructor shape `(handle, pollInterval)`
+ * maps directly onto `Layer.scoped` in the future Effect migration (#843).
  *
  * TODO: Re-examine caching when 'ContractCall' and 'ContractDeploy' have
  * transaction identifiers included.
@@ -109,17 +105,18 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
     return this.handle.client;
   }
 
-  async queryContractState(
+  queryContractState(
     address: ContractAddress,
     config?: BlockHeightConfig | BlockHashConfig
   ): Promise<ContractState | null> {
+    assertIsContractAddress(address);
     const offset: InputMaybe<ContractActionOffset> = config
       ? {
           blockOffset:
             config.type === 'blockHeight' ? { height: config.blockHeight } : { hash: config.blockHash }
         }
       : null;
-    const maybeContractState = await this.client
+    return this.client
       .query({
         query: CONTRACT_STATE_QUERY,
         variables: {
@@ -129,21 +126,22 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
         fetchPolicy: 'no-cache'
       })
       .then(maybeThrowQueryError)
-      .then((queryResult) => queryResult.data?.contractAction?.state ?? null);
-    return maybeContractState ? parseHexContractState(maybeContractState) : null;
+      .then((queryResult) => queryResult.data?.contractAction?.state ?? null)
+      .then((maybeContractState) => (maybeContractState ? parseHexContractState(maybeContractState) : null));
   }
 
-  async queryZSwapAndContractState(
+  queryZSwapAndContractState(
     address: ContractAddress,
     config?: BlockHeightConfig | BlockHashConfig
   ): Promise<[ZswapChainState, ContractState, LedgerParameters] | null> {
+    assertIsContractAddress(address);
     const offset = config
       ? {
           blockOffset:
             config.type === 'blockHeight' ? { height: config.blockHeight } : { hash: config.blockHash }
         }
       : null;
-    const maybeContractStates = await this.client
+    return this.client
       .query({
         query: CONTRACT_AND_ZSWAP_STATE_QUERY,
         variables: {
@@ -153,29 +151,32 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
         fetchPolicy: 'no-cache'
       })
       .then(maybeThrowQueryError)
-      .then((queryResult) => queryResult.data?.contractAction);
-    return maybeContractStates
-      ? [
-          parseHexZswapState(maybeContractStates.zswapState),
-          parseHexContractState(maybeContractStates.state),
-          maybeContractStates.transaction?.block?.ledgerParameters
-            ? parseHexLedgerParameters(maybeContractStates.transaction.block.ledgerParameters)
-            : LedgerParameters.initialParameters()
-        ]
-      : null;
+      .then((queryResult) => queryResult.data?.contractAction)
+      .then((maybeContractStates) =>
+        maybeContractStates
+          ? ([
+              parseHexZswapState(maybeContractStates.zswapState),
+              parseHexContractState(maybeContractStates.state),
+              maybeContractStates.transaction?.block?.ledgerParameters
+                ? parseHexLedgerParameters(maybeContractStates.transaction.block.ledgerParameters)
+                : LedgerParameters.initialParameters()
+            ] as [ZswapChainState, ContractState, LedgerParameters])
+          : null
+      );
   }
 
-  async queryUnshieldedBalances(
+  queryUnshieldedBalances(
     address: ContractAddress,
     config?: BlockHeightConfig | BlockHashConfig
   ): Promise<UnshieldedBalances | null> {
+    assertIsContractAddress(address);
     const offset: InputMaybe<ContractActionOffset> = config
       ? {
           blockOffset:
             config.type === 'blockHeight' ? { height: config.blockHeight } : { hash: config.blockHash }
         }
       : null;
-    const maybeUnshieldedBalances = await this.client
+    return this.client
       .query({
         query: QUERY_UNSHIELDED_BALANCES_WITH_OFFSET,
         variables: {
@@ -197,11 +198,14 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
           return contractAction.deploy.unshieldedBalances;
         }
         return [];
-      });
-    return maybeUnshieldedBalances ? toUnshieldedBalances(maybeUnshieldedBalances) : null;
+      })
+      .then((maybeUnshieldedBalances) =>
+        maybeUnshieldedBalances ? toUnshieldedBalances(maybeUnshieldedBalances) : null
+      );
   }
 
-  async queryDeployContractState(contractAddress: ContractAddress): Promise<ContractState | null> {
+  queryDeployContractState(contractAddress: ContractAddress): Promise<ContractState | null> {
+    assertIsContractAddress(contractAddress);
     return this.client
       .query({
         query: DEPLOY_CONTRACT_STATE_TX_QUERY,
@@ -231,19 +235,22 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
       .then((maybeContractState) => (maybeContractState ? parseHexContractState(maybeContractState) : null));
   }
 
-  async watchForContractState(contractAddress: ContractAddress): Promise<ContractState> {
+  watchForContractState(contractAddress: ContractAddress): Promise<ContractState> {
+    assertIsContractAddress(contractAddress);
     return Rx.firstValueFrom(
       waitForContractToAppear(this.client, this.pollInterval)(contractAddress)(null).pipe(Rx.map(parseHexContractState))
     );
   }
 
-  async watchForUnshieldedBalances(contractAddress: ContractAddress): Promise<UnshieldedBalances> {
+  watchForUnshieldedBalances(contractAddress: ContractAddress): Promise<UnshieldedBalances> {
+    assertIsContractAddress(contractAddress);
     return Rx.firstValueFrom(
       waitForUnshieldedBalancesToAppear(this.client, this.pollInterval)(contractAddress).pipe(Rx.map(toUnshieldedBalances))
     );
   }
 
-  async watchForDeployTxData(contractAddress: ContractAddress): Promise<FinalizedTxData> {
+  watchForDeployTxData(contractAddress: ContractAddress): Promise<FinalizedTxData> {
+    assertIsContractAddress(contractAddress);
     return Rx.firstValueFrom(
       this.client
         .watchQuery({
@@ -270,7 +277,7 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
     );
   }
 
-  async watchForTxData(txId: TransactionId): Promise<FinalizedTxData> {
+  watchForTxData(txId: TransactionId): Promise<FinalizedTxData> {
     return Rx.firstValueFrom(
       this.client
         .watchQuery({
@@ -284,7 +291,15 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
         .pipe(
           withCompleteQueryData(),
           Rx.filter((data) => data.transactions.length !== 0),
-          Rx.map((data) => data.transactions[0]!),
+          Rx.map((data) => {
+            const first = data.transactions[0];
+            if (first === undefined) {
+              throw new IndexerInvariantError(
+                'watchForTxData: empty transactions array passed the non-empty filter'
+              );
+            }
+            return first;
+          }),
           Rx.filter(isRegularTransaction),
           Rx.map(
             (transaction: RegularTransaction): FinalizedTxData => ({
@@ -315,6 +330,7 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
     contractAddress: ContractAddress,
     config: ContractStateObservableConfig = { type: 'latest' }
   ): Rx.Observable<ContractState> {
+    assertIsContractAddress(contractAddress);
     if (config.type === 'txId') {
       const contractStates = transactionIdToTransaction$(this.client, this.pollInterval)(config.txId).pipe(
         Rx.filter(isRegularTransaction),
@@ -348,6 +364,7 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
     contractAddress: ContractAddress,
     config: ContractStateObservableConfig = { type: 'latest' }
   ): Rx.Observable<UnshieldedBalances> {
+    assertIsContractAddress(contractAddress);
     if (config.type === 'txId') {
       throw new IndexerProviderConfigError(
         'txId configuration not supported for unshielded balances observable'

--- a/packages/indexer-public-data-provider/src/provider.ts
+++ b/packages/indexer-public-data-provider/src/provider.ts
@@ -45,12 +45,12 @@ import { IndexerDataError, IndexerInvariantError, IndexerProviderConfigError } f
 import type {
   ContractActionOffset,
   DeployContractStateTxQueryQuery,
-  DeployTxQueryQuery,
   InputMaybe,
   RegularTransaction
 } from './gen/graphql';
 import {
   type ExcludeEmptyAndNull,
+  extractRegularDeployTransaction,
   extractUnshieldedBalances,
   isRegularTransaction,
   toFinalizedDeployTxData
@@ -248,20 +248,14 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
 
   watchForDeployTxData(contractAddress: ContractAddress): Promise<FinalizedTxData> {
     assertIsContractAddress(contractAddress);
-    const extractRegular = (data: DeployTxQueryQuery): (RegularTransaction & { hash: string; identifiers: string[] }) | null => {
-      if (data.contractAction === null) return null;
-      const contract = data.contractAction as ExcludeEmptyAndNull<DeployTxQueryQuery['contractAction']>;
-      const transaction = 'deploy' in contract ? contract.deploy.transaction : contract.transaction;
-      return isRegularTransaction(transaction) ? transaction : null;
-    };
     return Rx.firstValueFrom(
       pollUntilPresent(
         this.client,
         DEPLOY_TX_QUERY,
         { address: contractAddress },
-        (data) => extractRegular(data) !== null,
+        (data) => extractRegularDeployTransaction(data.contractAction) !== null,
         (data) => {
-          const transaction = extractRegular(data);
+          const transaction = extractRegularDeployTransaction(data.contractAction);
           if (transaction === null) {
             throw new IndexerInvariantError(
               'watchForDeployTxData: extracted transaction unexpectedly null after predicate'

--- a/packages/indexer-public-data-provider/src/provider.ts
+++ b/packages/indexer-public-data-provider/src/provider.ts
@@ -203,6 +203,11 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
 
   queryDeployContractState(contractAddress: ContractAddress): Promise<ContractState | null> {
     assertIsContractAddress(contractAddress);
+    // Shape discrimination kept inline: this branch additionally does an
+    // address-correlated `find` over `contractActions` and throws
+    // `IndexerDataError.missingContractAction` (not `IndexerInvariantError`)
+    // on missing match — different error semantics from the helpers in
+    // `mapping.ts`, so extraction would obscure rather than simplify.
     return this.client
       .query({
         query: DEPLOY_CONTRACT_STATE_TX_QUERY,

--- a/packages/indexer-public-data-provider/src/provider.ts
+++ b/packages/indexer-public-data-provider/src/provider.ts
@@ -57,12 +57,12 @@ import {
   blockToContractState$,
   contractAddressToLatestBlockOffset$,
   maybeThrowQueryError,
+  pollUntilPresent,
   transactionIdToTransaction$,
   transactionToContractState$,
   waitForBlockToAppear,
   waitForContractToAppear,
-  waitForUnshieldedBalancesToAppear,
-  withCompleteQueryData
+  waitForUnshieldedBalancesToAppear
 } from './observables';
 import {
   CONTRACT_AND_ZSWAP_STATE_QUERY,
@@ -251,78 +251,72 @@ export class IndexerPublicDataProvider implements PublicDataProvider {
 
   watchForDeployTxData(contractAddress: ContractAddress): Promise<FinalizedTxData> {
     assertIsContractAddress(contractAddress);
+    const extractRegular = (data: DeployTxQueryQuery): (RegularTransaction & { hash: string; identifiers: string[] }) | null => {
+      if (data.contractAction === null) return null;
+      const contract = data.contractAction as ExcludeEmptyAndNull<DeployTxQueryQuery['contractAction']>;
+      const transaction = 'deploy' in contract ? contract.deploy.transaction : contract.transaction;
+      return isRegularTransaction(transaction) ? transaction : null;
+    };
     return Rx.firstValueFrom(
-      this.client
-        .watchQuery({
-          query: DEPLOY_TX_QUERY,
-          variables: {
-            address: contractAddress
-          },
-          pollInterval: this.pollInterval,
-          fetchPolicy: 'no-cache',
-          initialFetchPolicy: 'no-cache',
-          nextFetchPolicy: 'no-cache'
-        })
-        .pipe(
-          withCompleteQueryData(),
-          Rx.filter((data) => data.contractAction !== null),
-          Rx.map((data) => {
-            const contract = data.contractAction as ExcludeEmptyAndNull<DeployTxQueryQuery['contractAction']>;
-
-            return 'deploy' in contract ? contract.deploy.transaction : contract.transaction;
-          }),
-          Rx.filter(isRegularTransaction),
-          Rx.map((transaction: RegularTransaction) => toFinalizedDeployTxData(contractAddress, transaction))
-        )
+      pollUntilPresent(
+        this.client,
+        DEPLOY_TX_QUERY,
+        { address: contractAddress },
+        (data) => extractRegular(data) !== null,
+        (data) => {
+          const transaction = extractRegular(data);
+          if (transaction === null) {
+            throw new IndexerInvariantError(
+              'watchForDeployTxData: extracted transaction unexpectedly null after predicate'
+            );
+          }
+          return toFinalizedDeployTxData(contractAddress, transaction);
+        },
+        this.pollInterval
+      )
     );
   }
 
   watchForTxData(txId: TransactionId): Promise<FinalizedTxData> {
     return Rx.firstValueFrom(
-      this.client
-        .watchQuery({
-          query: TX_ID_QUERY,
-          variables: { offset: { identifier: txId } },
-          pollInterval: this.pollInterval,
-          fetchPolicy: 'no-cache',
-          initialFetchPolicy: 'no-cache',
-          nextFetchPolicy: 'no-cache'
-        })
-        .pipe(
-          withCompleteQueryData(),
-          Rx.filter((data) => data.transactions.length !== 0),
-          Rx.map((data) => {
-            const first = data.transactions[0];
-            if (first === undefined) {
-              throw new IndexerInvariantError(
-                'watchForTxData: empty transactions array passed the non-empty filter'
-              );
+      pollUntilPresent(
+        this.client,
+        TX_ID_QUERY,
+        { offset: { identifier: txId } },
+        (data) => {
+          const first = data.transactions[0];
+          return first !== undefined && isRegularTransaction(first);
+        },
+        (data): FinalizedTxData => {
+          const first = data.transactions[0];
+          if (first === undefined || !isRegularTransaction(first)) {
+            throw new IndexerInvariantError(
+              'watchForTxData: transactions array unexpectedly empty or non-regular after predicate'
+            );
+          }
+          const transaction: RegularTransaction & { hash: string; identifiers: string[] } = first;
+          return {
+            tx: parseHexTransaction(transaction.raw),
+            status: toTxStatus(transaction.transactionResult),
+            txId,
+            txHash: transaction.hash,
+            identifiers: transaction.identifiers,
+            blockHeight: transaction.block.height,
+            blockHash: transaction.block.hash,
+            segmentStatusMap: toSegmentStatusMap(transaction.transactionResult),
+            unshielded: toUnshieldedUtxos(transaction.unshieldedCreatedOutputs, transaction.unshieldedSpentOutputs),
+            blockTimestamp: transaction.block.timestamp,
+            blockAuthor: transaction.block.author,
+            indexerId: transaction.id,
+            protocolVersion: transaction.protocolVersion,
+            fees: {
+              paidFees: transaction.fees.paidFees,
+              estimatedFees: transaction.fees.estimatedFees
             }
-            return first;
-          }),
-          Rx.filter(isRegularTransaction),
-          Rx.map(
-            (transaction: RegularTransaction): FinalizedTxData => ({
-              tx: parseHexTransaction(transaction.raw),
-              status: toTxStatus(transaction.transactionResult),
-              txId,
-              txHash: transaction.hash,
-              identifiers: transaction.identifiers,
-              blockHeight: transaction.block.height,
-              blockHash: transaction.block.hash,
-              segmentStatusMap: toSegmentStatusMap(transaction.transactionResult),
-              unshielded: toUnshieldedUtxos(transaction.unshieldedCreatedOutputs, transaction.unshieldedSpentOutputs),
-              blockTimestamp: transaction.block.timestamp,
-              blockAuthor: transaction.block.author,
-              indexerId: transaction.id,
-              protocolVersion: transaction.protocolVersion,
-              fees: {
-                paidFees: transaction.fees.paidFees,
-                estimatedFees: transaction.fees.estimatedFees
-              }
-            })
-          )
-        )
+          };
+        },
+        this.pollInterval
+      )
     );
   }
 

--- a/packages/indexer-public-data-provider/src/test/indexer-public-data-provider-lifecycle.test.ts
+++ b/packages/indexer-public-data-provider/src/test/indexer-public-data-provider-lifecycle.test.ts
@@ -100,7 +100,11 @@ describe('indexerPublicDataProvider — config-object overload', () => {
     });
 
     const fakeTxId = '00'.repeat(32) as unknown as Parameters<typeof provider.watchForTxData>[0];
-    await provider.watchForTxData(fakeTxId).catch(() => undefined);
+    try {
+      await provider.watchForTxData(fakeTxId);
+    } catch {
+      // expected — the mocked watchQuery short-circuits before any data flows
+    }
 
     expect(watchQuerySpy).toHaveBeenCalledWith(
       expect.objectContaining({ pollInterval: customPollInterval })

--- a/packages/indexer-public-data-provider/src/test/indexer-public-data-provider-unshielded-balances.test.ts
+++ b/packages/indexer-public-data-provider/src/test/indexer-public-data-provider-unshielded-balances.test.ts
@@ -108,7 +108,10 @@ describe('Unshielded Balances Integration', () => {
       const provider = indexerPublicDataProvider(queryURL, subscriptionURL);
 
       expect(typeof provider.unshieldedBalancesObservable).toBe('function');
-      expect(provider.unshieldedBalancesObservable.length).toBe(2); // expects 2 parameters
+      // The class signature declares `config` with a default value of `{ type: 'latest' }`,
+      // so JS `function.length` reports 1 required parameter (Phase 3 removed the
+      // outer wrapper that had previously declared `config` without a default).
+      expect(provider.unshieldedBalancesObservable.length).toBe(1);
     });
 
     test('should throw error for txId configuration before address validation', () => {

--- a/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
+++ b/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
@@ -37,6 +37,7 @@ import {
   IndexerDataError,
   IndexerError,
   IndexerFormattedError,
+  IndexerInvariantError,
   IndexerProviderConfigError,
   IndexerQueryError,
   IndexerSubscriptionDataError
@@ -401,6 +402,25 @@ describe('IndexerProviderConfigError', () => {
     expect(error).toBeInstanceOf(IndexerError);
     expect(error.name).toBe('IndexerProviderConfigError');
     expect(error.message).toBe('Unsupported observable mode: txId');
+  });
+});
+
+describe('IndexerInvariantError', () => {
+  test('exposes message and name', () => {
+    const error = new IndexerInvariantError(
+      'watchForTxData: empty transactions array passed the non-empty filter'
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(IndexerError);
+    expect(error.name).toBe('IndexerInvariantError');
+    expect(error.message).toBe('watchForTxData: empty transactions array passed the non-empty filter');
+  });
+
+  test('is distinct from IndexerDataError', () => {
+    const error = new IndexerInvariantError('any');
+
+    expect(error).not.toBeInstanceOf(IndexerDataError);
   });
 });
 

--- a/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
+++ b/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
@@ -43,7 +43,7 @@ import {
   IndexerSubscriptionDataError
 } from '../errors';
 import type { TransactionResult } from '../gen/graphql';
-import { extractUnshieldedBalances } from '../mapping';
+import { extractRegularDeployTransaction, extractUnshieldedBalances } from '../mapping';
 
 describe('isRegularTransaction', () => {
   test('returns true for object with hash and identifiers array', () => {
@@ -419,6 +419,45 @@ describe('IndexerProviderConfigError', () => {
     expect(error).toBeInstanceOf(IndexerError);
     expect(error.name).toBe('IndexerProviderConfigError');
     expect(error.message).toBe('Unsupported observable mode: txId');
+  });
+});
+
+describe('extractRegularDeployTransaction', () => {
+  const regularTx = {
+    hash: 'tx-hash',
+    identifiers: ['id-1'],
+    block: { height: 1, hash: 'block-hash', author: null, timestamp: 0 },
+    raw: '',
+    id: 1,
+    protocolVersion: 0,
+    fees: { estimatedFees: '0', paidFees: '0' },
+    transactionResult: { status: 'SUCCESS' as const, segments: null },
+    contractActions: [],
+    unshieldedCreatedOutputs: [],
+    unshieldedSpentOutputs: []
+  };
+
+  test('returns null when contractAction is null', () => {
+    expect(extractRegularDeployTransaction(null)).toBeNull();
+  });
+
+  test('returns the regular transaction from the ContractDeploy / ContractUpdate variant', () => {
+    const action = { transaction: regularTx } as unknown as Parameters<typeof extractRegularDeployTransaction>[0];
+
+    expect(extractRegularDeployTransaction(action)).toEqual(regularTx);
+  });
+
+  test('returns the regular transaction from the ContractCall variant via deploy.transaction', () => {
+    const action = { deploy: { transaction: regularTx } } as unknown as Parameters<typeof extractRegularDeployTransaction>[0];
+
+    expect(extractRegularDeployTransaction(action)).toEqual(regularTx);
+  });
+
+  test('returns null when the underlying transaction is not a regular transaction', () => {
+    const systemTx = { id: 99, raw: '' }; // no identifiers/hash → fails isRegularTransaction
+    const action = { transaction: systemTx } as unknown as Parameters<typeof extractRegularDeployTransaction>[0];
+
+    expect(extractRegularDeployTransaction(action)).toBeNull();
   });
 });
 

--- a/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
+++ b/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
@@ -43,6 +43,7 @@ import {
   IndexerSubscriptionDataError
 } from '../errors';
 import type { TransactionResult } from '../gen/graphql';
+import { extractUnshieldedBalances } from '../mapping';
 
 describe('isRegularTransaction', () => {
   test('returns true for object with hash and identifiers array', () => {
@@ -418,6 +419,36 @@ describe('IndexerProviderConfigError', () => {
     expect(error).toBeInstanceOf(IndexerError);
     expect(error.name).toBe('IndexerProviderConfigError');
     expect(error.message).toBe('Unsupported observable mode: txId');
+  });
+});
+
+describe('extractUnshieldedBalances', () => {
+  const balance = { tokenType: 'abc', amount: '100' };
+
+  test('returns balances from direct unshieldedBalances field (ContractUpdate / ContractDeploy variant)', () => {
+    expect(extractUnshieldedBalances({ unshieldedBalances: [balance] }, 'site')).toEqual([balance]);
+  });
+
+  test('returns balances from deploy.unshieldedBalances (ContractCall variant)', () => {
+    expect(extractUnshieldedBalances({ deploy: { unshieldedBalances: [balance] } }, 'site')).toEqual([balance]);
+  });
+
+  test('returns an empty array when the matching field exists and is empty', () => {
+    expect(extractUnshieldedBalances({ unshieldedBalances: [] }, 'site')).toEqual([]);
+  });
+
+  test('throws IndexerInvariantError with the caller name when neither field is present', () => {
+    let thrown: unknown;
+    try {
+      extractUnshieldedBalances({} as never, 'siteName');
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(IndexerInvariantError);
+    expect((thrown as IndexerInvariantError).message).toBe(
+      'siteName: contractAction has neither unshieldedBalances nor deploy field'
+    );
   });
 });
 

--- a/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
+++ b/packages/indexer-public-data-provider/src/test/pure-functions.test.ts
@@ -78,6 +78,22 @@ describe('isRegularTransaction', () => {
 
     expect(isRegularTransaction(blockQueryResult)).toBe(false);
   });
+
+  test('returns false for null', () => {
+    expect(isRegularTransaction(null)).toBe(false);
+  });
+
+  test('returns false for undefined', () => {
+    expect(isRegularTransaction(undefined)).toBe(false);
+  });
+
+  test('returns false for a number primitive', () => {
+    expect(isRegularTransaction(42)).toBe(false);
+  });
+
+  test('returns false for a string primitive', () => {
+    expect(isRegularTransaction('hash')).toBe(false);
+  });
 });
 
 describe('toTxStatus', () => {

--- a/packages/types/src/public-data-provider.ts
+++ b/packages/types/src/public-data-provider.ts
@@ -203,17 +203,4 @@ export interface PublicDataProvider {
    * @return {Observable<UnshieldedBalances>} An observable that emits the unshielded balances for the provided address.
    */
   unshieldedBalancesObservable(address: ContractAddress, config: ContractStateObservableConfig): Observable<UnshieldedBalances>;
-
-  /**
-   * Releases resources held by this provider (WebSocket connection, pending
-   * subscriptions, in-memory cache). After calling this method, no further
-   * operations may be performed on this instance. Implementations that hold
-   * no resources should provide a no-op (`async dispose() {}`).
-   *
-   * Must be idempotent: repeated and concurrent invocations share a single
-   * teardown — they return the same `Promise`. If the first invocation
-   * rejects, subsequent invocations return the same rejected `Promise` —
-   * teardown is not retried.
-   */
-  dispose(): Promise<void>;
 }


### PR DESCRIPTION
# Overview

Phase 3 of #808 (consolidation + assertion hygiene) plus a partial Phase 4 slice (`pollUntilPresent` helper, no SUB switch).

**Phase 1 (#960) and Phase 2 (#961) are merged.** This PR now targets `main` directly with three commits on top.

## Commit 1 — `refactor: consolidate wrapper into class and harden assertion hygiene`

**Wrapper consolidation:**
- The outer factory wrapper in `index.ts` that re-implemented every method to add `assertIsContractAddress` is gone. `indexerPublicDataProvider` now returns `new IndexerPublicDataProvider(handle, pollInterval)` directly.
- `IndexerPublicDataProvider` methods that take a `ContractAddress` now call `assertIsContractAddress(addr)` synchronously as their first statement. `watchForTxData(txId)` retains its no-assertion behavior.

**Sync-throw preservation:**
- Dropped the `async` keyword from every query/watch method. The `assertIsContractAddress` check now throws synchronously rather than becoming a rejected promise — matching the pre-Phase-2 wrapper semantics. Query bodies are rewritten as `.then(...)` chains; semantically equivalent to the previous `await ... ; return ...` shape.

**Assertion hygiene:**
- New `IndexerInvariantError` class in `errors.ts` for provider-pipeline invariant violations. **Sibling to `IndexerDataError` (not a subclass, deviation from the spec language)** because the failure category is distinct: invariant errors signal a bug in the provider's RxJS composition, not malformed indexer payloads.
- Replaced both `data.transactions[0]!` non-null assertions in `observables.ts::transactionIdToTransaction$` and `provider.ts::watchForTxData` with explicit `if (first === undefined) throw new IndexerInvariantError(...)`. **No `!` non-null assertion operator remains in the package source.**
- `isRegularTransaction` in `mapping.ts` now takes `unknown` (was `any` with an `eslint-disable`). Adds a `typeof tx === 'object' && tx !== null` guard so primitive/`null` input returns `false` rather than throwing on `'identifiers' in tx`.

## Commit 2 — `refactor: introduce pollUntilPresent helper and route all watchQuery sites through it`

**Partial Phase 4 — consolidation only, no SUB switch.** Pure refactor.

Helper signature (in `observables.ts`):

```ts
pollUntilPresent<TQuery, TVars, TResult>(
  apolloClient: ApolloClient,
  query: TypedDocumentNode<TQuery, TVars>,
  variables: TVars,
  predicate: (data: TQuery) => boolean,
  mapFn: (data: TQuery) => TResult,
  pollInterval: number,
): Observable<TResult>
```

Sites refactored (all 7):

- `observables.ts`: `transactionIdToTransaction$`, `contractAddressToLatestBlockOffset$`, `waitForContractToAppear`, `waitForBlockToAppear`, `waitForUnshieldedBalancesToAppear`.
- `provider.ts`: `watchForDeployTxData`, `watchForTxData` — the secondary `filter(isRegularTransaction)` is folded into the `pollUntilPresent` predicate so the "keep polling until a regular transaction appears" semantic is preserved.

### Note on `transactionIdToTransaction$` behavior (M1)

The original `transactionIdToTransaction$` pipeline had no `take(1)`. The `pollUntilPresent` helper adds one. Net effect:
- Apollo `watchQuery` polling now stops after the first poll-match (fewer HTTP polls in steady state).
- Downstream `concatMap(blockOffsetToBlock$)` behavior is preserved — the inner subscription never completed in the original, so queued additional outer emissions were never reached.
- Consumer-visible behavior unchanged.

This is documented here so reviewers don't read the diff as "no behavior change at all"; the wire-traffic side is materially better.

## Commit 3 — `fix: address PR-3 pollUntilPresent review findings`

Three findings from the parallel code review on commit 2:

- **M2 (fail-fast)**: `waitForUnshieldedBalancesToAppear` and `blockOffsetToUnshieldedBalances$` previously returned `[]` when the indexer's `contractAction` payload had neither `unshieldedBalances` nor `deploy` field. The empty array silently swallowed a shape mismatch. Now throws `IndexerInvariantError`.
- **M3 (type-guard overload)**: `pollUntilPresent` now has a type-guard overload (`predicate: (data: TQuery) => data is TNarrowed`) that lets `mapFn` access narrowed fields without a cast. Three call sites simplified, three `as ExcludeEmptyAndNull<>` casts removed.
- **M1**: documented above.

## Tests

- New: `IndexerInvariantError` constructor/inheritance tests in `pure-functions.test.ts`. Locks in the sibling-not-subclass relationship with an explicit `not.toBeInstanceOf(IndexerDataError)`.
- Updated: `unshieldedBalancesObservable.length` expectation from 2 → 1 with an explanatory comment.

95 unit tests pass in `packages/indexer-public-data-provider` (66 baseline + 29 new across PR-2 and PR-3); lint clean; build green across the package, `packages/types`, the `midnight-js` barrel, and downstream `testkit-js`.

## Deliberate deviations

1. **`IndexerInvariantError` is a sibling of `IndexerDataError`, not a subclass.** Spec language said "subclass of IndexerDataError"; sibling fits the semantics better (provider-pipeline bug ≠ malformed indexer payload).
2. **`isRegularTransaction` no longer throws on `null`/primitive input** — returns `false` instead. Defensive improvement.
3. **Partial Phase 4**: only the `pollUntilPresent` consolidation lands here. The polling-→-subscriptions switch (originally Phase 4 part A) is deferred until the indexer's SUB-semantics audit.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided — 2 new tests for `IndexerInvariantError`; existing 93 tests cover the refactored polling sites end-to-end
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff (parallel code-reviewer agents — zero HIGH findings; three MED findings addressed in commit 3)
- [ ] Reviewer requested
- [x] Update README.md file (if relevant) — N/A
- [x] Update documentation (if relevant) — specs in `docs/specs/` cover Phase 3 + Phase 4 scope
- [x] No new todos introduced

## Links

Part of #808. Follows #960 (Phase 1, merged) and #961 (Phase 2, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
