### PR TITLE
feat: indexer schema - enhance contract event types and add dust generation support

### DIFF
--- a/packages/indexer-public-data-provider/schema.graphql
+++ b/packages/indexer-public-data-provider/schema.graphql
@@ -1,116 +1,178 @@
 """
+Tagged-union helper for fields like `Either<ZswapCoinPublicKey, ContractAddress>`
+used in standard unshielded events.
+
+Exactly one of `userAddress` or `contractAddress` is non-null; the `kind`
+discriminator says which.
+"""
+type AddressOrContract {
+	kind: AddressOrContractKind!
+	"""
+	Bech32m-encoded user address; populated when kind = USER.
+	Hex-encoded here at the wire level; clients re-encode if needed.
+	"""
+	userAddress: HexEncoded
+	"""
+	Hex-encoded contract address; populated when kind = CONTRACT.
+	"""
+	contractAddress: HexEncoded
+}
+
+enum AddressOrContractKind {
+	USER
+	CONTRACT
+}
+
+"""
 A block with its relevant data.
 """
 type Block {
-  """
-  The block hash.
-  """
-  hash: HexEncoded!
-  """
-  The block height.
-  """
-  height: Int!
-  """
-  The protocol version.
-  """
-  protocolVersion: Int!
-  """
-  The UNIX timestamp.
-  """
-  timestamp: Int!
-  """
-  The hex-encoded block author.
-  """
-  author: HexEncoded
-  """
-  The hex-encoded ledger parameters for this block.
-  """
-  ledgerParameters: HexEncoded!
-  """
-  The parent of this block.
-  """
-  parent: Block
-  """
-  The transactions within this block.
-  """
-  transactions: [Transaction!]!
-  """
-  The system parameters (governance) at this block height.
-  """
-  systemParameters: SystemParameters!
+	"""
+	The block hash.
+	"""
+	hash: HexEncoded!
+	"""
+	The block height.
+	"""
+	height: Int!
+	"""
+	The protocol version.
+	"""
+	protocolVersion: Int!
+	"""
+	The UNIX timestamp.
+	"""
+	timestamp: Int!
+	"""
+	The hex-encoded block author.
+	"""
+	author: HexEncoded
+	"""
+	The hex-encoded serialized zswap state Merkle tree root.
+	"""
+	zswapMerkleTreeRoot: HexEncoded!
+	"""
+	The hex-encoded ledger parameters for this block.
+	"""
+	ledgerParameters: HexEncoded!
+	"""
+	The zswap commitment tree end index at this block; exclusive, i.e. the next free index.
+	"""
+	zswapEndIndex: Int!
+	"""
+	The dust commitment tree end index at this block; exclusive, i.e. the next free index.
+	"""
+	dustCommitmentEndIndex: Int! @beta
+	"""
+	The dust generation tree end index at this block; exclusive, i.e. the next free index.
+	"""
+	dustGenerationEndIndex: Int! @beta
+	"""
+	The parent of this block.
+	"""
+	parent: Block
+	"""
+	The transactions within this block.
+	"""
+	transactions: [Transaction!]!
+	"""
+	The system parameters (governance) at this block height.
+	"""
+	systemParameters: SystemParameters!
+	"""
+	The hex-encoded dust commitment Merkle tree root at the latest indexed state.
+	"""
+	dustCommitmentMerkleTreeRoot: HexEncoded
+	"""
+	The hex-encoded dust generation Merkle tree root at the latest indexed state.
+	"""
+	dustGenerationMerkleTreeRoot: HexEncoded
 }
 
 """
 Either a block hash or a block height.
 """
 input BlockOffset @oneOf {
-  """
-  A hex-encoded block hash.
-  """
-  hash: HexEncoded
-  """
-  A block height.
-  """
-  height: Int
+	"""
+	A hex-encoded block hash.
+	"""
+	hash: HexEncoded
+	"""
+	A block height.
+	"""
+	height: Int
 }
 
 scalar CardanoRewardAddress
 
+"""
+A Merkle tree collapsed update between two indices.
+"""
 type CollapsedMerkleTree {
-  """
-  The zswap state start index.
-  """
-  startIndex: Int!
-  """
-  The zswap state end index.
-  """
-  endIndex: Int!
-  """
-  The hex-encoded value.
-  """
-  update: HexEncoded!
-  """
-  The protocol version.
-  """
-  protocolVersion: Int!
+	"""
+	The start index.
+	"""
+	startIndex: Int!
+	"""
+	The end index.
+	"""
+	endIndex: Int!
+	"""
+	The hex-encoded value.
+	"""
+	update: HexEncoded!
+	"""
+	The protocol version.
+	"""
+	protocolVersion: Int!
 }
 
 """
 Committee member for an epoch.
 """
 type CommitteeMember {
-  epochNo: Int!
-  position: Int!
-  sidechainPubkeyHex: String!
-  expectedSlots: Int!
-  auraPubkeyHex: String
-  poolIdHex: String
-  spoSkHex: String
+	epochNo: Int!
+	position: Int!
+	sidechainPubkeyHex: String!
+	expectedSlots: Int!
+	auraPubkeyHex: String
+	poolIdHex: String
+	spoSkHex: String
+}
+
+"""
+Options for the connect mutation.
+"""
+input ConnectOptions {
+	"""
+	Transaction index to start searching for relevant transactions (inclusive).
+	"""
+	startIndex: Int
 }
 
 """
 A contract action.
 """
 interface ContractAction {
-  address: HexEncoded!
-  state: HexEncoded!
-  zswapState: HexEncoded!
-  transaction: Transaction!
-  unshieldedBalances: [ContractBalance!]!
+	address: HexEncoded!
+	state: HexEncoded!
+	zswapState: HexEncoded!
+	transaction: Transaction!
+	unshieldedBalances: [ContractBalance!]!
 }
 
 """
 Either a block offset or a transaction offset.
 """
 input ContractActionOffset @oneOf {
-  """
-  Either a block hash or a block height.
-  """
-  blockOffset: BlockOffset
-  """
-  Either a transaction hash or a transaction identifier.
-  """
-  transactionOffset: TransactionOffset
+	"""
+	Either a block hash or a block height.
+	"""
+	blockOffset: BlockOffset
+	"""
+	Either a transaction hash or a transaction identifier.
+	"""
+	transactionOffset: TransactionOffset
 }
 
 """
@@ -119,562 +181,957 @@ This type is exposed through the GraphQL API to allow clients to query
 unshielded token balances for any contract action (Deploy, Call, Update).
 """
 type ContractBalance {
-  """
-  Hex-encoded token type identifier.
-  """
-  tokenType: HexEncoded!
-  """
-  Balance amount as string to support larger integer values (up to 16 bytes).
-  """
-  amount: String!
+	"""
+	Hex-encoded token type identifier.
+	"""
+	tokenType: HexEncoded!
+	"""
+	Balance amount as string to support larger integer values (up to 16 bytes).
+	"""
+	amount: String!
 }
 
 """
 A contract call.
 """
 type ContractCall implements ContractAction {
-  """
-  The hex-encoded serialized address.
-  """
-  address: HexEncoded!
-  """
-  The hex-encoded serialized state.
-  """
-  state: HexEncoded!
-  """
-  The hex-encoded serialized contract-specific zswap state.
-  """
-  zswapState: HexEncoded!
-  """
-  The entry point.
-  """
-  entryPoint: String!
-  """
-  Transaction for this contract call.
-  """
-  transaction: Transaction!
-  """
-  Contract deploy for this contract call.
-  """
-  deploy: ContractDeploy!
-  """
-  Unshielded token balances held by this contract.
-  """
-  unshieldedBalances: [ContractBalance!]!
+	"""
+	The hex-encoded serialized address.
+	"""
+	address: HexEncoded!
+	"""
+	The hex-encoded serialized state.
+	"""
+	state: HexEncoded!
+	"""
+	The hex-encoded serialized contract-specific zswap state.
+	"""
+	zswapState: HexEncoded!
+	"""
+	The entry point.
+	"""
+	entryPoint: String!
+	"""
+	Transaction for this contract call.
+	"""
+	transaction: Transaction!
+	"""
+	Contract deploy for this contract call.
+	"""
+	deploy: ContractDeploy!
+	"""
+	Unshielded token balances held by this contract.
+	"""
+	unshieldedBalances: [ContractBalance!]!
+	"""
+	Contract events emitted by this contract call.
+	
+	Only `ContractCall` exposes this field — `ContractDeploy` and
+	`ContractUpdate` don't execute circuits with the `log()` expression.
+	Per Andrzej's 12 May design call (#feat-public-events).
+	
+	Returns an empty list until the chain-indexer populates the
+	`ledger_events.contract_action_id` column from the v9 parse path
+	(gated on ticket #1157).
+	"""
+	contractEvents: [ContractEvent!]!
 }
 
 """
 A contract deployment.
 """
 type ContractDeploy implements ContractAction {
-  """
-  The hex-encoded serialized address.
-  """
-  address: HexEncoded!
-  """
-  The hex-encoded serialized state.
-  """
-  state: HexEncoded!
-  """
-  The hex-encoded serialized contract-specific zswap state.
-  """
-  zswapState: HexEncoded!
-  """
-  Transaction for this contract deploy.
-  """
-  transaction: Transaction!
-  """
-  Unshielded token balances held by this contract.
-  """
-  unshieldedBalances: [ContractBalance!]!
+	"""
+	The hex-encoded serialized address.
+	"""
+	address: HexEncoded!
+	"""
+	The hex-encoded serialized state.
+	"""
+	state: HexEncoded!
+	"""
+	The hex-encoded serialized contract-specific zswap state.
+	"""
+	zswapState: HexEncoded!
+	"""
+	Transaction for this contract deploy.
+	"""
+	transaction: Transaction!
+	"""
+	Unshielded token balances held by this contract.
+	"""
+	unshieldedBalances: [ContractBalance!]!
+}
+
+"""
+Common interface implemented by every concrete contract event type.
+"""
+interface ContractEvent {
+	id: Int!
+	raw: HexEncoded!
+	maxId: Int!
+	protocolVersion: Int!
+	version: Int!
+	contractAddress: HexEncoded!
+	transactionId: Int!
+}
+
+"""
+Filter for contract events queries and subscriptions. Block-range bounds
+live here so the same shape works for both (per Andrzej 21 May review).
+"""
+input ContractEventFilter {
+	"""
+	Required: the contract address to filter events for.
+	"""
+	contractAddress: HexEncoded!
+	"""
+	Optional: filter to a subset of contract event types. Indexer translates
+	to `variant = ANY(...)` against the indexed variant column.
+	"""
+	types: [ContractEventType!]
+	"""
+	Optional: prefix-match on indexed fields of the event. Standard events only.
+	"""
+	fieldPrefixes: [FieldPrefixFilter!]
+	"""
+	Optional: lower bound on the block height an event was emitted in. On
+	subscription, acts as a starting cursor (alternative to `id`).
+	"""
+	fromBlock: Int
+	"""
+	Optional: upper bound on the block height an event was emitted in. On
+	subscription, terminates the stream once the chain reaches this block.
+	"""
+	toBlock: Int
+}
+
+"""
+Closed enum of contract event types the indexer surfaces. Used in filter
+input only, response discrimination is via `__typename`. Mirrors the
+11 variants of `LogEventType` (onchain-vm/src/ops.rs, ledger-9 alpha).
+"""
+enum ContractEventType {
+	SHIELDED_SPEND
+	SHIELDED_RECEIVE
+	SHIELDED_MINT
+	SHIELDED_BURN
+	UNSHIELDED_SPEND
+	UNSHIELDED_RECEIVE
+	UNSHIELDED_MINT
+	UNSHIELDED_BURN
+	PAUSED
+	UNPAUSED
+	MISC
 }
 
 """
 A contract update.
 """
 type ContractUpdate implements ContractAction {
-  """
-  The hex-encoded serialized address.
-  """
-  address: HexEncoded!
-  """
-  The hex-encoded serialized state.
-  """
-  state: HexEncoded!
-  """
-  The hex-encoded serialized contract-specific zswap state.
-  """
-  zswapState: HexEncoded!
-  """
-  Transaction for this contract update.
-  """
-  transaction: Transaction!
-  """
-  Unshielded token balances held by this contract after the update.
-  """
-  unshieldedBalances: [ContractBalance!]!
+	"""
+	The hex-encoded serialized address.
+	"""
+	address: HexEncoded!
+	"""
+	The hex-encoded serialized state.
+	"""
+	state: HexEncoded!
+	"""
+	The hex-encoded serialized contract-specific zswap state.
+	"""
+	zswapState: HexEncoded!
+	"""
+	Transaction for this contract update.
+	"""
+	transaction: Transaction!
+	"""
+	Unshielded token balances held by this contract after the update.
+	"""
+	unshieldedBalances: [ContractBalance!]!
 }
 
 """
 The D-parameter controlling validator committee composition.
 """
 type DParameter {
-  """
-  Number of permissioned candidates.
-  """
-  numPermissionedCandidates: Int!
-  """
-  Number of registered candidates.
-  """
-  numRegisteredCandidates: Int!
+	"""
+	Number of permissioned candidates.
+	"""
+	numPermissionedCandidates: Int!
+	"""
+	Number of registered candidates.
+	"""
+	numRegisteredCandidates: Int!
 }
 
 """
 D-parameter change record for history queries.
 """
 type DParameterChange {
-  """
-  The block height where this parameter became effective.
-  """
-  blockHeight: Int!
-  """
-  The hex-encoded block hash where this parameter became effective.
-  """
-  blockHash: HexEncoded!
-  """
-  The UNIX timestamp when this parameter became effective.
-  """
-  timestamp: Int!
-  """
-  Number of permissioned candidates.
-  """
-  numPermissionedCandidates: Int!
-  """
-  Number of registered candidates.
-  """
-  numRegisteredCandidates: Int!
+	"""
+	The block height where this parameter became effective.
+	"""
+	blockHeight: Int!
+	"""
+	The hex-encoded block hash where this parameter became effective.
+	"""
+	blockHash: HexEncoded!
+	"""
+	The UNIX timestamp when this parameter became effective.
+	"""
+	timestamp: Int!
+	"""
+	Number of permissioned candidates.
+	"""
+	numPermissionedCandidates: Int!
+	"""
+	Number of registered candidates.
+	"""
+	numRegisteredCandidates: Int!
 }
 
 scalar DustAddress
 
 type DustGenerationDtimeUpdate implements DustLedgerEvent {
-  """
-  The ID of this dust ledger event.
-  """
-  id: Int!
-  """
-  The hex-encoded serialized event.
-  """
-  raw: HexEncoded!
-  """
-  The maximum ID of all dust ledger events.
-  """
-  maxId: Int!
-  """
-  The protocol version.
-  """
-  protocolVersion: Int!
+	"""
+	The ID of this dust ledger event.
+	"""
+	id: Int!
+	"""
+	The hex-encoded serialized event.
+	"""
+	raw: HexEncoded!
+	"""
+	The maximum ID of all dust ledger events.
+	"""
+	maxId: Int!
+	"""
+	The protocol version.
+	"""
+	protocolVersion: Int!
+}
+
+"""
+A dust generation dtime update emitted when the backing Night UTXO is
+spent and the entry's decay time is set.
+"""
+type DustGenerationDtimeUpdateItem @beta {
+	"""
+	Generation-tree index of the entry whose dtime changed.
+	"""
+	generationMtIndex: Int!
+	"""
+	The hex-encoded owner (dust address).
+	"""
+	owner: HexEncoded!
+	"""
+	Hex-encoded hash of the NIGHT UTXO that backs this dust output.
+	"""
+	nightUtxoHash: HexEncoded!
+	"""
+	The decay time as observed in this ledger event.
+	"""
+	newDtime: Int!
+	"""
+	The originating transaction ID (indexer-internal BIGSERIAL).
+	"""
+	transactionId: Int!
+	"""
+	The hex-encoded originating transaction hash (32-byte chain identifier).
+	"""
+	transactionHash: HexEncoded!
+	"""
+	Hex-encoded tagged-serialised `TreeInsertionPath<DustGenerationInfo>`
+	from the originating ledger event. Wallets deserialise this and hand
+	it to `generating_tree.update_from_evidence(...)`.
+	"""
+	treeInsertionPath: HexEncoded!
 }
 
 """
 DUST generation status for a specific Cardano reward address.
 """
 type DustGenerationStatus {
-  """
-  The Bech32-encoded Cardano reward address (e.g., stake_test1... or stake1...).
-  """
-  cardanoRewardAddress: CardanoRewardAddress!
-  """
-  The Bech32m-encoded associated DUST address if registered.
-  """
-  dustAddress: DustAddress
-  """
-  Whether this reward address is registered.
-  """
-  registered: Boolean!
-  """
-  NIGHT balance backing generation in STAR.
-  """
-  nightBalance: String!
-  """
-  DUST generation rate in SPECK per second.
-  """
-  generationRate: String!
-  """
-  Maximum DUST capacity in SPECK.
-  """
-  maxCapacity: String!
-  """
-  Current generated DUST capacity in SPECK.
-  """
-  currentCapacity: String!
-  """
-  Cardano UTXO transaction hash for update/unregister operations.
-  """
-  utxoTxHash: HexEncoded
-  """
-  Cardano UTXO output index for update/unregister operations.
-  """
-  utxoOutputIndex: Int
+	"""
+	The Bech32-encoded Cardano reward address (e.g., stake_test1... or stake1...).
+	"""
+	cardanoRewardAddress: CardanoRewardAddress!
+	"""
+	The Bech32m-encoded associated DUST address if registered.
+	"""
+	dustAddress: DustAddress
+	"""
+	Whether this reward address is registered.
+	"""
+	registered: Boolean!
+	"""
+	NIGHT balance backing generation in STAR.
+	"""
+	nightBalance: String!
+	"""
+	DUST generation rate in SPECK per second.
+	"""
+	generationRate: String!
+	"""
+	Maximum DUST capacity in SPECK.
+	"""
+	maxCapacity: String!
+	"""
+	Current generated DUST capacity in SPECK.
+	"""
+	currentCapacity: String!
+	"""
+	Cardano UTXO transaction hash for update/unregister operations.
+	"""
+	utxoTxHash: HexEncoded
+	"""
+	Cardano UTXO output index for update/unregister operations.
+	"""
+	utxoOutputIndex: Int
+}
+
+"""
+Dust generations for a Cardano reward address.
+"""
+type DustGenerations {
+	"""
+	The Bech32-encoded Cardano reward address.
+	"""
+	cardanoRewardAddress: CardanoRewardAddress!
+	"""
+	All active registrations with aggregated generation stats.
+	"""
+	registrations: [DustRegistration!]!
+}
+
+"""
+An event of the dust generations subscription.
+"""
+union DustGenerationsEvent = DustGenerationsItem | DustGenerationsProgress | DustGenerationDtimeUpdateItem
+
+"""
+A dust generations item with optional collapsed Merkle tree update.
+"""
+type DustGenerationsItem @beta {
+	"""
+	Index of this output in the dust commitment Merkle tree.
+	"""
+	commitmentMtIndex: Int!
+	"""
+	Index of this output in the dust generation Merkle tree.
+	"""
+	generationMtIndex: Int!
+	"""
+	The hex-encoded owner (dust address).
+	"""
+	owner: HexEncoded!
+	"""
+	The NIGHT value backing this output, in STAR.
+	"""
+	value: String!
+	"""
+	The DUST value at creation, in SPECK.
+	"""
+	initialValue: String!
+	"""
+	Hex-encoded hash of the NIGHT UTXO that backs this dust output.
+	"""
+	backingNight: HexEncoded!
+	"""
+	The creation timestamp.
+	"""
+	ctime: Int!
+	"""
+	The originating transaction ID (indexer-internal BIGSERIAL).
+	"""
+	transactionId: Int!
+	"""
+	The hex-encoded originating transaction hash (32-byte chain identifier).
+	"""
+	transactionHash: HexEncoded!
+	"""
+	Collapsed Merkle tree update filling the gap before this entry.
+	"""
+	collapsedMerkleTree: MerkleTreeCollapsedUpdate
+}
+
+"""
+Progress indicator for dust generations subscription (includes final collapsed update).
+"""
+type DustGenerationsProgress @beta {
+	"""
+	The highest index processed so far.
+	"""
+	highestIndex: Int!
+	"""
+	Final collapsed Merkle tree update covering remaining range.
+	"""
+	collapsedMerkleTree: MerkleTreeCollapsedUpdate
 }
 
 type DustInitialUtxo implements DustLedgerEvent {
-  """
-  The ID of this dust ledger event.
-  """
-  id: Int!
-  """
-  The hex-encoded serialized event.
-  """
-  raw: HexEncoded!
-  """
-  The maximum ID of all dust ledger events.
-  """
-  maxId: Int!
-  """
-  The protocol version.
-  """
-  protocolVersion: Int!
-  """
-  The dust output.
-  """
-  output: DustOutput!
+	"""
+	The ID of this dust ledger event.
+	"""
+	id: Int!
+	"""
+	The hex-encoded serialized event.
+	"""
+	raw: HexEncoded!
+	"""
+	The maximum ID of all dust ledger events.
+	"""
+	maxId: Int!
+	"""
+	The protocol version.
+	"""
+	protocolVersion: Int!
+	"""
+	The dust output.
+	"""
+	output: DustOutput!
 }
 
 """
 A dust related ledger event.
 """
 interface DustLedgerEvent {
-  id: Int!
-  raw: HexEncoded!
-  maxId: Int!
-  protocolVersion: Int!
+	id: Int!
+	raw: HexEncoded!
+	maxId: Int!
+	protocolVersion: Int!
+}
+
+"""
+A transaction containing a dust nullifier match with block context.
+"""
+type DustNullifierTransaction {
+	"""
+	The hex-encoded matched nullifier, in 32-byte little-endian form.
+	"""
+	nullifierLeBytes: HexEncoded! @beta
+	"""
+	The hex-encoded commitment, in 32-byte little-endian form.
+	"""
+	commitmentLeBytes: HexEncoded! @beta
+	"""
+	The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor).
+	"""
+	transactionId: Int!
+	"""
+	The hex-encoded transaction hash (32-byte chain identifier).
+	"""
+	transactionHash: HexEncoded!
+	"""
+	The block height containing this transaction.
+	"""
+	blockHeight: Int!
+	"""
+	The hex-encoded block hash (use to query block with ledger parameters).
+	"""
+	blockHash: HexEncoded!
+	"""
+	The transaction containing this nullifier match.
+	"""
+	transaction: Transaction! @beta
 }
 
 """
 A dust output.
 """
 type DustOutput {
-  """
-  The hex-encoded 32-byte nonce.
-  """
-  nonce: HexEncoded!
+	"""
+	The hex-encoded 32-byte nonce.
+	"""
+	nonce: HexEncoded!
+}
+
+"""
+A single dust registration with aggregated generation stats.
+"""
+type DustRegistration {
+	"""
+	The Bech32m-encoded DUST address.
+	"""
+	dustAddress: DustAddress!
+	"""
+	Whether this registration is valid.
+	"""
+	valid: Boolean!
+	"""
+	NIGHT balance backing generation in STAR.
+	"""
+	nightBalance: String!
+	"""
+	DUST generation rate in SPECK per second.
+	"""
+	generationRate: String!
+	"""
+	Maximum DUST capacity in SPECK.
+	"""
+	maxCapacity: String!
+	"""
+	Current generated DUST capacity in SPECK.
+	"""
+	currentCapacity: String!
+	"""
+	Cardano UTXO transaction hash.
+	"""
+	utxoTxHash: HexEncoded
+	"""
+	Cardano UTXO output index.
+	"""
+	utxoOutputIndex: Int
 }
 
 type DustSpendProcessed implements DustLedgerEvent {
-  """
-  The ID of this dust ledger event.
-  """
-  id: Int!
-  """
-  The hex-encoded serialized event.
-  """
-  raw: HexEncoded!
-  """
-  The maximum ID of all dust ledger events.
-  """
-  maxId: Int!
-  """
-  The protocol version.
-  """
-  protocolVersion: Int!
+	"""
+	The ID of this dust ledger event.
+	"""
+	id: Int!
+	"""
+	The hex-encoded serialized event.
+	"""
+	raw: HexEncoded!
+	"""
+	The maximum ID of all dust ledger events.
+	"""
+	maxId: Int!
+	"""
+	The protocol version.
+	"""
+	protocolVersion: Int!
 }
 
 """
 Current epoch information.
 """
 type EpochInfo {
-  epochNo: Int!
-  durationSeconds: Int!
-  elapsedSeconds: Int!
+	epochNo: Int!
+	durationSeconds: Int!
+	elapsedSeconds: Int!
 }
 
 """
 SPO performance for an epoch.
 """
 type EpochPerf {
-  epochNo: Int!
-  spoSkHex: String!
-  produced: Int!
-  expected: Int!
-  identityLabel: String
-  stakeSnapshot: String
-  poolIdHex: String
-  validatorClass: String
+	epochNo: Int!
+	spoSkHex: String!
+	produced: Int!
+	expected: Int!
+	identityLabel: String
+	stakeSnapshot: String
+	poolIdHex: String
+	validatorClass: String
+}
+
+"""
+Prefix filter on an indexed field of a standard event. Indexer resolves
+`fieldName` for all standard events from the variant; no descriptor needed.
+Not supported on Misc events.
+"""
+input FieldPrefixFilter {
+	"""
+	Field name (e.g. `nullifier`, `commitment`, `sender`). Must match an
+	indexed field of the filtered event type.
+	"""
+	fieldName: String!
+	"""
+	Hex-encoded prefix bytes. Empty string matches all values; otherwise
+	the indexer returns events whose field value starts with this prefix,
+	client filters to exact match if needed.
+	"""
+	prefix: HexEncoded!
 }
 
 """
 First valid epoch for an SPO identity.
 """
 type FirstValidEpoch {
-  idKey: String!
-  firstValidEpoch: Int!
+	idKey: String!
+	firstValidEpoch: Int!
 }
 
 scalar HexEncoded
 
+"""
+A Merkle tree collapsed update between two indices.
+"""
+type MerkleTreeCollapsedUpdate {
+	"""
+	The start index.
+	"""
+	startIndex: Int!
+	"""
+	The end index.
+	"""
+	endIndex: Int!
+	"""
+	The hex-encoded value.
+	"""
+	update: HexEncoded!
+	"""
+	The protocol version.
+	"""
+	protocolVersion: Int!
+}
+
+type MiscContractEvent implements ContractEvent {
+	id: Int!
+	raw: HexEncoded!
+	maxId: Int!
+	protocolVersion: Int!
+	version: Int!
+	contractAddress: HexEncoded!
+	transactionId: Int!
+	"""
+	Hex-encoded contract-defined event name (Compact Bytes<32>).
+	"""
+	name: HexEncoded!
+	"""
+	Hex-encoded opaque payload (Compact Bytes<256>); consumer brings
+	descriptor to decode.
+	"""
+	payload: HexEncoded!
+}
+
 type Mutation {
-  """
-  Connect the wallet with the given viewing key and return a session ID.
-  """
-  connect(viewingKey: ViewingKey!): HexEncoded!
-  """
-  Disconnect the wallet with the given session ID.
-  """
-  disconnect(sessionId: HexEncoded!): Unit!
+	"""
+	Connect the wallet with the given viewing key and return a session ID.
+	"""
+	connect(viewingKey: ViewingKey!, options: ConnectOptions): HexEncoded!
+	"""
+	Disconnect the wallet with the given session ID.
+	"""
+	disconnect(sessionId: HexEncoded!): Unit!
 }
 
 type ParamChange implements DustLedgerEvent {
-  """
-  The ID of this dust ledger event.
-  """
-  id: Int!
-  """
-  The hex-encoded serialized event.
-  """
-  raw: HexEncoded!
-  """
-  The maximum ID of all dust ledger events.
-  """
-  maxId: Int!
-  """
-  The protocol version.
-  """
-  protocolVersion: Int!
+	"""
+	The ID of this dust ledger event.
+	"""
+	id: Int!
+	"""
+	The hex-encoded serialized event.
+	"""
+	raw: HexEncoded!
+	"""
+	The maximum ID of all dust ledger events.
+	"""
+	maxId: Int!
+	"""
+	The protocol version.
+	"""
+	protocolVersion: Int!
+}
+
+type PausedEvent implements ContractEvent {
+	id: Int!
+	raw: HexEncoded!
+	maxId: Int!
+	protocolVersion: Int!
+	version: Int!
+	contractAddress: HexEncoded!
+	transactionId: Int!
 }
 
 """
 Pool metadata from Cardano.
 """
 type PoolMetadata {
-  poolIdHex: String!
-  hexId: String
-  name: String
-  ticker: String
-  homepageUrl: String
-  logoUrl: String
+	poolIdHex: String!
+	hexId: String
+	name: String
+	ticker: String
+	homepageUrl: String
+	logoUrl: String
 }
 
 """
 Presence event for an SPO in an epoch.
 """
 type PresenceEvent {
-  epochNo: Int!
-  idKey: String!
-  source: String!
-  status: String
+	epochNo: Int!
+	idKey: String!
+	source: String!
+	status: String
 }
 
 type Query {
-  """
-  Find a block for the given optional offset; if not present, the latest block is returned.
-  """
-  block(offset: BlockOffset): Block
-  """
-  Find transactions for the given offset.
-  """
-  transactions(offset: TransactionOffset!): [Transaction!]!
-  """
-  Find a contract action for the given address and optional offset.
-  """
-  contractAction(address: HexEncoded!, offset: ContractActionOffset): ContractAction
-  """
-  Get DUST generation status for specific Cardano reward addresses.
-  """
-  dustGenerationStatus(cardanoRewardAddresses: [CardanoRewardAddress!]!): [DustGenerationStatus!]!
-  """
-  Get the full history of D-parameter changes for governance auditability.
-  """
-  dParameterHistory: [DParameterChange!]!
-  """
-  Get the full history of Terms and Conditions changes for governance auditability.
-  """
-  termsAndConditionsHistory: [TermsAndConditionsChange!]!
-  """
-  List SPO identities with pagination.
-  """
-  spoIdentities(limit: Int, offset: Int): [SpoIdentity!]!
-  """
-  Get SPO identity by pool ID.
-  """
-  spoIdentityByPoolId(poolIdHex: String!): SpoIdentity
-  """
-  Get total count of SPOs.
-  """
-  spoCount: Int
-  """
-  Get pool metadata by pool ID.
-  """
-  poolMetadata(poolIdHex: String!): PoolMetadata
-  """
-  List pool metadata with pagination.
-  """
-  poolMetadataList(limit: Int, offset: Int, withNameOnly: Boolean): [PoolMetadata!]!
-  """
-  Get SPO with metadata by pool ID.
-  """
-  spoByPoolId(poolIdHex: String!): Spo
-  """
-  List SPOs with optional search.
-  """
-  spoList(limit: Int, offset: Int, search: String): [Spo!]!
-  """
-  Get composite SPO data (identity + metadata + performance).
-  """
-  spoCompositeByPoolId(poolIdHex: String!): SpoComposite
-  """
-  Get SPO identifiers ordered by performance.
-  """
-  stakePoolOperators(limit: Int): [String!]!
-  """
-  Get latest SPO performance entries.
-  """
-  spoPerformanceLatest(limit: Int, offset: Int): [EpochPerf!]!
-  """
-  Get SPO performance by SPO key.
-  """
-  spoPerformanceBySpoSk(spoSkHex: String!, limit: Int, offset: Int): [EpochPerf!]!
-  """
-  Get epoch performance for all SPOs.
-  """
-  epochPerformance(epoch: Int!, limit: Int, offset: Int): [EpochPerf!]!
-  """
-  Get current epoch information.
-  """
-  currentEpochInfo: EpochInfo
-  """
-  Get epoch utilization (produced/expected ratio).
-  """
-  epochUtilization(epoch: Int!): Float
-  """
-  Get committee membership for an epoch.
-  """
-  committee(epoch: Int!): [CommitteeMember!]!
-  """
-  Get cumulative registration totals for an epoch range.
-  """
-  registeredTotalsSeries(fromEpoch: Int!, toEpoch: Int!): [RegisteredTotals!]!
-  """
-  Get registration statistics for an epoch range.
-  """
-  registeredSpoSeries(fromEpoch: Int!, toEpoch: Int!): [RegisteredStat!]!
-  """
-  Get raw presence events for an epoch range.
-  """
-  registeredPresence(fromEpoch: Int!, toEpoch: Int!): [PresenceEvent!]!
-  """
-  Get first valid epoch for each SPO identity.
-  """
-  registeredFirstValidEpochs(uptoEpoch: Int): [FirstValidEpoch!]!
-  """
-  Get stake distribution with search and ordering.
-  """
-  stakeDistribution(limit: Int, offset: Int, search: String, orderByStakeDesc: Boolean): [StakeShare!]!
+	"""
+	Find a block for the given optional offset; if not present, the latest block is returned.
+	"""
+	block(offset: BlockOffset): Block
+	"""
+	Get a Merkle tree collapsed update for the given zswap state index range.
+	"""
+	zswapMerkleTreeCollapsedUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate!
+	"""
+	Find transactions for the given offset.
+	"""
+	transactions(offset: TransactionOffset!): [Transaction!]!
+	"""
+	Find a contract action for the given address and optional offset.
+	"""
+	contractAction(address: HexEncoded!, offset: ContractActionOffset): ContractAction
+	"""
+	Get DUST generation status for specific Cardano reward addresses.
+	"""
+	dustGenerationStatus(cardanoRewardAddresses: [CardanoRewardAddress!]!): [DustGenerationStatus!]!
+	"""
+	Get all active DUST registrations and aggregated generation stats for Cardano reward
+	addresses.
+	"""
+	dustGenerations(cardanoRewardAddresses: [CardanoRewardAddress!]!): [DustGenerations!]!
+	"""
+	Get a collapsed Merkle tree update for the dust commitment tree.
+	"""
+	dustCommitmentMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate! @beta
+	"""
+	Get a collapsed Merkle tree update for the dust generation tree.
+	"""
+	dustGenerationMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate! @beta
+	"""
+	Find contract events matching the filter, with optional pagination.
+	
+	Block-range bounds (`fromBlock`, `toBlock`) live on `ContractEventFilter`
+	for symmetry with the subscription. `limit`/`offset` are top-level args.
+	"""
+	contractEvents(filter: ContractEventFilter!, limit: Int, offset: Int): [ContractEvent!]!
+	"""
+	Get the full history of D-parameter changes for governance auditability.
+	"""
+	dParameterHistory: [DParameterChange!]!
+	"""
+	Get the full history of Terms and Conditions changes for governance auditability.
+	"""
+	termsAndConditionsHistory: [TermsAndConditionsChange!]!
+	"""
+	List SPO identities with pagination.
+	"""
+	spoIdentities(limit: Int, offset: Int): [SpoIdentity!]!
+	"""
+	Get SPO identity by pool ID.
+	"""
+	spoIdentityByPoolId(poolIdHex: String!): SpoIdentity
+	"""
+	Get total count of SPOs.
+	"""
+	spoCount: Int
+	"""
+	Get pool metadata by pool ID.
+	"""
+	poolMetadata(poolIdHex: String!): PoolMetadata
+	"""
+	List pool metadata with pagination.
+	"""
+	poolMetadataList(limit: Int, offset: Int, withNameOnly: Boolean): [PoolMetadata!]!
+	"""
+	Get SPO with metadata by pool ID.
+	"""
+	spoByPoolId(poolIdHex: String!): Spo
+	"""
+	List SPOs with optional search.
+	"""
+	spoList(limit: Int, offset: Int, search: String): [Spo!]!
+	"""
+	Get composite SPO data (identity + metadata + performance).
+	"""
+	spoCompositeByPoolId(poolIdHex: String!): SpoComposite
+	"""
+	Get SPO identifiers ordered by performance.
+	"""
+	stakePoolOperators(limit: Int): [String!]!
+	"""
+	Get latest SPO performance entries.
+	"""
+	spoPerformanceLatest(limit: Int, offset: Int): [EpochPerf!]!
+	"""
+	Get SPO performance by SPO key.
+	"""
+	spoPerformanceBySpoSk(spoSkHex: String!, limit: Int, offset: Int): [EpochPerf!]!
+	"""
+	Get epoch performance for all SPOs.
+	"""
+	epochPerformance(epoch: Int!, limit: Int, offset: Int): [EpochPerf!]!
+	"""
+	Get current epoch information.
+	"""
+	currentEpochInfo: EpochInfo
+	"""
+	Get epoch utilization (produced/expected ratio).
+	"""
+	epochUtilization(epoch: Int!): Float
+	"""
+	Get committee membership for an epoch.
+	"""
+	committee(epoch: Int!): [CommitteeMember!]!
+	"""
+	Get cumulative registration totals for an epoch range.
+	"""
+	registeredTotalsSeries(fromEpoch: Int!, toEpoch: Int!): [RegisteredTotals!]!
+	"""
+	Get registration statistics for an epoch range.
+	"""
+	registeredSpoSeries(fromEpoch: Int!, toEpoch: Int!): [RegisteredStat!]!
+	"""
+	Get raw presence events for an epoch range.
+	"""
+	registeredPresence(fromEpoch: Int!, toEpoch: Int!): [PresenceEvent!]!
+	"""
+	Get first valid epoch for each SPO identity.
+	"""
+	registeredFirstValidEpochs(uptoEpoch: Int): [FirstValidEpoch!]!
+	"""
+	Get stake distribution with search and ordering.
+	"""
+	stakeDistribution(limit: Int, offset: Int, search: String, orderByStakeDesc: Boolean): [StakeShare!]!
 }
 
 """
 Registration statistics for an epoch.
 """
 type RegisteredStat {
-  epochNo: Int!
-  federatedValidCount: Int!
-  federatedInvalidCount: Int!
-  registeredValidCount: Int!
-  registeredInvalidCount: Int!
-  dparam: Float
+	epochNo: Int!
+	federatedValidCount: Int!
+	federatedInvalidCount: Int!
+	registeredValidCount: Int!
+	registeredInvalidCount: Int!
+	dparam: Float
 }
 
 """
 Cumulative registration totals for an epoch.
 """
 type RegisteredTotals {
-  epochNo: Int!
-  totalRegistered: Int!
-  newlyRegistered: Int!
+	epochNo: Int!
+	totalRegistered: Int!
+	newlyRegistered: Int!
 }
 
 """
 A regular Midnight transaction.
 """
 type RegularTransaction implements Transaction {
-  """
-  The transaction ID.
-  """
-  id: Int!
-  """
-  The hex-encoded transaction hash.
-  """
-  hash: HexEncoded!
-  """
-  The protocol version.
-  """
-  protocolVersion: Int!
-  """
-  The hex-encoded serialized transaction content.
-  """
-  raw: HexEncoded!
-  """
-  The result of applying this transaction to the ledger state.
-  """
-  transactionResult: TransactionResult!
-  """
-  The hex-encoded serialized transaction identifiers.
-  """
-  identifiers: [HexEncoded!]!
-  """
-  The hex-encoded serialized merkle-tree root.
-  """
-  merkleTreeRoot: HexEncoded!
-  """
-  The zswap state start index.
-  """
-  startIndex: Int!
-  """
-  The zswap state end index.
-  """
-  endIndex: Int!
-  """
-  Fee information for this transaction.
-  """
-  fees: TransactionFees!
-  """
-  The block for this transaction.
-  """
-  block: Block!
-  """
-  The contract actions for this transaction.
-  """
-  contractActions: [ContractAction!]!
-  """
-  Unshielded UTXOs created by this transaction.
-  """
-  unshieldedCreatedOutputs: [UnshieldedUtxo!]!
-  """
-  Unshielded UTXOs spent (consumed) by this transaction.
-  """
-  unshieldedSpentOutputs: [UnshieldedUtxo!]!
-  """
-  Zswap ledger events of this transaction.
-  """
-  zswapLedgerEvents: [ZswapLedgerEvent!]!
-  """
-  Dust ledger events of this transaction.
-  """
-  dustLedgerEvents: [DustLedgerEvent!]!
+	"""
+	The transaction ID.
+	"""
+	id: Int!
+	"""
+	The hex-encoded transaction hash.
+	"""
+	hash: HexEncoded!
+	"""
+	The protocol version.
+	"""
+	protocolVersion: Int!
+	"""
+	The hex-encoded serialized transaction content.
+	"""
+	raw: HexEncoded!
+	"""
+	The result of applying this transaction to the ledger state.
+	"""
+	transactionResult: TransactionResult!
+	"""
+	The hex-encoded serialized transaction identifiers.
+	"""
+	identifiers: [HexEncoded!]!
+	"""
+	The hex-encoded serialized zswap state Merkle tree root.
+	"""
+	zswapMerkleTreeRoot: HexEncoded!
+	"""
+	The hex-encoded serialized zswap state Merkle tree root.
+	"""
+	merkleTreeRoot: HexEncoded! @deprecated(reason: "Use zswapMerkleTreeRoot instead")
+	"""
+	The start index into the zswap state.
+	"""
+	zswapStartIndex: Int!
+	"""
+	The start index into the zswap state.
+	"""
+	startIndex: Int! @deprecated(reason: "Use zswapStartIndex instead")
+	"""
+	The end index into the zswap state; exclusive, i.e. the next free index.
+	"""
+	zswapEndIndex: Int!
+	"""
+	The end index into the zswap state; exclusive, i.e. the next free index.
+	"""
+	endIndex: Int! @deprecated(reason: "Use zswapEndIndex instead")
+	"""
+	The dust commitment tree start index.
+	"""
+	dustCommitmentStartIndex: Int! @beta
+	"""
+	The dust commitment tree end index.
+	"""
+	dustCommitmentEndIndex: Int! @beta
+	"""
+	The dust generation tree start index.
+	"""
+	dustGenerationStartIndex: Int! @beta
+	"""
+	The dust generation tree end index.
+	"""
+	dustGenerationEndIndex: Int! @beta
+	"""
+	The fee for this transaction in SPECK (atomic unit of DUST).
+	"""
+	fee: String!
+	"""
+	Fee information for this transaction.
+	"""
+	fees: TransactionFees! @deprecated(reason: "Use fee instead")
+	"""
+	The block for this transaction.
+	"""
+	block: Block!
+	"""
+	The contract actions for this transaction.
+	"""
+	contractActions: [ContractAction!]!
+	"""
+	Unshielded UTXOs created by this transaction.
+	"""
+	unshieldedCreatedOutputs: [UnshieldedUtxo!]!
+	"""
+	Unshielded UTXOs spent (consumed) by this transaction.
+	"""
+	unshieldedSpentOutputs: [UnshieldedUtxo!]!
+	"""
+	Zswap ledger events of this transaction.
+	"""
+	zswapLedgerEvents: [ZswapLedgerEvent!]!
+	"""
+	Dust ledger events of this transaction.
+	"""
+	dustLedgerEvents: [DustLedgerEvent!]!
 }
 
 """
-A transaction relevant for the subscribing wallet and an optional collapsed merkle tree.
+A transaction relevant for the subscribing wallet and an optional zswap state Merkle tree
+collapsed update.
 """
 type RelevantTransaction {
-  """
-  A transaction relevant for the subscribing wallet.
-  """
-  transaction: RegularTransaction!
-  """
-  An optional collapsed merkle tree.
-  """
-  collapsedMerkleTree: CollapsedMerkleTree
+	"""
+	A transaction relevant for the subscribing wallet.
+	"""
+	transaction: RegularTransaction!
+	"""
+	Only include a zswap state Merkle tree collapsed update if there is a gap between the
+	current zswap index "driving" the subscription and the zswap start index of the
+	transaction.
+	"""
+	zswapCollapsedUpdate: MerkleTreeCollapsedUpdate
+	"""
+	An optional collapsed Merkle tree.
+	"""
+	collapsedMerkleTree: CollapsedMerkleTree @deprecated(reason: "Use zswapCollapsedUpdate instead")
 }
 
 """
@@ -682,14 +1139,124 @@ One of many segments for a partially successful transaction result showing succe
 segment.
 """
 type Segment {
-  """
-  Segment ID.
-  """
-  id: Int!
-  """
-  Successful or not.
-  """
-  success: Boolean!
+	"""
+	Segment ID.
+	"""
+	id: Int!
+	"""
+	Successful or not.
+	"""
+	success: Boolean!
+}
+
+type ShieldedBurnEvent implements ContractEvent {
+	id: Int!
+	raw: HexEncoded!
+	maxId: Int!
+	protocolVersion: Int!
+	version: Int!
+	contractAddress: HexEncoded!
+	transactionId: Int!
+	"""
+	Indexed.
+	"""
+	nullifier: HexEncoded!
+	"""
+	Optional, hidden in some shielded burns (`Maybe<Uint<128>>`).
+	"""
+	amount: String
+}
+
+type ShieldedMintEvent implements ContractEvent {
+	id: Int!
+	raw: HexEncoded!
+	maxId: Int!
+	protocolVersion: Int!
+	version: Int!
+	contractAddress: HexEncoded!
+	transactionId: Int!
+	"""
+	Indexed.
+	"""
+	commitment: HexEncoded!
+	"""
+	Indexed (per Andrzej, useful for token-type queries).
+	"""
+	domainSep: HexEncoded!
+	"""
+	Optional, hidden in some shielded mints (`Maybe<Uint<128>>`).
+	"""
+	amount: String
+}
+
+"""
+A transaction containing a shielded (zswap) nullifier match with block context.
+"""
+type ShieldedNullifierTransaction {
+	"""
+	The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor).
+	"""
+	transactionId: Int!
+	"""
+	The hex-encoded transaction hash (32-byte chain identifier).
+	"""
+	transactionHash: HexEncoded!
+	"""
+	The hex-encoded block hash (use to query block with ledger parameters).
+	"""
+	blockHash: HexEncoded!
+	"""
+	The block height containing this transaction.
+	"""
+	blockHeight: Int!
+	"""
+	The hex-encoded matched nullifier.
+	"""
+	nullifier: HexEncoded!
+	"""
+	The transaction containing this nullifier match.
+	"""
+	transaction: Transaction! @beta
+}
+
+type ShieldedReceiveEvent implements ContractEvent {
+	id: Int!
+	raw: HexEncoded!
+	maxId: Int!
+	protocolVersion: Int!
+	version: Int!
+	contractAddress: HexEncoded!
+	transactionId: Int!
+	"""
+	Indexed.
+	"""
+	commitment: HexEncoded!
+	"""
+	Indexed. Optional ciphertext for shielded coin receipt
+	(`Maybe<Bytes<512>>`). Hex-encoded, up to 512 bytes.
+	"""
+	ciphertext: HexEncoded
+	"""
+	Set when received by a contract; null for user recipients
+	(`Maybe<ContractAddress>`). Renamed from `contractAddress` in the CoIP
+	to avoid collision with the top-level emitting `contractAddress`
+	inherited from the ContractEvent interface.
+	"""
+	receivingContractAddress: HexEncoded
+}
+
+type ShieldedSpendEvent implements ContractEvent {
+	id: Int!
+	raw: HexEncoded!
+	maxId: Int!
+	protocolVersion: Int!
+	version: Int!
+	contractAddress: HexEncoded!
+	transactionId: Int!
+	"""
+	Indexed.
+	"""
+	nullifier: HexEncoded!
 }
 
 """
@@ -701,60 +1268,80 @@ union ShieldedTransactionsEvent = RelevantTransaction | ShieldedTransactionsProg
 Information about the shielded transactions indexing progress.
 """
 type ShieldedTransactionsProgress {
-  """
-  The highest zswap state end index (see `endIndex` of `Transaction`) of all transactions. It
-  represents the known state of the blockchain. A value of zero (completely unlikely) means
-  that no shielded transactions have been indexed yet.
-  """
-  highestEndIndex: Int!
-  """
-  The highest zswap state end index (see `endIndex` of `Transaction`) of all transactions
-  checked for relevance. Initially less than and eventually (when some wallet has been fully
-  indexed) equal to `highest_end_index`. A value of zero (very unlikely) means that no wallet
-  has subscribed before and indexing for the subscribing wallet has not yet started.
-  """
-  highestCheckedEndIndex: Int!
-  """
-  The highest zswap state end index (see `endIndex` of `Transaction`) of all relevant
-  transactions for the subscribing wallet. Usually less than `highest_checked_end_index`
-  unless the latest checked transaction is relevant for the subscribing wallet. A value of
-  zero means that no relevant transactions have been indexed for the subscribing wallet.
-  """
-  highestRelevantEndIndex: Int!
+	"""
+	The highest end index into the zswap state for all transactions. It represents the known
+	state of the blockchain. A value of zero (completely unlikely) means that no shielded
+	transactions have been indexed yet.
+	"""
+	highestZswapEndIndex: Int!
+	"""
+	The highest end index into the zswap state for all transactions. It represents the known
+	state of the blockchain. A value of zero (completely unlikely) means that no shielded
+	transactions have been indexed yet.
+	"""
+	highestEndIndex: Int! @deprecated(reason: "Use highestZswapEndIndex instead")
+	"""
+	The highest highest end index into the zswap state for all transactions checked for
+	relevance. Initially less than and eventually (when some wallet has been fully indexed)
+	equal to `highest_end_index`. A value of zero (very unlikely) means that no wallet
+	has subscribed before and indexing for the subscribing wallet has not yet started.
+	"""
+	highestCheckedZswapEndIndex: Int!
+	"""
+	The highest highest end index into the zswap state for all transactions checked for
+	relevance. Initially less than and eventually (when some wallet has been fully indexed)
+	equal to `highest_end_index`. A value of zero (very unlikely) means that no wallet
+	has subscribed before and indexing for the subscribing wallet has not yet started.
+	"""
+	highestCheckedEndIndex: Int! @deprecated(reason: "Use highestCheckedZswapEndIndex instead")
+	"""
+	The highest highest end index into the zswap state for all relevant transactions for the
+	subscribing wallet. Usually less than `highest_checked_end_index` unless the latest
+	checked transaction is relevant for the subscribing wallet. A value of zero means that
+	no relevant transactions have been indexed for the subscribing wallet.
+	"""
+	highestRelevantZswapEndIndex: Int!
+	"""
+	The highest highest end index into the zswap state for all relevant transactions for the
+	subscribing wallet. Usually less than `highest_checked_end_index` unless the latest
+	checked transaction is relevant for the subscribing wallet. A value of zero means that
+	no relevant transactions have been indexed for the subscribing wallet.
+	"""
+	highestRelevantEndIndex: Int! @deprecated(reason: "Use highestRelevantZswapEndIndex instead")
 }
 
 """
 SPO with optional metadata.
 """
 type Spo {
-  poolIdHex: String!
-  validatorClass: String!
-  sidechainPubkeyHex: String!
-  auraPubkeyHex: String
-  name: String
-  ticker: String
-  homepageUrl: String
-  logoUrl: String
+	poolIdHex: String!
+	validatorClass: String!
+	sidechainPubkeyHex: String!
+	auraPubkeyHex: String
+	name: String
+	ticker: String
+	homepageUrl: String
+	logoUrl: String
 }
 
 """
 Composite SPO data (identity + metadata + performance).
 """
 type SpoComposite {
-  identity: SpoIdentity
-  metadata: PoolMetadata
-  performance: [EpochPerf!]!
+	identity: SpoIdentity
+	metadata: PoolMetadata
+	performance: [EpochPerf!]!
 }
 
 """
 SPO identity information.
 """
 type SpoIdentity {
-  poolIdHex: String!
-  mainchainPubkeyHex: String!
-  sidechainPubkeyHex: String!
-  auraPubkeyHex: String
-  validatorClass: String!
+	poolIdHex: String!
+	mainchainPubkeyHex: String!
+	sidechainPubkeyHex: String!
+	auraPubkeyHex: String
+	validatorClass: String!
 }
 
 """
@@ -763,229 +1350,253 @@ Stake share information for an SPO.
 Values are sourced from mainchain pool data (e.g., Blockfrost) and keyed by Cardano pool_id.
 """
 type StakeShare {
-  """
-  Cardano pool ID (56-character hex string).
-  """
-  poolIdHex: String!
-  """
-  Pool name from metadata.
-  """
-  name: String
-  """
-  Pool ticker from metadata.
-  """
-  ticker: String
-  """
-  Pool homepage URL from metadata.
-  """
-  homepageUrl: String
-  """
-  Pool logo URL from metadata.
-  """
-  logoUrl: String
-  """
-  Current live stake in lovelace.
-  """
-  liveStake: String
-  """
-  Current active stake in lovelace.
-  """
-  activeStake: String
-  """
-  Number of live delegators.
-  """
-  liveDelegators: Int
-  """
-  Saturation ratio (0.0 to 1.0+).
-  """
-  liveSaturation: Float
-  """
-  Declared pledge in lovelace.
-  """
-  declaredPledge: String
-  """
-  Current live pledge in lovelace.
-  """
-  livePledge: String
-  """
-  Stake share as a fraction of total stake.
-  """
-  stakeShare: Float
+	"""
+	Cardano pool ID (56-character hex string).
+	"""
+	poolIdHex: String!
+	"""
+	Pool name from metadata.
+	"""
+	name: String
+	"""
+	Pool ticker from metadata.
+	"""
+	ticker: String
+	"""
+	Pool homepage URL from metadata.
+	"""
+	homepageUrl: String
+	"""
+	Pool logo URL from metadata.
+	"""
+	logoUrl: String
+	"""
+	Current live stake in lovelace.
+	"""
+	liveStake: String
+	"""
+	Current active stake in lovelace.
+	"""
+	activeStake: String
+	"""
+	Number of live delegators.
+	"""
+	liveDelegators: Int
+	"""
+	Saturation ratio (0.0 to 1.0+).
+	"""
+	liveSaturation: Float
+	"""
+	Declared pledge in lovelace.
+	"""
+	declaredPledge: String
+	"""
+	Current live pledge in lovelace.
+	"""
+	livePledge: String
+	"""
+	Stake share as a fraction of total stake.
+	"""
+	stakeShare: Float
 }
 
 type Subscription {
-  """
-  Subscribe to blocks starting at the given offset or at the latest block if the offset is
-  omitted.
-  """
-  blocks(offset: BlockOffset): Block!
-  """
-  Subscribe to contract actions with the given address starting at the given offset or at the
-  latest block if the offset is omitted.
-  """
-  contractActions(address: HexEncoded!, offset: BlockOffset): ContractAction!
-  """
-  Subscribe to dust ledger events starting at the given ID or at the very start if omitted.
-  """
-  dustLedgerEvents(id: Int): DustLedgerEvent!
-  """
-  Subscribe to shielded transaction events for the given session ID starting at the given
-  index or at zero if omitted.
-  """
-  shieldedTransactions(sessionId: HexEncoded!, index: Int): ShieldedTransactionsEvent!
-  """
-  Subscribe unshielded transaction events for the given address and the given transaction ID
-  or zero if omitted.
-  """
-  unshieldedTransactions(address: UnshieldedAddress!, transactionId: Int): UnshieldedTransactionsEvent!
-  """
-  Subscribe to zswap ledger events starting at the given ID or at the very start if omitted.
-  """
-  zswapLedgerEvents(id: Int): ZswapLedgerEvent!
+	"""
+	Subscribe to blocks starting at the given offset or at the latest block if the offset is
+	omitted.
+	"""
+	blocks(offset: BlockOffset): Block!
+	"""
+	Subscribe to contract actions with the given address starting at the given offset or at the
+	latest block if the offset is omitted.
+	"""
+	contractActions(address: HexEncoded!, offset: BlockOffset): ContractAction!
+	"""
+	Subscribe to contract events matching the given filter, returning
+	events in monotonic `id` order.
+	"""
+	contractEvents(filter: ContractEventFilter!, id: Int): ContractEvent!
+	"""
+	Subscribe to dust generation entries for a dust address in `[start_index, end_index]`
+	inclusive. `dustGenerationEndIndex` is exclusive, pass `dustGenerationEndIndex - 1`.
+	Entries interleaved with collapsed Merkle tree updates and owned-entry dtime updates.
+	"""
+	dustGenerations(dustAddress: DustAddress!, startIndex: Int!, endIndex: Int!): DustGenerationsEvent! @beta
+	"""
+	Subscribe to dust ledger events starting at the given ID or at the very start if omitted.
+	"""
+	dustLedgerEvents(id: Int): DustLedgerEvent!
+	"""
+	Subscribe to transactions containing dust nullifiers whose 32-byte little-endian form
+	starts with one of the provided prefixes. Returns transaction and block references for
+	the wallet to fetch full data. If `toBlock` is specified, the subscription finishes
+	after reaching that block.
+	"""
+	dustNullifierTransactions(nullifierLeBytesPrefixes: [HexEncoded!]!, fromBlock: Int, toBlock: Int): DustNullifierTransaction!
+	"""
+	Subscribe to transactions containing shielded (zswap) nullifiers matching the provided
+	prefixes. Returns transaction and block references for wallet to fetch full data.
+	If `toBlock` is specified, the subscription finishes after reaching that block.
+	"""
+	shieldedNullifierTransactions(nullifierPrefixes: [HexEncoded!]!, fromBlock: Int, toBlock: Int): ShieldedNullifierTransaction!
+	"""
+	Subscribe to shielded transaction events for the given session ID starting at the given
+	index or at zero if omitted.
+	"""
+	shieldedTransactions(sessionId: HexEncoded!, index: Int): ShieldedTransactionsEvent!
+	"""
+	Subscribe unshielded transaction events for the given address and the given transaction ID
+	or zero if omitted.
+	"""
+	unshieldedTransactions(address: UnshieldedAddress!, transactionId: Int): UnshieldedTransactionsEvent!
+	"""
+	Subscribe to zswap ledger events starting at the given ID or at the very start if omitted.
+	"""
+	zswapLedgerEvents(id: Int): ZswapLedgerEvent!
 }
 
 """
 System parameters at a specific block height.
 """
 type SystemParameters {
-  """
-  The D-parameter controlling validator committee composition.
-  """
-  dParameter: DParameter!
-  """
-  The current Terms and Conditions, if any have been set.
-  """
-  termsAndConditions: TermsAndConditions
+	"""
+	The D-parameter controlling validator committee composition.
+	"""
+	dParameter: DParameter!
+	"""
+	The current Terms and Conditions, if any have been set.
+	"""
+	termsAndConditions: TermsAndConditions
 }
 
 """
 A system Midnight transaction.
 """
 type SystemTransaction implements Transaction {
-  """
-  The transaction ID.
-  """
-  id: Int!
-  """
-  The hex-encoded transaction hash.
-  """
-  hash: HexEncoded!
-  """
-  The protocol version.
-  """
-  protocolVersion: Int!
-  """
-  The hex-encoded serialized transaction content.
-  """
-  raw: HexEncoded!
-  """
-  The block for this transaction.
-  """
-  block: Block!
-  """
-  The contract actions for this transaction.
-  """
-  contractActions: [ContractAction!]!
-  """
-  Unshielded UTXOs created by this transaction.
-  """
-  unshieldedCreatedOutputs: [UnshieldedUtxo!]!
-  """
-  Unshielded UTXOs spent (consumed) by this transaction.
-  """
-  unshieldedSpentOutputs: [UnshieldedUtxo!]!
-  """
-  Zswap ledger events of this transaction.
-  """
-  zswapLedgerEvents: [ZswapLedgerEvent!]!
-  """
-  Dust ledger events of this transaction.
-  """
-  dustLedgerEvents: [DustLedgerEvent!]!
+	"""
+	The transaction ID.
+	"""
+	id: Int!
+	"""
+	The hex-encoded transaction hash.
+	"""
+	hash: HexEncoded!
+	"""
+	The protocol version.
+	"""
+	protocolVersion: Int!
+	"""
+	The hex-encoded serialized transaction content.
+	"""
+	raw: HexEncoded!
+	"""
+	The block for this transaction.
+	"""
+	block: Block!
+	"""
+	The contract actions for this transaction.
+	"""
+	contractActions: [ContractAction!]!
+	"""
+	Unshielded UTXOs created by this transaction.
+	"""
+	unshieldedCreatedOutputs: [UnshieldedUtxo!]!
+	"""
+	Unshielded UTXOs spent (consumed) by this transaction.
+	"""
+	unshieldedSpentOutputs: [UnshieldedUtxo!]!
+	"""
+	Zswap ledger events of this transaction.
+	"""
+	zswapLedgerEvents: [ZswapLedgerEvent!]!
+	"""
+	Dust ledger events of this transaction.
+	"""
+	dustLedgerEvents: [DustLedgerEvent!]!
 }
 
 """
 Terms and Conditions agreement.
 """
 type TermsAndConditions {
-  """
-  The hex-encoded hash of the Terms and Conditions document.
-  """
-  hash: HexEncoded!
-  """
-  The URL where the Terms and Conditions can be found.
-  """
-  url: String!
+	"""
+	The hex-encoded hash of the Terms and Conditions document.
+	"""
+	hash: HexEncoded!
+	"""
+	The URL where the Terms and Conditions can be found.
+	"""
+	url: String!
 }
 
 """
 Terms and Conditions change record for history queries.
 """
 type TermsAndConditionsChange {
-  """
-  The block height where this T&C version became effective.
-  """
-  blockHeight: Int!
-  """
-  The hex-encoded block hash where this T&C version became effective.
-  """
-  blockHash: HexEncoded!
-  """
-  The UNIX timestamp when this T&C version became effective.
-  """
-  timestamp: Int!
-  """
-  The hex-encoded hash of the Terms and Conditions document.
-  """
-  hash: HexEncoded!
-  """
-  The URL where the Terms and Conditions can be found.
-  """
-  url: String!
+	"""
+	The block height where this T&C version became effective.
+	"""
+	blockHeight: Int!
+	"""
+	The hex-encoded block hash where this T&C version became effective.
+	"""
+	blockHash: HexEncoded!
+	"""
+	The UNIX timestamp when this T&C version became effective.
+	"""
+	timestamp: Int!
+	"""
+	The hex-encoded hash of the Terms and Conditions document.
+	"""
+	hash: HexEncoded!
+	"""
+	The URL where the Terms and Conditions can be found.
+	"""
+	url: String!
 }
 
 """
 A Midnight transaction.
 """
 interface Transaction {
-  id: Int!
-  hash: HexEncoded!
-  protocolVersion: Int!
-  raw: HexEncoded!
-  block: Block!
-  contractActions: [ContractAction!]!
-  unshieldedCreatedOutputs: [UnshieldedUtxo!]!
-  unshieldedSpentOutputs: [UnshieldedUtxo!]!
-  zswapLedgerEvents: [ZswapLedgerEvent!]!
-  dustLedgerEvents: [DustLedgerEvent!]!
+	id: Int!
+	hash: HexEncoded!
+	protocolVersion: Int!
+	raw: HexEncoded!
+	block: Block!
+	contractActions: [ContractAction!]!
+	unshieldedCreatedOutputs: [UnshieldedUtxo!]!
+	unshieldedSpentOutputs: [UnshieldedUtxo!]!
+	zswapLedgerEvents: [ZswapLedgerEvent!]!
+	dustLedgerEvents: [DustLedgerEvent!]!
 }
 
 """
-Fees information for a transaction, including both paid and estimated fees.
+Fees information for a transaction.
 """
 type TransactionFees {
-  """
-  The actual fees paid for this transaction in DUST.
-  """
-  paidFees: String!
-  """
-  The estimated fees that was calculated for this transaction in DUST.
-  """
-  estimatedFees: String!
+	"""
+	The fees for this transaction in SPECK (atomic unit of DUST).
+	"""
+	paidFees: String!
+	"""
+	The fees for this transaction in SPECK (atomic unit of DUST).
+	"""
+	estimatedFees: String! @deprecated(reason: "Use paidFees instead")
 }
 
 """
 Either a transaction hash or a transaction identifier.
 """
 input TransactionOffset @oneOf {
-  """
-  A hex-encoded transaction hash.
-  """
-  hash: HexEncoded
-  """
-  A hex-encoded transaction identifier.
-  """
-  identifier: HexEncoded
+	"""
+	A hex-encoded transaction hash.
+	"""
+	hash: HexEncoded
+	"""
+	A hex-encoded transaction identifier.
+	"""
+	identifier: HexEncoded
 }
 
 """
@@ -993,39 +1604,133 @@ The result of applying a transaction to the ledger state. In case of a partial s
 there will be segments.
 """
 type TransactionResult {
-  status: TransactionResultStatus!
-  segments: [Segment!]
+	status: TransactionResultStatus!
+	segments: [Segment!]
 }
 
 """
 The status of the transaction result: success, partial success or failure.
 """
 enum TransactionResultStatus {
-  SUCCESS
-  PARTIAL_SUCCESS
-  FAILURE
+	SUCCESS
+	PARTIAL_SUCCESS
+	FAILURE
 }
 
 scalar Unit
 
+type UnpausedEvent implements ContractEvent {
+	id: Int!
+	raw: HexEncoded!
+	maxId: Int!
+	protocolVersion: Int!
+	version: Int!
+	contractAddress: HexEncoded!
+	transactionId: Int!
+}
+
 scalar UnshieldedAddress
+
+type UnshieldedBurnEvent implements ContractEvent {
+	id: Int!
+	raw: HexEncoded!
+	maxId: Int!
+	protocolVersion: Int!
+	version: Int!
+	contractAddress: HexEncoded!
+	transactionId: Int!
+	"""
+	Indexed.
+	"""
+	sender: AddressOrContract!
+	"""
+	Indexed; matches existing unshielded_utxos.token_type index.
+	"""
+	tokenType: HexEncoded!
+	amount: String!
+}
+
+type UnshieldedMintEvent implements ContractEvent {
+	id: Int!
+	raw: HexEncoded!
+	maxId: Int!
+	protocolVersion: Int!
+	version: Int!
+	contractAddress: HexEncoded!
+	transactionId: Int!
+	"""
+	Indexed.
+	"""
+	domainSep: HexEncoded!
+	"""
+	Indexed; matches existing unshielded_utxos.token_type index.
+	"""
+	tokenType: HexEncoded!
+	amount: String!
+}
+
+type UnshieldedReceiveEvent implements ContractEvent {
+	id: Int!
+	raw: HexEncoded!
+	maxId: Int!
+	protocolVersion: Int!
+	version: Int!
+	contractAddress: HexEncoded!
+	transactionId: Int!
+	"""
+	Indexed.
+	"""
+	recipient: AddressOrContract!
+	"""
+	Indexed.
+	"""
+	domainSep: HexEncoded!
+	"""
+	Indexed; matches existing unshielded_utxos.token_type index.
+	"""
+	tokenType: HexEncoded!
+	amount: String!
+}
+
+type UnshieldedSpendEvent implements ContractEvent {
+	id: Int!
+	raw: HexEncoded!
+	maxId: Int!
+	protocolVersion: Int!
+	version: Int!
+	contractAddress: HexEncoded!
+	transactionId: Int!
+	"""
+	Indexed.
+	"""
+	sender: AddressOrContract!
+	"""
+	Indexed.
+	"""
+	domainSep: HexEncoded!
+	"""
+	Indexed; matches existing unshielded_utxos.token_type index.
+	"""
+	tokenType: HexEncoded!
+	amount: String!
+}
 
 """
 A transaction that created and/or spent UTXOs alongside these and other information.
 """
 type UnshieldedTransaction {
-  """
-  The transaction that created and/or spent UTXOs.
-  """
-  transaction: Transaction!
-  """
-  UTXOs created in the above transaction, possibly empty.
-  """
-  createdUtxos: [UnshieldedUtxo!]!
-  """
-  UTXOs spent in the above transaction, possibly empty.
-  """
-  spentUtxos: [UnshieldedUtxo!]!
+	"""
+	The transaction that created and/or spent UTXOs.
+	"""
+	transaction: Transaction!
+	"""
+	UTXOs created in the above transaction, possibly empty.
+	"""
+	createdUtxos: [UnshieldedUtxo!]!
+	"""
+	UTXOs spent in the above transaction, possibly empty.
+	"""
+	spentUtxos: [UnshieldedUtxo!]!
 }
 
 """
@@ -1037,56 +1742,56 @@ union UnshieldedTransactionsEvent = UnshieldedTransaction | UnshieldedTransactio
 Information about the unshielded indexing progress.
 """
 type UnshieldedTransactionsProgress {
-  """
-  The highest transaction ID of all currently known transactions for a subscribed address.
-  """
-  highestTransactionId: Int!
+	"""
+	The highest transaction ID of all currently known transactions for a subscribed address.
+	"""
+	highestTransactionId: Int!
 }
 
 """
 Represents an unshielded UTXO.
 """
 type UnshieldedUtxo {
-  """
-  Owner Bech32m-encoded address.
-  """
-  owner: UnshieldedAddress!
-  """
-  Token hex-encoded serialized token type.
-  """
-  tokenType: HexEncoded!
-  """
-  UTXO value (quantity) as a string to support u128.
-  """
-  value: String!
-  """
-  The hex-encoded serialized intent hash.
-  """
-  intentHash: HexEncoded!
-  """
-  Index of this output within its creating transaction.
-  """
-  outputIndex: Int!
-  """
-  The creation time in seconds.
-  """
-  ctime: Int
-  """
-  The hex-encoded initial nonce for DUST generation tracking.
-  """
-  initialNonce: HexEncoded!
-  """
-  Whether this UTXO is registered for DUST generation.
-  """
-  registeredForDustGeneration: Boolean!
-  """
-  Transaction that created this UTXO.
-  """
-  createdAtTransaction: Transaction!
-  """
-  Transaction that spent this UTXO.
-  """
-  spentAtTransaction: Transaction
+	"""
+	Owner Bech32m-encoded address.
+	"""
+	owner: UnshieldedAddress!
+	"""
+	Token hex-encoded serialized token type.
+	"""
+	tokenType: HexEncoded!
+	"""
+	UTXO value (quantity) as a string to support u128.
+	"""
+	value: String!
+	"""
+	The hex-encoded serialized intent hash.
+	"""
+	intentHash: HexEncoded!
+	"""
+	Index of this output within its creating transaction.
+	"""
+	outputIndex: Int!
+	"""
+	The creation time in seconds.
+	"""
+	ctime: Int
+	"""
+	The hex-encoded initial nonce for DUST generation tracking.
+	"""
+	initialNonce: HexEncoded!
+	"""
+	Whether this UTXO is registered for DUST generation.
+	"""
+	registeredForDustGeneration: Boolean!
+	"""
+	Transaction that created this UTXO.
+	"""
+	createdAtTransaction: Transaction!
+	"""
+	Transaction that spent this UTXO.
+	"""
+	spentAtTransaction: Transaction
 }
 
 scalar ViewingKey
@@ -1095,24 +1800,37 @@ scalar ViewingKey
 A zswap related ledger event.
 """
 type ZswapLedgerEvent {
-  """
-  The ID of this zswap ledger event.
-  """
-  id: Int!
-  """
-  The hex-encoded serialized event.
-  """
-  raw: HexEncoded!
-  """
-  The maximum ID of all zswap ledger events.
-  """
-  maxId: Int!
-  """
-  The protocol version.
-  """
-  protocolVersion: Int!
+	"""
+	The ID of this zswap ledger event.
+	"""
+	id: Int!
+	"""
+	The hex-encoded serialized event.
+	"""
+	raw: HexEncoded!
+	"""
+	The maximum ID of all zswap ledger events.
+	"""
+	maxId: Int!
+	"""
+	The protocol version.
+	"""
+	protocolVersion: Int!
 }
 
+"""
+Marks a schema field or type as in-flight / unstable. Consumers should
+expect the marked surface to change without notice; stability is signalled
+by removal of the directive.
+
+Currently used for the dust-generation API surface that's in mid-redesign
+pending #1181. See #1173.
+"""
+directive @beta on FIELD_DEFINITION | OBJECT
+"""
+Marks an element of a GraphQL schema as no longer supported.
+"""
+directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
 """
 Directs the executor to include this field or fragment only when the `if` argument is true.
 """
@@ -1126,7 +1844,8 @@ Directs the executor to skip this field or fragment when the `if` argument is tr
 """
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 schema {
-  query: Query
-  mutation: Mutation
-  subscription: Subscription
+	query: Query
+	mutation: Mutation
+	subscription: Subscription
 }
+

--- a/packages/indexer-public-data-provider/src/gen/graphql.ts
+++ b/packages/indexer-public-data-provider/src/gen/graphql.ts
@@ -22,10 +22,41 @@ export type Scalars = {
   ViewingKey: { input: string; output: string; }
 };
 
+/**
+ * Tagged-union helper for fields like `Either<ZswapCoinPublicKey, ContractAddress>`
+ * used in standard unshielded events.
+ *
+ * Exactly one of `userAddress` or `contractAddress` is non-null; the `kind`
+ * discriminator says which.
+ */
+export type AddressOrContract = {
+  /** Hex-encoded contract address; populated when kind = CONTRACT. */
+  readonly contractAddress: Maybe<Scalars['HexEncoded']['output']>;
+  readonly kind: AddressOrContractKind;
+  /**
+   * Bech32m-encoded user address; populated when kind = USER.
+   * Hex-encoded here at the wire level; clients re-encode if needed.
+   */
+  readonly userAddress: Maybe<Scalars['HexEncoded']['output']>;
+};
+
+export type AddressOrContractKind =
+  | 'CONTRACT'
+  | 'USER'
+  | '%future added value';
+
 /** A block with its relevant data. */
 export type Block = {
   /** The hex-encoded block author. */
   readonly author: Maybe<Scalars['HexEncoded']['output']>;
+  /** The dust commitment tree end index at this block; exclusive, i.e. the next free index. */
+  readonly dustCommitmentEndIndex: Scalars['Int']['output'];
+  /** The hex-encoded dust commitment Merkle tree root at the latest indexed state. */
+  readonly dustCommitmentMerkleTreeRoot: Maybe<Scalars['HexEncoded']['output']>;
+  /** The dust generation tree end index at this block; exclusive, i.e. the next free index. */
+  readonly dustGenerationEndIndex: Scalars['Int']['output'];
+  /** The hex-encoded dust generation Merkle tree root at the latest indexed state. */
+  readonly dustGenerationMerkleTreeRoot: Maybe<Scalars['HexEncoded']['output']>;
   /** The block hash. */
   readonly hash: Scalars['HexEncoded']['output'];
   /** The block height. */
@@ -42,6 +73,10 @@ export type Block = {
   readonly timestamp: Scalars['Int']['output'];
   /** The transactions within this block. */
   readonly transactions: ReadonlyArray<Transaction>;
+  /** The zswap commitment tree end index at this block; exclusive, i.e. the next free index. */
+  readonly zswapEndIndex: Scalars['Int']['output'];
+  /** The hex-encoded serialized zswap state Merkle tree root. */
+  readonly zswapMerkleTreeRoot: Scalars['HexEncoded']['output'];
 };
 
 /** Either a block hash or a block height. */
@@ -51,12 +86,13 @@ export type BlockOffset =
   |  /** A block height. */
   { readonly hash?: never; readonly height: Scalars['Int']['input']; };
 
+/** A Merkle tree collapsed update between two indices. */
 export type CollapsedMerkleTree = {
-  /** The zswap state end index. */
+  /** The end index. */
   readonly endIndex: Scalars['Int']['output'];
   /** The protocol version. */
   readonly protocolVersion: Scalars['Int']['output'];
-  /** The zswap state start index. */
+  /** The start index. */
   readonly startIndex: Scalars['Int']['output'];
   /** The hex-encoded value. */
   readonly update: Scalars['HexEncoded']['output'];
@@ -71,6 +107,12 @@ export type CommitteeMember = {
   readonly position: Scalars['Int']['output'];
   readonly sidechainPubkeyHex: Scalars['String']['output'];
   readonly spoSkHex: Maybe<Scalars['String']['output']>;
+};
+
+/** Options for the connect mutation. */
+export type ConnectOptions = {
+  /** Transaction index to start searching for relevant transactions (inclusive). */
+  readonly startIndex: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** A contract action. */
@@ -105,6 +147,18 @@ export type ContractBalance = {
 export type ContractCall = ContractAction & {
   /** The hex-encoded serialized address. */
   readonly address: Scalars['HexEncoded']['output'];
+  /**
+   * Contract events emitted by this contract call.
+   *
+   * Only `ContractCall` exposes this field — `ContractDeploy` and
+   * `ContractUpdate` don't execute circuits with the `log()` expression.
+   * Per Andrzej's 12 May design call (#feat-public-events).
+   *
+   * Returns an empty list until the chain-indexer populates the
+   * `ledger_events.contract_action_id` column from the v9 parse path
+   * (gated on ticket #1157).
+   */
+  readonly contractEvents: ReadonlyArray<ContractEvent>;
   /** Contract deploy for this contract call. */
   readonly deploy: ContractDeploy;
   /** The entry point. */
@@ -132,6 +186,62 @@ export type ContractDeploy = ContractAction & {
   /** The hex-encoded serialized contract-specific zswap state. */
   readonly zswapState: Scalars['HexEncoded']['output'];
 };
+
+/** Common interface implemented by every concrete contract event type. */
+export type ContractEvent = {
+  readonly contractAddress: Scalars['HexEncoded']['output'];
+  readonly id: Scalars['Int']['output'];
+  readonly maxId: Scalars['Int']['output'];
+  readonly protocolVersion: Scalars['Int']['output'];
+  readonly raw: Scalars['HexEncoded']['output'];
+  readonly transactionId: Scalars['Int']['output'];
+  readonly version: Scalars['Int']['output'];
+};
+
+/**
+ * Filter for contract events queries and subscriptions. Block-range bounds
+ * live here so the same shape works for both (per Andrzej 21 May review).
+ */
+export type ContractEventFilter = {
+  /** Required: the contract address to filter events for. */
+  readonly contractAddress: Scalars['HexEncoded']['input'];
+  /** Optional: prefix-match on indexed fields of the event. Standard events only. */
+  readonly fieldPrefixes: InputMaybe<ReadonlyArray<FieldPrefixFilter>>;
+  /**
+   * Optional: lower bound on the block height an event was emitted in. On
+   * subscription, acts as a starting cursor (alternative to `id`).
+   */
+  readonly fromBlock: InputMaybe<Scalars['Int']['input']>;
+  /**
+   * Optional: upper bound on the block height an event was emitted in. On
+   * subscription, terminates the stream once the chain reaches this block.
+   */
+  readonly toBlock: InputMaybe<Scalars['Int']['input']>;
+  /**
+   * Optional: filter to a subset of contract event types. Indexer translates
+   * to `variant = ANY(...)` against the indexed variant column.
+   */
+  readonly types: InputMaybe<ReadonlyArray<ContractEventType>>;
+};
+
+/**
+ * Closed enum of contract event types the indexer surfaces. Used in filter
+ * input only, response discrimination is via `__typename`. Mirrors the
+ * 11 variants of `LogEventType` (onchain-vm/src/ops.rs, ledger-9 alpha).
+ */
+export type ContractEventType =
+  | 'MISC'
+  | 'PAUSED'
+  | 'SHIELDED_BURN'
+  | 'SHIELDED_MINT'
+  | 'SHIELDED_RECEIVE'
+  | 'SHIELDED_SPEND'
+  | 'UNPAUSED'
+  | 'UNSHIELDED_BURN'
+  | 'UNSHIELDED_MINT'
+  | 'UNSHIELDED_RECEIVE'
+  | 'UNSHIELDED_SPEND'
+  | '%future added value';
 
 /** A contract update. */
 export type ContractUpdate = ContractAction & {
@@ -180,6 +290,31 @@ export type DustGenerationDtimeUpdate = DustLedgerEvent & {
   readonly raw: Scalars['HexEncoded']['output'];
 };
 
+/**
+ * A dust generation dtime update emitted when the backing Night UTXO is
+ * spent and the entry's decay time is set.
+ */
+export type DustGenerationDtimeUpdateItem = {
+  /** Generation-tree index of the entry whose dtime changed. */
+  readonly generationMtIndex: Scalars['Int']['output'];
+  /** The decay time as observed in this ledger event. */
+  readonly newDtime: Scalars['Int']['output'];
+  /** Hex-encoded hash of the NIGHT UTXO that backs this dust output. */
+  readonly nightUtxoHash: Scalars['HexEncoded']['output'];
+  /** The hex-encoded owner (dust address). */
+  readonly owner: Scalars['HexEncoded']['output'];
+  /** The hex-encoded originating transaction hash (32-byte chain identifier). */
+  readonly transactionHash: Scalars['HexEncoded']['output'];
+  /** The originating transaction ID (indexer-internal BIGSERIAL). */
+  readonly transactionId: Scalars['Int']['output'];
+  /**
+   * Hex-encoded tagged-serialised `TreeInsertionPath<DustGenerationInfo>`
+   * from the originating ledger event. Wallets deserialise this and hand
+   * it to `generating_tree.update_from_evidence(...)`.
+   */
+  readonly treeInsertionPath: Scalars['HexEncoded']['output'];
+};
+
 /** DUST generation status for a specific Cardano reward address. */
 export type DustGenerationStatus = {
   /** The Bech32-encoded Cardano reward address (e.g., stake_test1... or stake1...). */
@@ -200,6 +335,49 @@ export type DustGenerationStatus = {
   readonly utxoOutputIndex: Maybe<Scalars['Int']['output']>;
   /** Cardano UTXO transaction hash for update/unregister operations. */
   readonly utxoTxHash: Maybe<Scalars['HexEncoded']['output']>;
+};
+
+/** Dust generations for a Cardano reward address. */
+export type DustGenerations = {
+  /** The Bech32-encoded Cardano reward address. */
+  readonly cardanoRewardAddress: Scalars['CardanoRewardAddress']['output'];
+  /** All active registrations with aggregated generation stats. */
+  readonly registrations: ReadonlyArray<DustRegistration>;
+};
+
+/** An event of the dust generations subscription. */
+export type DustGenerationsEvent = DustGenerationDtimeUpdateItem | DustGenerationsItem | DustGenerationsProgress;
+
+/** A dust generations item with optional collapsed Merkle tree update. */
+export type DustGenerationsItem = {
+  /** Hex-encoded hash of the NIGHT UTXO that backs this dust output. */
+  readonly backingNight: Scalars['HexEncoded']['output'];
+  /** Collapsed Merkle tree update filling the gap before this entry. */
+  readonly collapsedMerkleTree: Maybe<MerkleTreeCollapsedUpdate>;
+  /** Index of this output in the dust commitment Merkle tree. */
+  readonly commitmentMtIndex: Scalars['Int']['output'];
+  /** The creation timestamp. */
+  readonly ctime: Scalars['Int']['output'];
+  /** Index of this output in the dust generation Merkle tree. */
+  readonly generationMtIndex: Scalars['Int']['output'];
+  /** The DUST value at creation, in SPECK. */
+  readonly initialValue: Scalars['String']['output'];
+  /** The hex-encoded owner (dust address). */
+  readonly owner: Scalars['HexEncoded']['output'];
+  /** The hex-encoded originating transaction hash (32-byte chain identifier). */
+  readonly transactionHash: Scalars['HexEncoded']['output'];
+  /** The originating transaction ID (indexer-internal BIGSERIAL). */
+  readonly transactionId: Scalars['Int']['output'];
+  /** The NIGHT value backing this output, in STAR. */
+  readonly value: Scalars['String']['output'];
+};
+
+/** Progress indicator for dust generations subscription (includes final collapsed update). */
+export type DustGenerationsProgress = {
+  /** Final collapsed Merkle tree update covering remaining range. */
+  readonly collapsedMerkleTree: Maybe<MerkleTreeCollapsedUpdate>;
+  /** The highest index processed so far. */
+  readonly highestIndex: Scalars['Int']['output'];
 };
 
 export type DustInitialUtxo = DustLedgerEvent & {
@@ -223,10 +401,48 @@ export type DustLedgerEvent = {
   readonly raw: Scalars['HexEncoded']['output'];
 };
 
+/** A transaction containing a dust nullifier match with block context. */
+export type DustNullifierTransaction = {
+  /** The hex-encoded block hash (use to query block with ledger parameters). */
+  readonly blockHash: Scalars['HexEncoded']['output'];
+  /** The block height containing this transaction. */
+  readonly blockHeight: Scalars['Int']['output'];
+  /** The hex-encoded commitment, in 32-byte little-endian form. */
+  readonly commitmentLeBytes: Scalars['HexEncoded']['output'];
+  /** The hex-encoded matched nullifier, in 32-byte little-endian form. */
+  readonly nullifierLeBytes: Scalars['HexEncoded']['output'];
+  /** The transaction containing this nullifier match. */
+  readonly transaction: Transaction;
+  /** The hex-encoded transaction hash (32-byte chain identifier). */
+  readonly transactionHash: Scalars['HexEncoded']['output'];
+  /** The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor). */
+  readonly transactionId: Scalars['Int']['output'];
+};
+
 /** A dust output. */
 export type DustOutput = {
   /** The hex-encoded 32-byte nonce. */
   readonly nonce: Scalars['HexEncoded']['output'];
+};
+
+/** A single dust registration with aggregated generation stats. */
+export type DustRegistration = {
+  /** Current generated DUST capacity in SPECK. */
+  readonly currentCapacity: Scalars['String']['output'];
+  /** The Bech32m-encoded DUST address. */
+  readonly dustAddress: Scalars['DustAddress']['output'];
+  /** DUST generation rate in SPECK per second. */
+  readonly generationRate: Scalars['String']['output'];
+  /** Maximum DUST capacity in SPECK. */
+  readonly maxCapacity: Scalars['String']['output'];
+  /** NIGHT balance backing generation in STAR. */
+  readonly nightBalance: Scalars['String']['output'];
+  /** Cardano UTXO output index. */
+  readonly utxoOutputIndex: Maybe<Scalars['Int']['output']>;
+  /** Cardano UTXO transaction hash. */
+  readonly utxoTxHash: Maybe<Scalars['HexEncoded']['output']>;
+  /** Whether this registration is valid. */
+  readonly valid: Scalars['Boolean']['output'];
 };
 
 export type DustSpendProcessed = DustLedgerEvent & {
@@ -259,10 +475,58 @@ export type EpochPerf = {
   readonly validatorClass: Maybe<Scalars['String']['output']>;
 };
 
+/**
+ * Prefix filter on an indexed field of a standard event. Indexer resolves
+ * `fieldName` for all standard events from the variant; no descriptor needed.
+ * Not supported on Misc events.
+ */
+export type FieldPrefixFilter = {
+  /**
+   * Field name (e.g. `nullifier`, `commitment`, `sender`). Must match an
+   * indexed field of the filtered event type.
+   */
+  readonly fieldName: Scalars['String']['input'];
+  /**
+   * Hex-encoded prefix bytes. Empty string matches all values; otherwise
+   * the indexer returns events whose field value starts with this prefix,
+   * client filters to exact match if needed.
+   */
+  readonly prefix: Scalars['HexEncoded']['input'];
+};
+
 /** First valid epoch for an SPO identity. */
 export type FirstValidEpoch = {
   readonly firstValidEpoch: Scalars['Int']['output'];
   readonly idKey: Scalars['String']['output'];
+};
+
+/** A Merkle tree collapsed update between two indices. */
+export type MerkleTreeCollapsedUpdate = {
+  /** The end index. */
+  readonly endIndex: Scalars['Int']['output'];
+  /** The protocol version. */
+  readonly protocolVersion: Scalars['Int']['output'];
+  /** The start index. */
+  readonly startIndex: Scalars['Int']['output'];
+  /** The hex-encoded value. */
+  readonly update: Scalars['HexEncoded']['output'];
+};
+
+export type MiscContractEvent = ContractEvent & {
+  readonly contractAddress: Scalars['HexEncoded']['output'];
+  readonly id: Scalars['Int']['output'];
+  readonly maxId: Scalars['Int']['output'];
+  /** Hex-encoded contract-defined event name (Compact Bytes<32>). */
+  readonly name: Scalars['HexEncoded']['output'];
+  /**
+   * Hex-encoded opaque payload (Compact Bytes<256>); consumer brings
+   * descriptor to decode.
+   */
+  readonly payload: Scalars['HexEncoded']['output'];
+  readonly protocolVersion: Scalars['Int']['output'];
+  readonly raw: Scalars['HexEncoded']['output'];
+  readonly transactionId: Scalars['Int']['output'];
+  readonly version: Scalars['Int']['output'];
 };
 
 export type Mutation = {
@@ -274,6 +538,7 @@ export type Mutation = {
 
 
 export type MutationConnectArgs = {
+  options: InputMaybe<ConnectOptions>;
   viewingKey: Scalars['ViewingKey']['input'];
 };
 
@@ -291,6 +556,16 @@ export type ParamChange = DustLedgerEvent & {
   readonly protocolVersion: Scalars['Int']['output'];
   /** The hex-encoded serialized event. */
   readonly raw: Scalars['HexEncoded']['output'];
+};
+
+export type PausedEvent = ContractEvent & {
+  readonly contractAddress: Scalars['HexEncoded']['output'];
+  readonly id: Scalars['Int']['output'];
+  readonly maxId: Scalars['Int']['output'];
+  readonly protocolVersion: Scalars['Int']['output'];
+  readonly raw: Scalars['HexEncoded']['output'];
+  readonly transactionId: Scalars['Int']['output'];
+  readonly version: Scalars['Int']['output'];
 };
 
 /** Pool metadata from Cardano. */
@@ -318,12 +593,28 @@ export type Query = {
   readonly committee: ReadonlyArray<CommitteeMember>;
   /** Find a contract action for the given address and optional offset. */
   readonly contractAction: Maybe<ContractAction>;
+  /**
+   * Find contract events matching the filter, with optional pagination.
+   *
+   * Block-range bounds (`fromBlock`, `toBlock`) live on `ContractEventFilter`
+   * for symmetry with the subscription. `limit`/`offset` are top-level args.
+   */
+  readonly contractEvents: ReadonlyArray<ContractEvent>;
   /** Get current epoch information. */
   readonly currentEpochInfo: Maybe<EpochInfo>;
   /** Get the full history of D-parameter changes for governance auditability. */
   readonly dParameterHistory: ReadonlyArray<DParameterChange>;
+  /** Get a collapsed Merkle tree update for the dust commitment tree. */
+  readonly dustCommitmentMerkleTreeUpdate: MerkleTreeCollapsedUpdate;
+  /** Get a collapsed Merkle tree update for the dust generation tree. */
+  readonly dustGenerationMerkleTreeUpdate: MerkleTreeCollapsedUpdate;
   /** Get DUST generation status for specific Cardano reward addresses. */
   readonly dustGenerationStatus: ReadonlyArray<DustGenerationStatus>;
+  /**
+   * Get all active DUST registrations and aggregated generation stats for Cardano reward
+   * addresses.
+   */
+  readonly dustGenerations: ReadonlyArray<DustGenerations>;
   /** Get epoch performance for all SPOs. */
   readonly epochPerformance: ReadonlyArray<EpochPerf>;
   /** Get epoch utilization (produced/expected ratio). */
@@ -364,6 +655,8 @@ export type Query = {
   readonly termsAndConditionsHistory: ReadonlyArray<TermsAndConditionsChange>;
   /** Find transactions for the given offset. */
   readonly transactions: ReadonlyArray<Transaction>;
+  /** Get a Merkle tree collapsed update for the given zswap state index range. */
+  readonly zswapMerkleTreeCollapsedUpdate: MerkleTreeCollapsedUpdate;
 };
 
 
@@ -383,7 +676,31 @@ export type QueryContractActionArgs = {
 };
 
 
+export type QueryContractEventsArgs = {
+  filter: ContractEventFilter;
+  limit: InputMaybe<Scalars['Int']['input']>;
+  offset: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type QueryDustCommitmentMerkleTreeUpdateArgs = {
+  endIndex: Scalars['Int']['input'];
+  startIndex: Scalars['Int']['input'];
+};
+
+
+export type QueryDustGenerationMerkleTreeUpdateArgs = {
+  endIndex: Scalars['Int']['input'];
+  startIndex: Scalars['Int']['input'];
+};
+
+
 export type QueryDustGenerationStatusArgs = {
+  cardanoRewardAddresses: ReadonlyArray<Scalars['CardanoRewardAddress']['input']>;
+};
+
+
+export type QueryDustGenerationsArgs = {
   cardanoRewardAddresses: ReadonlyArray<Scalars['CardanoRewardAddress']['input']>;
 };
 
@@ -493,6 +810,12 @@ export type QueryTransactionsArgs = {
   offset: TransactionOffset;
 };
 
+
+export type QueryZswapMerkleTreeCollapsedUpdateArgs = {
+  endIndex: Scalars['Int']['input'];
+  startIndex: Scalars['Int']['input'];
+};
+
 /** Registration statistics for an epoch. */
 export type RegisteredStat = {
   readonly dparam: Maybe<Scalars['Float']['output']>;
@@ -516,11 +839,27 @@ export type RegularTransaction = Transaction & {
   readonly block: Block;
   /** The contract actions for this transaction. */
   readonly contractActions: ReadonlyArray<ContractAction>;
+  /** The dust commitment tree end index. */
+  readonly dustCommitmentEndIndex: Scalars['Int']['output'];
+  /** The dust commitment tree start index. */
+  readonly dustCommitmentStartIndex: Scalars['Int']['output'];
+  /** The dust generation tree end index. */
+  readonly dustGenerationEndIndex: Scalars['Int']['output'];
+  /** The dust generation tree start index. */
+  readonly dustGenerationStartIndex: Scalars['Int']['output'];
   /** Dust ledger events of this transaction. */
   readonly dustLedgerEvents: ReadonlyArray<DustLedgerEvent>;
-  /** The zswap state end index. */
+  /**
+   * The end index into the zswap state; exclusive, i.e. the next free index.
+   * @deprecated Use zswapEndIndex instead
+   */
   readonly endIndex: Scalars['Int']['output'];
-  /** Fee information for this transaction. */
+  /** The fee for this transaction in SPECK (atomic unit of DUST). */
+  readonly fee: Scalars['String']['output'];
+  /**
+   * Fee information for this transaction.
+   * @deprecated Use fee instead
+   */
   readonly fees: TransactionFees;
   /** The hex-encoded transaction hash. */
   readonly hash: Scalars['HexEncoded']['output'];
@@ -528,13 +867,19 @@ export type RegularTransaction = Transaction & {
   readonly id: Scalars['Int']['output'];
   /** The hex-encoded serialized transaction identifiers. */
   readonly identifiers: ReadonlyArray<Scalars['HexEncoded']['output']>;
-  /** The hex-encoded serialized merkle-tree root. */
+  /**
+   * The hex-encoded serialized zswap state Merkle tree root.
+   * @deprecated Use zswapMerkleTreeRoot instead
+   */
   readonly merkleTreeRoot: Scalars['HexEncoded']['output'];
   /** The protocol version. */
   readonly protocolVersion: Scalars['Int']['output'];
   /** The hex-encoded serialized transaction content. */
   readonly raw: Scalars['HexEncoded']['output'];
-  /** The zswap state start index. */
+  /**
+   * The start index into the zswap state.
+   * @deprecated Use zswapStartIndex instead
+   */
   readonly startIndex: Scalars['Int']['output'];
   /** The result of applying this transaction to the ledger state. */
   readonly transactionResult: TransactionResult;
@@ -542,16 +887,34 @@ export type RegularTransaction = Transaction & {
   readonly unshieldedCreatedOutputs: ReadonlyArray<UnshieldedUtxo>;
   /** Unshielded UTXOs spent (consumed) by this transaction. */
   readonly unshieldedSpentOutputs: ReadonlyArray<UnshieldedUtxo>;
+  /** The end index into the zswap state; exclusive, i.e. the next free index. */
+  readonly zswapEndIndex: Scalars['Int']['output'];
   /** Zswap ledger events of this transaction. */
   readonly zswapLedgerEvents: ReadonlyArray<ZswapLedgerEvent>;
+  /** The hex-encoded serialized zswap state Merkle tree root. */
+  readonly zswapMerkleTreeRoot: Scalars['HexEncoded']['output'];
+  /** The start index into the zswap state. */
+  readonly zswapStartIndex: Scalars['Int']['output'];
 };
 
-/** A transaction relevant for the subscribing wallet and an optional collapsed merkle tree. */
+/**
+ * A transaction relevant for the subscribing wallet and an optional zswap state Merkle tree
+ * collapsed update.
+ */
 export type RelevantTransaction = {
-  /** An optional collapsed merkle tree. */
+  /**
+   * An optional collapsed Merkle tree.
+   * @deprecated Use zswapCollapsedUpdate instead
+   */
   readonly collapsedMerkleTree: Maybe<CollapsedMerkleTree>;
   /** A transaction relevant for the subscribing wallet. */
   readonly transaction: RegularTransaction;
+  /**
+   * Only include a zswap state Merkle tree collapsed update if there is a gap between the
+   * current zswap index "driving" the subscription and the zswap start index of the
+   * transaction.
+   */
+  readonly zswapCollapsedUpdate: Maybe<MerkleTreeCollapsedUpdate>;
 };
 
 /**
@@ -565,31 +928,136 @@ export type Segment = {
   readonly success: Scalars['Boolean']['output'];
 };
 
+export type ShieldedBurnEvent = ContractEvent & {
+  /** Optional, hidden in some shielded burns (`Maybe<Uint<128>>`). */
+  readonly amount: Maybe<Scalars['String']['output']>;
+  readonly contractAddress: Scalars['HexEncoded']['output'];
+  readonly id: Scalars['Int']['output'];
+  readonly maxId: Scalars['Int']['output'];
+  /** Indexed. */
+  readonly nullifier: Scalars['HexEncoded']['output'];
+  readonly protocolVersion: Scalars['Int']['output'];
+  readonly raw: Scalars['HexEncoded']['output'];
+  readonly transactionId: Scalars['Int']['output'];
+  readonly version: Scalars['Int']['output'];
+};
+
+export type ShieldedMintEvent = ContractEvent & {
+  /** Optional, hidden in some shielded mints (`Maybe<Uint<128>>`). */
+  readonly amount: Maybe<Scalars['String']['output']>;
+  /** Indexed. */
+  readonly commitment: Scalars['HexEncoded']['output'];
+  readonly contractAddress: Scalars['HexEncoded']['output'];
+  /** Indexed (per Andrzej, useful for token-type queries). */
+  readonly domainSep: Scalars['HexEncoded']['output'];
+  readonly id: Scalars['Int']['output'];
+  readonly maxId: Scalars['Int']['output'];
+  readonly protocolVersion: Scalars['Int']['output'];
+  readonly raw: Scalars['HexEncoded']['output'];
+  readonly transactionId: Scalars['Int']['output'];
+  readonly version: Scalars['Int']['output'];
+};
+
+/** A transaction containing a shielded (zswap) nullifier match with block context. */
+export type ShieldedNullifierTransaction = {
+  /** The hex-encoded block hash (use to query block with ledger parameters). */
+  readonly blockHash: Scalars['HexEncoded']['output'];
+  /** The block height containing this transaction. */
+  readonly blockHeight: Scalars['Int']['output'];
+  /** The hex-encoded matched nullifier. */
+  readonly nullifier: Scalars['HexEncoded']['output'];
+  /** The transaction containing this nullifier match. */
+  readonly transaction: Transaction;
+  /** The hex-encoded transaction hash (32-byte chain identifier). */
+  readonly transactionHash: Scalars['HexEncoded']['output'];
+  /** The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor). */
+  readonly transactionId: Scalars['Int']['output'];
+};
+
+export type ShieldedReceiveEvent = ContractEvent & {
+  /**
+   * Indexed. Optional ciphertext for shielded coin receipt
+   * (`Maybe<Bytes<512>>`). Hex-encoded, up to 512 bytes.
+   */
+  readonly ciphertext: Maybe<Scalars['HexEncoded']['output']>;
+  /** Indexed. */
+  readonly commitment: Scalars['HexEncoded']['output'];
+  readonly contractAddress: Scalars['HexEncoded']['output'];
+  readonly id: Scalars['Int']['output'];
+  readonly maxId: Scalars['Int']['output'];
+  readonly protocolVersion: Scalars['Int']['output'];
+  readonly raw: Scalars['HexEncoded']['output'];
+  /**
+   * Set when received by a contract; null for user recipients
+   * (`Maybe<ContractAddress>`). Renamed from `contractAddress` in the CoIP
+   * to avoid collision with the top-level emitting `contractAddress`
+   * inherited from the ContractEvent interface.
+   */
+  readonly receivingContractAddress: Maybe<Scalars['HexEncoded']['output']>;
+  readonly transactionId: Scalars['Int']['output'];
+  readonly version: Scalars['Int']['output'];
+};
+
+export type ShieldedSpendEvent = ContractEvent & {
+  readonly contractAddress: Scalars['HexEncoded']['output'];
+  readonly id: Scalars['Int']['output'];
+  readonly maxId: Scalars['Int']['output'];
+  /** Indexed. */
+  readonly nullifier: Scalars['HexEncoded']['output'];
+  readonly protocolVersion: Scalars['Int']['output'];
+  readonly raw: Scalars['HexEncoded']['output'];
+  readonly transactionId: Scalars['Int']['output'];
+  readonly version: Scalars['Int']['output'];
+};
+
 /** An event of the shielded transactions subscription. */
 export type ShieldedTransactionsEvent = RelevantTransaction | ShieldedTransactionsProgress;
 
 /** Information about the shielded transactions indexing progress. */
 export type ShieldedTransactionsProgress = {
   /**
-   * The highest zswap state end index (see `endIndex` of `Transaction`) of all transactions
-   * checked for relevance. Initially less than and eventually (when some wallet has been fully
-   * indexed) equal to `highest_end_index`. A value of zero (very unlikely) means that no wallet
+   * The highest highest end index into the zswap state for all transactions checked for
+   * relevance. Initially less than and eventually (when some wallet has been fully indexed)
+   * equal to `highest_end_index`. A value of zero (very unlikely) means that no wallet
    * has subscribed before and indexing for the subscribing wallet has not yet started.
+   * @deprecated Use highestCheckedZswapEndIndex instead
    */
   readonly highestCheckedEndIndex: Scalars['Int']['output'];
   /**
-   * The highest zswap state end index (see `endIndex` of `Transaction`) of all transactions. It
-   * represents the known state of the blockchain. A value of zero (completely unlikely) means
-   * that no shielded transactions have been indexed yet.
+   * The highest highest end index into the zswap state for all transactions checked for
+   * relevance. Initially less than and eventually (when some wallet has been fully indexed)
+   * equal to `highest_end_index`. A value of zero (very unlikely) means that no wallet
+   * has subscribed before and indexing for the subscribing wallet has not yet started.
+   */
+  readonly highestCheckedZswapEndIndex: Scalars['Int']['output'];
+  /**
+   * The highest end index into the zswap state for all transactions. It represents the known
+   * state of the blockchain. A value of zero (completely unlikely) means that no shielded
+   * transactions have been indexed yet.
+   * @deprecated Use highestZswapEndIndex instead
    */
   readonly highestEndIndex: Scalars['Int']['output'];
   /**
-   * The highest zswap state end index (see `endIndex` of `Transaction`) of all relevant
-   * transactions for the subscribing wallet. Usually less than `highest_checked_end_index`
-   * unless the latest checked transaction is relevant for the subscribing wallet. A value of
-   * zero means that no relevant transactions have been indexed for the subscribing wallet.
+   * The highest highest end index into the zswap state for all relevant transactions for the
+   * subscribing wallet. Usually less than `highest_checked_end_index` unless the latest
+   * checked transaction is relevant for the subscribing wallet. A value of zero means that
+   * no relevant transactions have been indexed for the subscribing wallet.
+   * @deprecated Use highestRelevantZswapEndIndex instead
    */
   readonly highestRelevantEndIndex: Scalars['Int']['output'];
+  /**
+   * The highest highest end index into the zswap state for all relevant transactions for the
+   * subscribing wallet. Usually less than `highest_checked_end_index` unless the latest
+   * checked transaction is relevant for the subscribing wallet. A value of zero means that
+   * no relevant transactions have been indexed for the subscribing wallet.
+   */
+  readonly highestRelevantZswapEndIndex: Scalars['Int']['output'];
+  /**
+   * The highest end index into the zswap state for all transactions. It represents the known
+   * state of the blockchain. A value of zero (completely unlikely) means that no shielded
+   * transactions have been indexed yet.
+   */
+  readonly highestZswapEndIndex: Scalars['Int']['output'];
 };
 
 /** SPO with optional metadata. */
@@ -663,8 +1131,32 @@ export type Subscription = {
    * latest block if the offset is omitted.
    */
   readonly contractActions: ContractAction;
+  /**
+   * Subscribe to contract events matching the given filter, returning
+   * events in monotonic `id` order.
+   */
+  readonly contractEvents: ContractEvent;
+  /**
+   * Subscribe to dust generation entries for a dust address in `[start_index, end_index]`
+   * inclusive. `dustGenerationEndIndex` is exclusive, pass `dustGenerationEndIndex - 1`.
+   * Entries interleaved with collapsed Merkle tree updates and owned-entry dtime updates.
+   */
+  readonly dustGenerations: DustGenerationsEvent;
   /** Subscribe to dust ledger events starting at the given ID or at the very start if omitted. */
   readonly dustLedgerEvents: DustLedgerEvent;
+  /**
+   * Subscribe to transactions containing dust nullifiers whose 32-byte little-endian form
+   * starts with one of the provided prefixes. Returns transaction and block references for
+   * the wallet to fetch full data. If `toBlock` is specified, the subscription finishes
+   * after reaching that block.
+   */
+  readonly dustNullifierTransactions: DustNullifierTransaction;
+  /**
+   * Subscribe to transactions containing shielded (zswap) nullifiers matching the provided
+   * prefixes. Returns transaction and block references for wallet to fetch full data.
+   * If `toBlock` is specified, the subscription finishes after reaching that block.
+   */
+  readonly shieldedNullifierTransactions: ShieldedNullifierTransaction;
   /**
    * Subscribe to shielded transaction events for the given session ID starting at the given
    * index or at zero if omitted.
@@ -691,8 +1183,35 @@ export type SubscriptionContractActionsArgs = {
 };
 
 
+export type SubscriptionContractEventsArgs = {
+  filter: ContractEventFilter;
+  id: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type SubscriptionDustGenerationsArgs = {
+  dustAddress: Scalars['DustAddress']['input'];
+  endIndex: Scalars['Int']['input'];
+  startIndex: Scalars['Int']['input'];
+};
+
+
 export type SubscriptionDustLedgerEventsArgs = {
   id: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type SubscriptionDustNullifierTransactionsArgs = {
+  fromBlock: InputMaybe<Scalars['Int']['input']>;
+  nullifierLeBytesPrefixes: ReadonlyArray<Scalars['HexEncoded']['input']>;
+  toBlock: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type SubscriptionShieldedNullifierTransactionsArgs = {
+  fromBlock: InputMaybe<Scalars['Int']['input']>;
+  nullifierPrefixes: ReadonlyArray<Scalars['HexEncoded']['input']>;
+  toBlock: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -780,11 +1299,14 @@ export type Transaction = {
   readonly zswapLedgerEvents: ReadonlyArray<ZswapLedgerEvent>;
 };
 
-/** Fees information for a transaction, including both paid and estimated fees. */
+/** Fees information for a transaction. */
 export type TransactionFees = {
-  /** The estimated fees that was calculated for this transaction in DUST. */
+  /**
+   * The fees for this transaction in SPECK (atomic unit of DUST).
+   * @deprecated Use paidFees instead
+   */
   readonly estimatedFees: Scalars['String']['output'];
-  /** The actual fees paid for this transaction in DUST. */
+  /** The fees for this transaction in SPECK (atomic unit of DUST). */
   readonly paidFees: Scalars['String']['output'];
 };
 
@@ -810,6 +1332,80 @@ export type TransactionResultStatus =
   | 'PARTIAL_SUCCESS'
   | 'SUCCESS'
   | '%future added value';
+
+export type UnpausedEvent = ContractEvent & {
+  readonly contractAddress: Scalars['HexEncoded']['output'];
+  readonly id: Scalars['Int']['output'];
+  readonly maxId: Scalars['Int']['output'];
+  readonly protocolVersion: Scalars['Int']['output'];
+  readonly raw: Scalars['HexEncoded']['output'];
+  readonly transactionId: Scalars['Int']['output'];
+  readonly version: Scalars['Int']['output'];
+};
+
+export type UnshieldedBurnEvent = ContractEvent & {
+  readonly amount: Scalars['String']['output'];
+  readonly contractAddress: Scalars['HexEncoded']['output'];
+  readonly id: Scalars['Int']['output'];
+  readonly maxId: Scalars['Int']['output'];
+  readonly protocolVersion: Scalars['Int']['output'];
+  readonly raw: Scalars['HexEncoded']['output'];
+  /** Indexed. */
+  readonly sender: AddressOrContract;
+  /** Indexed; matches existing unshielded_utxos.token_type index. */
+  readonly tokenType: Scalars['HexEncoded']['output'];
+  readonly transactionId: Scalars['Int']['output'];
+  readonly version: Scalars['Int']['output'];
+};
+
+export type UnshieldedMintEvent = ContractEvent & {
+  readonly amount: Scalars['String']['output'];
+  readonly contractAddress: Scalars['HexEncoded']['output'];
+  /** Indexed. */
+  readonly domainSep: Scalars['HexEncoded']['output'];
+  readonly id: Scalars['Int']['output'];
+  readonly maxId: Scalars['Int']['output'];
+  readonly protocolVersion: Scalars['Int']['output'];
+  readonly raw: Scalars['HexEncoded']['output'];
+  /** Indexed; matches existing unshielded_utxos.token_type index. */
+  readonly tokenType: Scalars['HexEncoded']['output'];
+  readonly transactionId: Scalars['Int']['output'];
+  readonly version: Scalars['Int']['output'];
+};
+
+export type UnshieldedReceiveEvent = ContractEvent & {
+  readonly amount: Scalars['String']['output'];
+  readonly contractAddress: Scalars['HexEncoded']['output'];
+  /** Indexed. */
+  readonly domainSep: Scalars['HexEncoded']['output'];
+  readonly id: Scalars['Int']['output'];
+  readonly maxId: Scalars['Int']['output'];
+  readonly protocolVersion: Scalars['Int']['output'];
+  readonly raw: Scalars['HexEncoded']['output'];
+  /** Indexed. */
+  readonly recipient: AddressOrContract;
+  /** Indexed; matches existing unshielded_utxos.token_type index. */
+  readonly tokenType: Scalars['HexEncoded']['output'];
+  readonly transactionId: Scalars['Int']['output'];
+  readonly version: Scalars['Int']['output'];
+};
+
+export type UnshieldedSpendEvent = ContractEvent & {
+  readonly amount: Scalars['String']['output'];
+  readonly contractAddress: Scalars['HexEncoded']['output'];
+  /** Indexed. */
+  readonly domainSep: Scalars['HexEncoded']['output'];
+  readonly id: Scalars['Int']['output'];
+  readonly maxId: Scalars['Int']['output'];
+  readonly protocolVersion: Scalars['Int']['output'];
+  readonly raw: Scalars['HexEncoded']['output'];
+  /** Indexed. */
+  readonly sender: AddressOrContract;
+  /** Indexed; matches existing unshielded_utxos.token_type index. */
+  readonly tokenType: Scalars['HexEncoded']['output'];
+  readonly transactionId: Scalars['Int']['output'];
+  readonly version: Scalars['Int']['output'];
+};
 
 /** A transaction that created and/or spent UTXOs alongside these and other information. */
 export type UnshieldedTransaction = {


### PR DESCRIPTION
# Overview

Updates `packages/indexer-public-data-provider/schema.graphql` to the latest indexer schema (v4 events) and regenerates `src/gen/graphql.ts` accordingly. **Schema + codegen only — no consumer code changes.**

Cherry-picked from `chore/indexer-schema-v4-events` (commit `2243b1a6`). Subsequent commits on that branch build the feature (contractEvents API, decoders, integration) on top of this schema; this PR carries only the schema/codegen so the consumer feature can land in a separate, focused PR.

## Notable schema additions

- `AddressOrContract` / `AddressOrContractKind` — tagged-union helper for `Either<ZswapCoinPublicKey, ContractAddress>` in standard unshielded events
- Expanded contract event types
- Dust generation support types

## Submission Checklist

- [x] Useful pull request description
- [ ] Tests are provided (if possible) — N/A, schema/codegen only
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant) — N/A
- [ ] Update documentation (if relevant) — N/A
- [x] No new todos introduced

## Links

<!-- Add Jira/Confluence links if applicable -->