### PR TITLE
docs: add .env.example and examples/ directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,43 @@
+# Copy this file to .env and fill in values for your environment.
+# direnv loads .env automatically if present (via `dotenv_if_exists` in .envrc).
+
+# ---------------------------------------------------------------------------
+# Compact compiler
+# ---------------------------------------------------------------------------
+
+# Version of compactc to install when running `yarn build`.
+# Must match an actual release tag on midnightntwrk/compact.
+COMPACTC_VERSION=0.31.0
+
+# Advanced: override the tag prefix and repo if you host a custom fork.
+# COMPACT_TAG_PREFIX=compactc-v
+# COMPACT_REPO=midnightntwrk/compact
+
+# ---------------------------------------------------------------------------
+# Testkit / Docker integration tests
+# ---------------------------------------------------------------------------
+
+# Which network environment to pull Docker images for.
+# Allowed values: qanet | preview | preprod | mainnet | devnet
+TESTKIT_DOCKER_ENV=preprod
+
+# ---------------------------------------------------------------------------
+# Application endpoints (used in examples and your own dApps)
+# ---------------------------------------------------------------------------
+
+# GraphQL endpoint of a Midnight Indexer (HTTP and WebSocket).
+INDEXER_HTTP_URL=https://indexer.midnight.network/api/v1/graphql
+INDEXER_WS_URL=wss://indexer.midnight.network/api/v1/graphql
+
+# Proof server endpoint.
+PROOF_SERVER_URL=https://proof.midnight.network
+
+# Base URL where ZK circuit artifacts are hosted.
+ZK_CONFIG_BASE_URL=https://artifacts.midnight.network
+
+# ---------------------------------------------------------------------------
+# Private state encryption
+# ---------------------------------------------------------------------------
+
+# Minimum 16 characters. Keep this secret — it encrypts all local private state.
+# PRIVATE_STATE_PASSWORD=change-me-to-something-secure-at-least-16-chars

--- a/examples/01-providers.ts
+++ b/examples/01-providers.ts
@@ -1,0 +1,78 @@
+/**
+ * 01-providers.ts
+ *
+ * Shows how to assemble the MidnightProviders object that every
+ * contract deployment and call requires.
+ *
+ * Run:
+ *   tsx 01-providers.ts
+ */
+
+import 'dotenv/config';
+import { levelPrivateStateProvider } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
+import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
+import { httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client-proof-provider';
+import { FetchZkConfigProvider } from '@midnight-ntwrk/midnight-js-fetch-zk-config-provider';
+import { setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import type { MidnightProviders } from '@midnight-ntwrk/midnight-js-types';
+
+// 1. Choose the network.
+//    Valid values: 'devnet' | 'testnet' | 'mainnet'
+setNetworkId('testnet');
+
+// 2. Read configuration from environment variables (see ../.env.example).
+const {
+  INDEXER_HTTP_URL = 'https://indexer.midnight.network/api/v1/graphql',
+  INDEXER_WS_URL = 'wss://indexer.midnight.network/api/v1/graphql',
+  PROOF_SERVER_URL = 'https://proof.midnight.network',
+  ZK_CONFIG_BASE_URL = 'https://artifacts.midnight.network',
+  PRIVATE_STATE_PASSWORD,
+} = process.env;
+
+if (!PRIVATE_STATE_PASSWORD || PRIVATE_STATE_PASSWORD.length < 16) {
+  throw new Error('PRIVATE_STATE_PASSWORD must be at least 16 characters');
+}
+
+// 3. Build each provider individually so they can be reused or replaced.
+
+/** Retrieves ZK circuit artifacts (WASM, keys) from a remote URL. */
+const zkConfigProvider = new FetchZkConfigProvider(ZK_CONFIG_BASE_URL);
+
+/**
+ * Stores and retrieves private state encrypted on the local filesystem.
+ * AES-256-GCM with PBKDF2-SHA256 (600 000 iterations).
+ */
+const privateStateProvider = levelPrivateStateProvider({
+  privateStoragePasswordProvider: () => PRIVATE_STATE_PASSWORD,
+  accountId: 'example-account',
+});
+
+/**
+ * Queries the Midnight Indexer for public on-chain data.
+ * Requires both an HTTP endpoint (queries) and a WebSocket endpoint
+ * (subscriptions).
+ */
+const publicDataProvider = indexerPublicDataProvider(
+  INDEXER_HTTP_URL,
+  INDEXER_WS_URL,
+);
+
+/**
+ * Sends circuit inputs to the proof server and receives ZK proofs back.
+ * Pass the same zkConfigProvider so it can fetch the proving key.
+ */
+const proofProvider = httpClientProofProvider(PROOF_SERVER_URL, zkConfigProvider);
+
+// 4. Combine into the providers bag.
+//    walletProvider and midnightProvider come from @midnight-ntwrk/wallet-sdk
+//    and depend on the connected wallet extension — omitted here for brevity.
+const providers = {
+  privateStateProvider,
+  publicDataProvider,
+  zkConfigProvider,
+  proofProvider,
+  // walletProvider,    // from @midnight-ntwrk/wallet-sdk
+  // midnightProvider,  // from @midnight-ntwrk/wallet-sdk
+} satisfies Partial<MidnightProviders<never, never, never, never>>;
+
+console.log('Providers assembled:', Object.keys(providers).join(', '));

--- a/examples/02-deploy-contract.ts
+++ b/examples/02-deploy-contract.ts
@@ -1,0 +1,95 @@
+/**
+ * 02-deploy-contract.ts
+ *
+ * Shows how to deploy a Compact contract and call one of its circuits.
+ *
+ * The example uses a minimal counter contract:
+ *   - initial state: { counter: 0n }
+ *   - circuits: increment() and decrement()
+ *
+ * Run:
+ *   tsx 02-deploy-contract.ts
+ *
+ * Note: Deploying a contract requires a connected wallet. The walletProvider
+ * and midnightProvider stubs below must be replaced with real instances from
+ * @midnight-ntwrk/wallet-sdk before this example will produce a transaction.
+ */
+
+import 'dotenv/config';
+import { deployContract, findDeployedContract } from '@midnight-ntwrk/midnight-js-contracts';
+import { levelPrivateStateProvider } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
+import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
+import { httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client-proof-provider';
+import { FetchZkConfigProvider } from '@midnight-ntwrk/midnight-js-fetch-zk-config-provider';
+import { setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import type { MidnightProviders } from '@midnight-ntwrk/midnight-js-types';
+
+// ---------------------------------------------------------------------------
+// Types emitted by the Compact compiler for a counter.compact contract.
+// In a real project these come from the generated .d.ts file.
+// ---------------------------------------------------------------------------
+interface CounterLedger {
+  counter: bigint;
+}
+
+// Replace with the actual import once you have compiled counter.compact:
+//   import { Contract, witnesses } from './counter/contract/index.cjs';
+declare const Contract: unknown;
+declare const witnesses: unknown;
+
+// ---------------------------------------------------------------------------
+// Setup (same as 01-providers.ts)
+// ---------------------------------------------------------------------------
+setNetworkId('testnet');
+
+const {
+  INDEXER_HTTP_URL = 'https://indexer.midnight.network/api/v1/graphql',
+  INDEXER_WS_URL = 'wss://indexer.midnight.network/api/v1/graphql',
+  PROOF_SERVER_URL = 'https://proof.midnight.network',
+  ZK_CONFIG_BASE_URL = 'https://artifacts.midnight.network',
+  PRIVATE_STATE_PASSWORD = 'example-password-replace-me',
+} = process.env;
+
+const zkConfigProvider = new FetchZkConfigProvider(ZK_CONFIG_BASE_URL);
+
+const providers: MidnightProviders<CounterLedger, never, never, never> = {
+  privateStateProvider: levelPrivateStateProvider({
+    privateStoragePasswordProvider: () => PRIVATE_STATE_PASSWORD,
+    accountId: 'example-account',
+  }),
+  publicDataProvider: indexerPublicDataProvider(INDEXER_HTTP_URL, INDEXER_WS_URL),
+  zkConfigProvider,
+  proofProvider: httpClientProofProvider(PROOF_SERVER_URL, zkConfigProvider),
+  walletProvider: null as never,    // replace with real wallet provider
+  midnightProvider: null as never,  // replace with real midnight provider
+};
+
+// ---------------------------------------------------------------------------
+// Deploy
+// ---------------------------------------------------------------------------
+async function main() {
+  console.log('Deploying counter contract...');
+
+  const deployed = await deployContract(providers, {
+    // The JS module produced by `compactc counter.compact`
+    contract: Contract as never,
+    witnesses: witnesses as never,
+    privateStateId: 'counter-state',
+    initialPrivateState: {},
+  });
+
+  console.log('Contract deployed at address:', deployed.deployTxData.public.contractAddress);
+
+  // ---------------------------------------------------------------------------
+  // Call a circuit
+  // ---------------------------------------------------------------------------
+  console.log('Calling increment()...');
+  const txData = await deployed.callTx.increment();
+  console.log('Transaction hash:', txData.public.txHash);
+
+  // Read the updated on-chain ledger state
+  const ledger = await deployed.queryContractState('counter');
+  console.log('Counter value after increment:', (ledger as CounterLedger).counter);
+}
+
+main().catch(console.error);

--- a/examples/03-find-contract.ts
+++ b/examples/03-find-contract.ts
@@ -1,0 +1,70 @@
+/**
+ * 03-find-contract.ts
+ *
+ * Shows how to locate and interact with a contract that was already
+ * deployed in a previous session, using only its on-chain address.
+ *
+ * Run:
+ *   CONTRACT_ADDRESS=<address> tsx 03-find-contract.ts
+ */
+
+import 'dotenv/config';
+import { findDeployedContract } from '@midnight-ntwrk/midnight-js-contracts';
+import { levelPrivateStateProvider } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
+import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
+import { httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client-proof-provider';
+import { FetchZkConfigProvider } from '@midnight-ntwrk/midnight-js-fetch-zk-config-provider';
+import { setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import type { MidnightProviders } from '@midnight-ntwrk/midnight-js-types';
+
+// See 02-deploy-contract.ts for the full type definitions.
+interface CounterLedger { counter: bigint }
+declare const Contract: unknown;
+declare const witnesses: unknown;
+
+setNetworkId('testnet');
+
+const {
+  INDEXER_HTTP_URL = 'https://indexer.midnight.network/api/v1/graphql',
+  INDEXER_WS_URL = 'wss://indexer.midnight.network/api/v1/graphql',
+  PROOF_SERVER_URL = 'https://proof.midnight.network',
+  ZK_CONFIG_BASE_URL = 'https://artifacts.midnight.network',
+  PRIVATE_STATE_PASSWORD = 'example-password-replace-me',
+  CONTRACT_ADDRESS,
+} = process.env;
+
+if (!CONTRACT_ADDRESS) {
+  console.error('Usage: CONTRACT_ADDRESS=<address> tsx 03-find-contract.ts');
+  process.exit(1);
+}
+
+const zkConfigProvider = new FetchZkConfigProvider(ZK_CONFIG_BASE_URL);
+
+const providers: MidnightProviders<CounterLedger, never, never, never> = {
+  privateStateProvider: levelPrivateStateProvider({
+    privateStoragePasswordProvider: () => PRIVATE_STATE_PASSWORD,
+    accountId: 'example-account',
+  }),
+  publicDataProvider: indexerPublicDataProvider(INDEXER_HTTP_URL, INDEXER_WS_URL),
+  zkConfigProvider,
+  proofProvider: httpClientProofProvider(PROOF_SERVER_URL, zkConfigProvider),
+  walletProvider: null as never,
+  midnightProvider: null as never,
+};
+
+async function main() {
+  console.log('Looking up contract at:', CONTRACT_ADDRESS);
+
+  const contract = await findDeployedContract(providers, {
+    contractAddress: CONTRACT_ADDRESS,
+    contract: Contract as never,
+    witnesses: witnesses as never,
+    privateStateId: 'counter-state',
+    initialPrivateState: {},
+  });
+
+  const ledger = await contract.queryContractState('counter');
+  console.log('Current counter value:', (ledger as CounterLedger).counter);
+}
+
+main().catch(console.error);

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,33 @@
+# Midnight.js Examples
+
+Standalone TypeScript snippets showing common patterns with the SDK.
+Each file is self-contained and can be run directly with `tsx`.
+
+## Prerequisites
+
+```bash
+# Node.js >= 22
+node -v
+
+# Install tsx globally (or use npx)
+npm install -g tsx
+
+# Copy and configure the environment file
+cp ../.env.example ../.env
+# Edit ../.env with your endpoints and password
+```
+
+## Examples
+
+| File | What it shows |
+| ---- | ------------- |
+| [`01-providers.ts`](./01-providers.ts) | Assemble the full `MidnightProviders` object |
+| [`02-deploy-contract.ts`](./02-deploy-contract.ts) | Deploy a Compact contract and call a circuit |
+| [`03-find-contract.ts`](./03-find-contract.ts) | Find and re-join an already-deployed contract |
+
+## Running an example
+
+```bash
+cd examples
+tsx 01-providers.ts
+```


### PR DESCRIPTION
## Summary

Closes #861

Addresses the two concrete gaps still remaining after the README was fleshed out:

### `.env.example`

Documents every environment variable the SDK and testkit Docker setup accept:

- `COMPACTC_VERSION` / `COMPACT_TAG_PREFIX` / `COMPACT_REPO` (compiler)
- `TESTKIT_DOCKER_ENV` (integration test target network)
- `INDEXER_HTTP_URL` / `INDEXER_WS_URL` (public data provider)
- `PROOF_SERVER_URL` (proof provider)
- `ZK_CONFIG_BASE_URL` (ZK artifact retrieval)
- `PRIVATE_STATE_PASSWORD` (private state encryption)

### `examples/`

Three annotated, runnable TypeScript snippets (runnable with `tsx`):

| File | What it shows |
|---|---|
| `01-providers.ts` | Assemble the full `MidnightProviders` object |
| `02-deploy-contract.ts` | Deploy a Compact contract and call a circuit |
| `03-find-contract.ts` | Locate and re-join an already-deployed contract by address |

Each example reads configuration from `.env` (via `dotenv/config`) and includes inline comments explaining every step.