### PR TITLE
fix(testkit-js): wait on indexer healthcheck with 3-minute startup timeout

### DIFF
--- a/testkit-js/testkit-js/src/configuration.ts
+++ b/testkit-js/testkit-js/src/configuration.ts
@@ -49,7 +49,7 @@ export const defaultContainersConfiguration: ContainersConfiguration = {
       indexer: {
         name: 'indexer',
         port: 8088,
-        waitStrategy: Wait.forListeningPorts()
+        waitStrategy: Wait.forHealthCheck().withStartupTimeout(3 * 60_000)
       }
     }
   },


### PR DESCRIPTION
# Overview

`nodejs.it.test.ts > should run ESM module successfully` has been flaking with `expected 1 to be +0` after ~62s. The child Node process spawned by the test runs the full e2e flow (`dist/counter.mjs`) and exits with code 1 because docker compose `up` rejects on a wait-strategy timeout.

Root cause: the standalone `indexer` entry in `defaultContainersConfiguration` used `Wait.forListeningPorts()` with no override, so it fell back to testcontainers' default `startupTimeoutMs = 60_000`. The indexer is gated on `depends_on: node: service_healthy` and only starts binding port 8088 once the node is healthy, so under load it routinely exceeds 60s and trips the timeout. The ~62s test duration matches the 60s timeout plus a couple of seconds of compose orchestration overhead.

Fix: switch the wait strategy to `Wait.forHealthCheck().withStartupTimeout(3 * 60_000)` so we wait on the existing compose healthcheck (`cat /var/run/indexer-standalone/running`) instead of a raw port bind, and use the same 3-minute budget already applied to the proof-server entries.

Diff is one line in `testkit-js/testkit-js/src/configuration.ts`.

## Submission Checklist

- [x] Useful pull request description
- [ ] Tests are provided (if possible) — N/A, this only widens an existing test-infra timeout; the flake is environmental and can't be deterministically reproduced in a unit test
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant) — N/A
- [ ] Update documentation (if relevant) — N/A
- [x] No new todos introduced

## Test plan

- [x] `yarn lint` clean
- [x] `yarn build:testkit` succeeds (testkit-js + testkit-js-e2e)
- [ ] Re-run `vitest test/nodejs.it.test.ts` locally and confirm no regression at the indexer wait stage
- [ ] CI integration job passes (`[skip_it]` not used)