### PR TITLE
build(testkit-js): build compact-runtime from compact/ submodule (opt-in)

### DIFF
--- a/.github/workflows/ci-testkit-js-build.yml
+++ b/.github/workflows/ci-testkit-js-build.yml
@@ -91,27 +91,17 @@ jobs:
       - name: Configure yarn
         run: yarn config set 'npmScopes.midnight-ntwrk.npmAuthToken' ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
 
-      - name: Cache Turbo and Yarn dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5.0.5
-        with:
-          path: |
-            **/node_modules
-            ~/.yarn
-            .turbo
-          key: turbo-testkit-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/turbo.json') }}
-          restore-keys: |
-            turbo-testkit-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: |
-          yarn install --immutable
-
       # Opt-in compactc build from the `compact/` submodule (feature-branch dev
       # against unreleased compactc). Activated by either:
       #   * workflow_dispatch input `compactc_source=submodule`, or
       #   * PR label `compactc-from-source`.
       # When active, `packages/compact/run-compactc` uses COMPACT_HOME and
-      # `fetch-compactc` skips the prebuilt-binary download.
+      # `fetch-compactc` skips the prebuilt-binary download; the source-built
+      # @midnight-ntwrk/compact-runtime is also injected before yarn install.
+      #
+      # Computed BEFORE the cache key so opt-in and default paths use disjoint
+      # cache buckets, preventing a mutated yarn.lock from one path from
+      # poisoning the other on subsequent runs.
       - name: Detect compactc build mode
         id: compactc-mode
         env:
@@ -125,6 +115,21 @@ jobs:
             echo "should_build=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Cache Turbo and Yarn dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5.0.5
+        with:
+          path: |
+            **/node_modules
+            ~/.yarn
+            .turbo
+          key: turbo-testkit-${{ runner.os }}-${{ steps.compactc-mode.outputs.should_build }}-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/turbo.json') }}
+          restore-keys: |
+            turbo-testkit-${{ runner.os }}-${{ steps.compactc-mode.outputs.should_build }}-
+
+      # Conditional compactc/runtime source build runs BEFORE yarn install so
+      # only a single install happens (no `--immutable` re-install after a
+      # mutated package.json). The portal/file resolution for the runtime is
+      # in place by the time yarn resolves the dependency tree.
       - name: Init compact submodule
         if: steps.compactc-mode.outputs.should_build == 'true'
         run: git submodule update --init --recursive compact
@@ -145,23 +150,22 @@ jobs:
           ./scripts/build-compactc.sh
           echo "COMPACT_HOME=$GITHUB_WORKSPACE/.compact-home" >> "$GITHUB_ENV"
 
-      # Pair the compactc opt-in with @midnight-ntwrk/compact-runtime built
-      # from the same submodule. The runtime is laid out at .compact-runtime-home
-      # and pulled into the workspace via a Yarn portal: resolution; without it,
-      # protocol/package.json would still consume the npm-published runtime,
-      # which can pair-mismatch a feature-branch compactc.
       - name: Build compact-runtime from submodule
         if: steps.compactc-mode.outputs.should_build == 'true'
         run: ./scripts/build-compact-runtime.sh
 
-      - name: Inject portal:./.compact-runtime-home resolution
+      - name: Inject file:./.compact-runtime-home resolution
         if: steps.compactc-mode.outputs.should_build == 'true'
         run: node scripts/use-source-compact-runtime.js
 
-      - name: Re-install dependencies with portal resolution
+      - name: Install dependencies (default path, immutable)
+        if: steps.compactc-mode.outputs.should_build != 'true'
+        run: yarn install --immutable
+
+      - name: Install dependencies (source-build opt-in)
         if: steps.compactc-mode.outputs.should_build == 'true'
-        # package.json was mutated by the previous step, so yarn install must
-        # run without --immutable to materialize the portal: link.
+        # package.json was mutated by the resolution-inject step, so yarn install
+        # must run without --immutable.
         run: yarn install
 
       - name: Run build

--- a/.github/workflows/ci-testkit-js-build.yml
+++ b/.github/workflows/ci-testkit-js-build.yml
@@ -145,6 +145,25 @@ jobs:
           ./scripts/build-compactc.sh
           echo "COMPACT_HOME=$GITHUB_WORKSPACE/.compact-home" >> "$GITHUB_ENV"
 
+      # Pair the compactc opt-in with @midnight-ntwrk/compact-runtime built
+      # from the same submodule. The runtime is laid out at .compact-runtime-home
+      # and pulled into the workspace via a Yarn portal: resolution; without it,
+      # protocol/package.json would still consume the npm-published runtime,
+      # which can pair-mismatch a feature-branch compactc.
+      - name: Build compact-runtime from submodule
+        if: steps.compactc-mode.outputs.should_build == 'true'
+        run: ./scripts/build-compact-runtime.sh
+
+      - name: Inject portal:./.compact-runtime-home resolution
+        if: steps.compactc-mode.outputs.should_build == 'true'
+        run: node scripts/use-source-compact-runtime.js
+
+      - name: Re-install dependencies with portal resolution
+        if: steps.compactc-mode.outputs.should_build == 'true'
+        # package.json was mutated by the previous step, so yarn install must
+        # run without --immutable to materialize the portal: link.
+        run: yarn install
+
       - name: Run build
         run: yarn build ${{ inputs.yarn_filter }} --cache-dir ./turbo
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ midnight-concurrent-test-db
 
 # Generated compactc wrapper from scripts/build-compactc.sh (points into the nix store)
 .compact-home/
+
+# Locally-built @midnight-ntwrk/compact-runtime npm package (Yarn portal: target)
+.compact-runtime-home/
+.compact-runtime-home-build/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+node scripts/check-no-source-leak.js
 npx lint-staged

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -305,7 +305,7 @@ pull request.
 
 A feature-branch compactc can emit code that requires a paired
 `@midnight-ntwrk/compact-runtime`. Build the runtime npm package from the
-same submodule and point Yarn at it via a `portal:` resolution:
+same submodule and point Yarn at it via a `file:` resolution:
 
 ```bash
 # Path A: native nix

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -301,6 +301,37 @@ CI, either trigger the `CI` workflow via `workflow_dispatch` with input
 `compactc_source=submodule`, or add the `compactc-from-source` label to your
 pull request.
 
+### Pairing with `@midnight-ntwrk/compact-runtime` from the same submodule
+
+A feature-branch compactc can emit code that requires a paired
+`@midnight-ntwrk/compact-runtime`. Build the runtime npm package from the
+same submodule and point Yarn at it via a `portal:` resolution:
+
+```bash
+# Path A: native nix
+./scripts/build-compact-runtime.sh
+
+# Path B: Docker (no host nix)
+./scripts/build-compact-runtime-docker.sh
+
+# Inject the resolution into root package.json, then install.
+node scripts/use-source-compact-runtime.js
+yarn install   # without --immutable; the previous step mutated package.json
+```
+
+`packages/protocol` (the only consumer) now resolves to
+`./.compact-runtime-home/`. To revert when done:
+
+```bash
+node scripts/use-source-compact-runtime.js --restore
+yarn install
+```
+
+In CI, the same `compactc-from-source` opt-in (PR label or workflow_dispatch
+input `compactc_source=submodule`) builds both compactc and compact-runtime
+and injects the portal resolution before `yarn build` — so the pair is
+always coherent.
+
 ## Troubleshooting
 
 See [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for common issues and solutions.

--- a/packages/http-client-proof-provider/package.json
+++ b/packages/http-client-proof-provider/package.json
@@ -23,7 +23,7 @@
     "clean": "rm -rf dist tsconfig.build.tsbuildinfo .rollup.cache reports coverage logs src/test/resources/compiled",
     "compact": "yarn fetch-compactc && yarn compact-simple",
     "compact-simple": "run-compactc src/test/resources/simple.compact ./src/test/resources/compiled/simple",
-    "build": "node ../../scripts/check-compiled.js src/test/resources/compiled && rollup -c rollup.config.mjs",
+    "build": "node ../../scripts/check-compiled.js src/test/resources/compiled --force-on-compact-home && rollup -c rollup.config.mjs",
     "test": "vitest run",
     "deploy": "yarn npm publish --tolerate-republish"
   },

--- a/scripts/build-compact-runtime-docker.sh
+++ b/scripts/build-compact-runtime-docker.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# This file is part of midnight-js.
+# Copyright (C) 2025-2026 Midnight Foundation
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build @midnight-ntwrk/compact-runtime from the `compact/` submodule inside a
+# Docker container, so developers without host nix can still produce the
+# `.compact-runtime-home/` npm package that Yarn's `portal:` protocol points at.
+# The Dockerfile delegates to `scripts/build-compact-runtime.sh` so the build
+# logic lives in one place.
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+
+if [ ! -f compact/flake.nix ]; then
+  echo "error: compact submodule not initialized. Run: git submodule update --init compact" >&2
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "error: docker is required to build compact-runtime without host nix." >&2
+  exit 1
+fi
+
+home="${repo_root}/.compact-runtime-home"
+rm -rf "$home"
+mkdir -p "$home"
+
+image_tag="midnight-js-compact-runtime-local:latest"
+echo "Building compact-runtime Docker image '$image_tag' (first build can be slow)..."
+
+# Build context = repo root, narrowed by the repo-root `.dockerignore` to
+# `scripts/` and `compact/` (minus compact/.git).
+docker build --tag "$image_tag" --file - "$repo_root" <<'DOCKERFILE'
+FROM nixos/nix:latest
+RUN mkdir -p /etc/nix && { \
+    echo "extra-experimental-features = nix-command flakes"; \
+    echo "sandbox = false"; \
+    echo "extra-substituters = https://cache.iog.io"; \
+    echo "extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="; \
+  } >> /etc/nix/nix.conf
+COPY scripts/build-compact-runtime.sh /opt/build/scripts/build-compact-runtime.sh
+COPY compact /opt/build/compact
+WORKDIR /opt/build
+# `git+file://` flake ref needs a `.git` (excluded by .dockerignore), so use
+# the path-flake override the script supports.
+ENV COMPACTC_FLAKE_REF=path:/opt/build/compact
+# Lay out the runtime npm package outside the host bind-mount target.
+ENV COMPACT_RUNTIME_OUT=/compact-runtime-home
+RUN /opt/build/scripts/build-compact-runtime.sh
+DOCKERFILE
+
+# Extract the built package to the host's .compact-runtime-home. The image's
+# /compact-runtime-home is the canonical layout; we copy it onto the host so
+# Yarn's portal: can point at .compact-runtime-home without a docker run for
+# every node_modules read.
+container_id=$(docker create "$image_tag")
+trap 'docker rm -f "$container_id" >/dev/null 2>&1 || true' EXIT
+docker cp "$container_id:/compact-runtime-home/." "$home/"
+
+version=$(node -e "console.log(require('$home/package.json').version)" 2>/dev/null || echo unknown)
+echo "compact-runtime $version extracted to $home"
+echo "Inject the Yarn portal: resolution with: node scripts/use-source-compact-runtime.js"

--- a/scripts/build-compact-runtime-docker.sh
+++ b/scripts/build-compact-runtime-docker.sh
@@ -21,20 +21,14 @@
 
 set -euo pipefail
 
-repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-cd "$repo_root"
+# shellcheck source=./lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+cd "$REPO_ROOT"
 
-if [ ! -f compact/flake.nix ]; then
-  echo "error: compact submodule not initialized. Run: git submodule update --init compact" >&2
-  exit 1
-fi
+assert_submodule_initialized
+assert_command docker "building compact-runtime without host nix"
 
-if ! command -v docker >/dev/null 2>&1; then
-  echo "error: docker is required to build compact-runtime without host nix." >&2
-  exit 1
-fi
-
-home="${repo_root}/.compact-runtime-home"
+home="${REPO_ROOT}/.compact-runtime-home"
 rm -rf "$home"
 mkdir -p "$home"
 
@@ -43,7 +37,7 @@ echo "Building compact-runtime Docker image '$image_tag' (first build can be slo
 
 # Build context = repo root, narrowed by the repo-root `.dockerignore` to
 # `scripts/` and `compact/` (minus compact/.git).
-docker build --tag "$image_tag" --file - "$repo_root" <<'DOCKERFILE'
+docker build --tag "$image_tag" --file - "$REPO_ROOT" <<'DOCKERFILE'
 FROM nixos/nix:latest
 RUN mkdir -p /etc/nix && { \
     echo "extra-experimental-features = nix-command flakes"; \
@@ -52,24 +46,24 @@ RUN mkdir -p /etc/nix && { \
     echo "extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="; \
   } >> /etc/nix/nix.conf
 COPY scripts/build-compact-runtime.sh /opt/build/scripts/build-compact-runtime.sh
+COPY scripts/lib.sh /opt/build/scripts/lib.sh
 COPY compact /opt/build/compact
 WORKDIR /opt/build
-# `git+file://` flake ref needs a `.git` (excluded by .dockerignore), so use
-# the path-flake override the script supports.
+# `path:` flake ref tolerates the missing `.git` (excluded by .dockerignore).
 ENV COMPACTC_FLAKE_REF=path:/opt/build/compact
 # Lay out the runtime npm package outside the host bind-mount target.
 ENV COMPACT_RUNTIME_OUT=/compact-runtime-home
 RUN /opt/build/scripts/build-compact-runtime.sh
 DOCKERFILE
 
-# Extract the built package to the host's .compact-runtime-home. The image's
-# /compact-runtime-home is the canonical layout; we copy it onto the host so
-# Yarn's portal: can point at .compact-runtime-home without a docker run for
-# every node_modules read.
-container_id=$(docker create "$image_tag")
-trap 'docker rm -f "$container_id" >/dev/null 2>&1 || true' EXIT
-docker cp "$container_id:/compact-runtime-home/." "$home/"
+# Extract via `docker run --rm` with a bind mount, avoiding the
+# create/cp/remove cycle.
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  --volume "$home:/out" \
+  "$image_tag" \
+  sh -c 'cp -R /compact-runtime-home/. /out/'
 
-version=$(node -e "console.log(require('$home/package.json').version)" 2>/dev/null || echo unknown)
-echo "compact-runtime $version extracted to $home"
-echo "Inject the Yarn portal: resolution with: node scripts/use-source-compact-runtime.js"
+version=$(grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]+"' "$home/package.json" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+echo "compact-runtime ${version:-unknown} extracted to $home"
+echo "Inject the Yarn file: resolution with: node scripts/use-source-compact-runtime.js"

--- a/scripts/build-compact-runtime.sh
+++ b/scripts/build-compact-runtime.sh
@@ -27,32 +27,24 @@
 
 set -euo pipefail
 
-repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-cd "$repo_root"
+# shellcheck source=./lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+cd "$REPO_ROOT"
 
-if [ ! -f compact/flake.nix ]; then
-  echo "error: compact submodule not initialized. Run: git submodule update --init compact" >&2
-  exit 1
-fi
-
-if ! command -v nix >/dev/null 2>&1; then
-  echo "error: nix is required to build compact-runtime from the submodule." >&2
-  exit 1
-fi
+assert_submodule_initialized
+assert_command nix "building compact-runtime from the submodule"
 
 # Output directory for the materialized npm package. Defaults to
 # `.compact-runtime-home` at the repo root; `scripts/build-compact-runtime-docker.sh`
 # overrides via COMPACT_RUNTIME_OUT to install outside its runtime bind-mount target.
-home="${COMPACT_RUNTIME_OUT:-${repo_root}/.compact-runtime-home}"
+home="${COMPACT_RUNTIME_OUT:-${REPO_ROOT}/.compact-runtime-home}"
 
-# Flake reference for the compact build. Defaults to the local submodule as a
-# git working tree (picks up uncommitted edits). Overridable via
-# COMPACTC_FLAKE_REF (e.g., `path:/some/copy/of/compact` in environments where
-# the submodule has no `.git` directory).
-flake_ref="${COMPACTC_FLAKE_REF:-git+file://${repo_root}/compact}"
+# Default flake reference: see scripts/lib.sh:default_compact_flake_ref.
+flake_ref="${COMPACTC_FLAKE_REF:-$(default_compact_flake_ref)}"
 
-# Use a sibling out-link to keep the compactc gcroot independent.
-gcroot_dir="$(dirname "$home")/$(basename "$home")-build"
+# Sibling gcroot directory keeps the runtime nix gcroot independent of the
+# compactc one.
+gcroot_dir="${home}-build"
 mkdir -p "$gcroot_dir"
 
 echo "Building compact-runtime from ${flake_ref} (first build can be slow)..."
@@ -74,6 +66,6 @@ cp -RL "$src_pkg_dir"/. "$home/"
 # Ensure files are writable (nix-store paths are read-only by default).
 chmod -R u+w "$home"
 
-version=$(node -e "console.log(require('$home/package.json').version)" 2>/dev/null || echo unknown)
-echo "compact-runtime $version laid out at $home"
-echo "Inject the Yarn portal: resolution with: node scripts/use-source-compact-runtime.js"
+version=$(grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]+"' "$home/package.json" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+echo "compact-runtime ${version:-unknown} laid out at $home"
+echo "Inject the Yarn file: resolution with: node scripts/use-source-compact-runtime.js"

--- a/scripts/build-compact-runtime.sh
+++ b/scripts/build-compact-runtime.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# This file is part of midnight-js.
+# Copyright (C) 2025-2026 Midnight Foundation
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build @midnight-ntwrk/compact-runtime from the `compact/` submodule via nix
+# and lay out the resulting npm package at `.compact-runtime-home/` so it can
+# be consumed via Yarn's `portal:` protocol.
+#
+# Companion to `scripts/build-compactc.sh`. Use both when developing against
+# an unreleased compactc/runtime pair; their generated artifacts (compactc
+# binary + compact-runtime npm package) must come from the same source tree.
+#
+# First build can be slow: without nix `trusted-users` access to the IOG cache
+# (`cache.iog.io`), the dependencies compile from source. Subsequent runs are
+# cached.
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+
+if [ ! -f compact/flake.nix ]; then
+  echo "error: compact submodule not initialized. Run: git submodule update --init compact" >&2
+  exit 1
+fi
+
+if ! command -v nix >/dev/null 2>&1; then
+  echo "error: nix is required to build compact-runtime from the submodule." >&2
+  exit 1
+fi
+
+# Output directory for the materialized npm package. Defaults to
+# `.compact-runtime-home` at the repo root; `scripts/build-compact-runtime-docker.sh`
+# overrides via COMPACT_RUNTIME_OUT to install outside its runtime bind-mount target.
+home="${COMPACT_RUNTIME_OUT:-${repo_root}/.compact-runtime-home}"
+
+# Flake reference for the compact build. Defaults to the local submodule as a
+# git working tree (picks up uncommitted edits). Overridable via
+# COMPACTC_FLAKE_REF (e.g., `path:/some/copy/of/compact` in environments where
+# the submodule has no `.git` directory).
+flake_ref="${COMPACTC_FLAKE_REF:-git+file://${repo_root}/compact}"
+
+# Use a sibling out-link to keep the compactc gcroot independent.
+gcroot_dir="$(dirname "$home")/$(basename "$home")-build"
+mkdir -p "$gcroot_dir"
+
+echo "Building compact-runtime from ${flake_ref} (first build can be slow)..."
+nix build --out-link "$gcroot_dir/result" "${flake_ref}#runtime.package"
+
+# `packages.runtime.package` layout (per compact/flake.nix):
+#   $out/lib/node_modules/@midnight-ntwrk/compact-runtime/{package.json,dist/,...}
+# Materialize a flat npm package directory at $home so Yarn `portal:` can point
+# at it without a wrapper layer.
+src_pkg_dir="$(readlink -f "$gcroot_dir/result")/lib/node_modules/@midnight-ntwrk/compact-runtime"
+if [ ! -d "$src_pkg_dir" ]; then
+  echo "error: built runtime package not found at $src_pkg_dir" >&2
+  exit 1
+fi
+
+rm -rf "$home"
+mkdir -p "$home"
+cp -RL "$src_pkg_dir"/. "$home/"
+# Ensure files are writable (nix-store paths are read-only by default).
+chmod -R u+w "$home"
+
+version=$(node -e "console.log(require('$home/package.json').version)" 2>/dev/null || echo unknown)
+echo "compact-runtime $version laid out at $home"
+echo "Inject the Yarn portal: resolution with: node scripts/use-source-compact-runtime.js"

--- a/scripts/build-compactc-docker.sh
+++ b/scripts/build-compactc-docker.sh
@@ -28,20 +28,14 @@
 
 set -euo pipefail
 
-repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-cd "$repo_root"
+# shellcheck source=./lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+cd "$REPO_ROOT"
 
-if [ ! -f compact/flake.nix ]; then
-  echo "error: compact submodule not initialized. Run: git submodule update --init compact" >&2
-  exit 1
-fi
+assert_submodule_initialized
+assert_command docker "building compactc without host nix"
 
-if ! command -v docker >/dev/null 2>&1; then
-  echo "error: docker is required to build compactc without host nix." >&2
-  exit 1
-fi
-
-home="${repo_root}/.compact-home"
+home="${REPO_ROOT}/.compact-home"
 mkdir -p "$home"
 
 image_tag="midnight-js-compactc-local:latest"
@@ -54,7 +48,7 @@ echo "Building compactc Docker image '$image_tag' (first build can be slow)..."
 #
 # The compactc bundle is installed at /compactc-home (NOT /work/.compact-home)
 # so the runtime bind-mount of the caller's CWD to /host-cwd cannot shadow it.
-docker build --tag "$image_tag" --file - "$repo_root" <<'DOCKERFILE'
+docker build --tag "$image_tag" --file - "$REPO_ROOT" <<'DOCKERFILE'
 FROM nixos/nix:latest
 # Append (don't clobber) so the base image's defaults survive. `extra-` merges
 # onto those defaults. sandbox=false because container runtimes usually lack
@@ -66,10 +60,10 @@ RUN mkdir -p /etc/nix && { \
     echo "extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="; \
   } >> /etc/nix/nix.conf
 COPY scripts/build-compactc.sh /opt/build-compactc/scripts/build-compactc.sh
+COPY scripts/lib.sh /opt/build-compactc/scripts/lib.sh
 COPY compact /opt/build-compactc/compact
 WORKDIR /opt/build-compactc
-# `git+file://` flake ref needs a `.git` (excluded by .dockerignore), so use
-# the path-flake override `scripts/build-compactc.sh` already supports.
+# `path:` flake ref tolerates the missing `.git` (excluded by .dockerignore).
 ENV COMPACTC_FLAKE_REF=path:/opt/build-compactc/compact
 # Direct the script to lay the bundle outside the host bind-mount target.
 ENV COMPACT_BUILD_OUT=/compactc-home

--- a/scripts/build-compactc.sh
+++ b/scripts/build-compactc.sh
@@ -29,30 +29,22 @@
 
 set -euo pipefail
 
-repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-cd "$repo_root"
+# shellcheck source=./lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+cd "$REPO_ROOT"
 
-if [ ! -f compact/flake.nix ]; then
-  echo "error: compact submodule not initialized. Run: git submodule update --init compact" >&2
-  exit 1
-fi
-
-if ! command -v nix >/dev/null 2>&1; then
-  echo "error: nix is required to build compactc from the submodule." >&2
-  exit 1
-fi
+assert_submodule_initialized
+assert_command nix "building compactc from the submodule"
 
 # Output directory for the wrapper + nix gcroot. Defaults to `.compact-home`
 # at the repo root; `scripts/build-compactc-docker.sh` overrides it via
 # COMPACT_BUILD_OUT to install the bundle outside its runtime bind-mount target.
-home="${COMPACT_BUILD_OUT:-${repo_root}/.compact-home}"
+home="${COMPACT_BUILD_OUT:-${REPO_ROOT}/.compact-home}"
 mkdir -p "$home"
 
-# Flake reference for the compact build. Defaults to the local submodule as a
-# git working tree (picks up uncommitted edits). Overridable via
-# COMPACTC_FLAKE_REF (e.g., `path:/some/copy/of/compact` in environments where
-# the submodule has no `.git` directory).
-flake_ref="${COMPACTC_FLAKE_REF:-git+file://${repo_root}/compact}"
+# Default flake reference: `path:` works with paths containing spaces and
+# without a `.git` (unlike `git+file://`). Overridable via COMPACTC_FLAKE_REF.
+flake_ref="${COMPACTC_FLAKE_REF:-$(default_compact_flake_ref)}"
 
 # --out-link registers an indirect gcroot, so the built compiler survives
 # `nix-collect-garbage` and the wrapper keeps pointing at a live store path.

--- a/scripts/check-no-source-leak.js
+++ b/scripts/check-no-source-leak.js
@@ -1,0 +1,60 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Pre-commit guard: refuse to stage a root package.json that still carries the
+// local source-build resolution injected by `scripts/use-source-compact-runtime.js`.
+// Without this guard, a developer iterating on `compact/` could accidentally
+// commit `file:./.compact-runtime-home` into the repo and break CI for every
+// runner without that directory.
+
+const { execFileSync } = require('child_process');
+
+const LEAK_MARKERS = [
+  'file:./.compact-runtime-home',
+  'portal:./.compact-runtime-home',
+];
+
+let staged;
+try {
+  staged = execFileSync('git', ['diff', '--cached', '--name-only'], { encoding: 'utf8' })
+    .split('\n')
+    .filter(Boolean);
+} catch (err) {
+  console.error(`pre-commit guard: failed to list staged files (${err.message}).`);
+  process.exit(0);
+}
+
+if (!staged.includes('package.json')) {
+  process.exit(0);
+}
+
+let stagedContent;
+try {
+  stagedContent = execFileSync('git', ['show', ':package.json'], { encoding: 'utf8' });
+} catch (err) {
+  console.error(`pre-commit guard: failed to read staged package.json (${err.message}).`);
+  process.exit(0);
+}
+
+const leak = LEAK_MARKERS.find((marker) => stagedContent.includes(marker));
+if (leak) {
+  console.error(
+    `\n  Refusing to commit package.json: it contains '${leak}', which is a local\n` +
+    "  source-build resolution that must not land in git history.\n\n" +
+    "  Run: node scripts/use-source-compact-runtime.js --restore && yarn install\n" +
+    "  then re-stage package.json.\n"
+  );
+  process.exit(1);
+}

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# This file is part of midnight-js.
+# Copyright (C) 2025-2026 Midnight Foundation
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shared helpers for scripts/build-*.sh. Sourced; do not exec.
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+#   cd "$REPO_ROOT"
+#   assert_submodule_initialized
+#   assert_command nix "building compactc from the submodule"
+#   flake_ref="${COMPACTC_FLAKE_REF:-$(default_compact_flake_ref)}"
+
+# Resolve the repo root from the caller's path. BASH_SOURCE[1] is the sourcing
+# script; ${0%/*}/.. is its directory's parent.
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[1]}")/.." && pwd)
+
+assert_submodule_initialized() {
+  if [ ! -f "$REPO_ROOT/compact/flake.nix" ]; then
+    echo "error: compact submodule not initialized. Run: git submodule update --init compact" >&2
+    exit 1
+  fi
+}
+
+assert_command() {
+  local cmd="$1"
+  local use_case="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "error: $cmd is required for $use_case." >&2
+    exit 1
+  fi
+}
+
+# `path:` flake refs tolerate spaces in the path (no URL encoding required) and
+# work without a `.git` directory, so they are the safe default for both local
+# checkouts and Docker COPY contexts. `git+file://` is left available via the
+# COMPACTC_FLAKE_REF override for callers that explicitly want git semantics.
+default_compact_flake_ref() {
+  echo "path:$REPO_ROOT/compact"
+}

--- a/scripts/use-source-compact-runtime.js
+++ b/scripts/use-source-compact-runtime.js
@@ -1,0 +1,70 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Inject (or restore) a Yarn `portal:` resolution that points the
+// @midnight-ntwrk/compact-runtime dependency at the locally-built package
+// under `.compact-runtime-home/`. Run `yarn install` afterwards to materialize.
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const packageJsonPath = path.join(repoRoot, 'package.json');
+const runtimeHome = path.join(repoRoot, '.compact-runtime-home');
+const portalSpec = 'portal:./.compact-runtime-home';
+const dependencyKey = '@midnight-ntwrk/compact-runtime';
+
+const args = new Set(process.argv.slice(2));
+const restore = args.has('--restore');
+
+const raw = fs.readFileSync(packageJsonPath, 'utf8');
+const pkg = JSON.parse(raw);
+
+function write(updated) {
+  const next = JSON.stringify(updated, null, 2) + '\n';
+  if (next === raw) {
+    console.log('No change to package.json.');
+    return;
+  }
+  fs.writeFileSync(packageJsonPath, next);
+}
+
+if (restore) {
+  if (pkg.resolutions && pkg.resolutions[dependencyKey] === portalSpec) {
+    delete pkg.resolutions[dependencyKey];
+    if (Object.keys(pkg.resolutions).length === 0) {
+      delete pkg.resolutions;
+    }
+    write(pkg);
+    console.log(`Removed portal: resolution for ${dependencyKey}. Run 'yarn install' to materialize.`);
+  } else {
+    console.log(`No portal: resolution for ${dependencyKey} present; nothing to restore.`);
+  }
+  process.exit(0);
+}
+
+// Inject path.
+const runtimePackageJson = path.join(runtimeHome, 'package.json');
+if (!fs.existsSync(runtimePackageJson)) {
+  console.error(`Error: ${runtimePackageJson} not found.`);
+  console.error('Run ./scripts/build-compact-runtime.sh (or ./scripts/build-compact-runtime-docker.sh) first.');
+  process.exit(1);
+}
+
+pkg.resolutions = pkg.resolutions || {};
+pkg.resolutions[dependencyKey] = portalSpec;
+write(pkg);
+console.log(`Injected portal: resolution for ${dependencyKey} → ${portalSpec}.`);
+console.log("Run 'yarn install' (without --immutable) to materialize.");

--- a/scripts/use-source-compact-runtime.js
+++ b/scripts/use-source-compact-runtime.js
@@ -13,9 +13,13 @@
  * limitations under the License.
  */
 
-// Inject (or restore) a Yarn `portal:` resolution that points the
+// Inject (or restore) a Yarn `file:` resolution that points the
 // @midnight-ntwrk/compact-runtime dependency at the locally-built package
 // under `.compact-runtime-home/`. Run `yarn install` afterwards to materialize.
+//
+// Uses `file:` rather than `portal:` so Yarn installs the runtime's transitive
+// dependencies (e.g. @noble/hashes, object-inspect) into the root workspace.
+// `portal:` would symlink the package but skip its dependency tree.
 
 const fs = require('fs');
 const path = require('path');
@@ -23,14 +27,26 @@ const path = require('path');
 const repoRoot = path.resolve(__dirname, '..');
 const packageJsonPath = path.join(repoRoot, 'package.json');
 const runtimeHome = path.join(repoRoot, '.compact-runtime-home');
-const portalSpec = 'portal:./.compact-runtime-home';
+const sourceSpec = 'file:./.compact-runtime-home';
 const dependencyKey = '@midnight-ntwrk/compact-runtime';
 
-const args = new Set(process.argv.slice(2));
-const restore = args.has('--restore');
+const restore = process.argv.includes('--restore');
 
-const raw = fs.readFileSync(packageJsonPath, 'utf8');
-const pkg = JSON.parse(raw);
+let raw;
+try {
+  raw = fs.readFileSync(packageJsonPath, 'utf8');
+} catch (err) {
+  console.error(`Error reading ${packageJsonPath}: ${err.message}`);
+  process.exit(1);
+}
+
+let pkg;
+try {
+  pkg = JSON.parse(raw);
+} catch (err) {
+  console.error(`Error parsing ${packageJsonPath} as JSON: ${err.message}`);
+  process.exit(1);
+}
 
 function write(updated) {
   const next = JSON.stringify(updated, null, 2) + '\n';
@@ -42,15 +58,15 @@ function write(updated) {
 }
 
 if (restore) {
-  if (pkg.resolutions && pkg.resolutions[dependencyKey] === portalSpec) {
+  if (pkg.resolutions && pkg.resolutions[dependencyKey] === sourceSpec) {
     delete pkg.resolutions[dependencyKey];
     if (Object.keys(pkg.resolutions).length === 0) {
       delete pkg.resolutions;
     }
     write(pkg);
-    console.log(`Removed portal: resolution for ${dependencyKey}. Run 'yarn install' to materialize.`);
+    console.log(`Removed file: resolution for ${dependencyKey}. Run 'yarn install' to materialize.`);
   } else {
-    console.log(`No portal: resolution for ${dependencyKey} present; nothing to restore.`);
+    console.log(`No source-build resolution for ${dependencyKey} present; nothing to restore.`);
   }
   process.exit(0);
 }
@@ -64,7 +80,7 @@ if (!fs.existsSync(runtimePackageJson)) {
 }
 
 pkg.resolutions = pkg.resolutions || {};
-pkg.resolutions[dependencyKey] = portalSpec;
+pkg.resolutions[dependencyKey] = sourceSpec;
 write(pkg);
-console.log(`Injected portal: resolution for ${dependencyKey} → ${portalSpec}.`);
+console.log(`Injected file: resolution for ${dependencyKey} → ${sourceSpec}.`);
 console.log("Run 'yarn install' (without --immutable) to materialize.");


### PR DESCRIPTION
## Summary

Pairs PR #978's compactc-from-submodule opt-in with a build of the `@midnight-ntwrk/compact-runtime` npm package from the same submodule, so a feature-branch compactc can be tested against the runtime it was designed to emit code for.

**Stacked on #978** — base branch is `feat/compactc-from-submodule`. Will retarget to `main` once #978 lands.

**Local dev:**

- `scripts/build-compact-runtime.sh` — nix build of the flake's `runtime.package` output, laid out at `.compact-runtime-home/` as a flat npm package directory.
- `scripts/build-compact-runtime-docker.sh` — Docker variant for hosts without nix; reuses `build-compact-runtime.sh` inside the container and `docker cp`s the result back onto the host.
- `scripts/use-source-compact-runtime.js` — idempotent: injects (default) or removes (`--restore`) a Yarn `portal:./.compact-runtime-home` resolution in root `package.json`. Run `yarn install` after each.

**CI:**

- The existing `compactc-from-source` PR label and `workflow_dispatch` input now also build the runtime, inject the portal resolution, and re-run `yarn install` (without `--immutable`) before the build steps. Default behaviour unchanged.

**Why portal:** `packages/protocol` is the only consumer of `@midnight-ntwrk/compact-runtime`. Yarn `portal:` symlinks the local directory without copying or recording deps in the lockfile, so the override is reversible and incrementally fast.

## Test plan

- [x] Default CI path (no label, no dispatch input) unchanged — both initial `yarn install --immutable` and `Run build` steps still gate the rest of the pipeline.
- [ ] Apply `compactc-from-source` label to a PR and verify CI:
  - [ ] `Build compact-runtime from submodule` step succeeds
  - [ ] `.compact-runtime-home/package.json` materializes and matches submodule version
  - [ ] `Inject portal:./.compact-runtime-home resolution` step mutates `package.json`
  - [ ] `Re-install dependencies with portal resolution` resolves `packages/protocol` to the portal target
  - [ ] `yarn build` succeeds against the source-built runtime
- [ ] Local: `./scripts/build-compact-runtime.sh && node scripts/use-source-compact-runtime.js && yarn install` and verify `packages/protocol/node_modules/@midnight-ntwrk/compact-runtime` points at `.compact-runtime-home`
- [ ] Docker variant: same as above with `build-compact-runtime-docker.sh`
- [ ] Restore path: `node scripts/use-source-compact-runtime.js --restore && yarn install` removes the resolution cleanly