### PR TITLE
fix(midnight-js): pass signing key kind via KEYS_SIGNING_KIND config key

### DIFF
--- a/packages/types/src/contract.ts
+++ b/packages/types/src/contract.ts
@@ -96,7 +96,7 @@ export const makeContractExecutableRuntime:
     if (options.signingKey) {
       config = config.concat([
         ['KEYS_SIGNING', options.signingKey.value],
-        ['KEYS_SIGNINGKIND', options.signingKey.tag]
+        ['KEYS_SIGNING_KIND', options.signingKey.tag]
       ])
     }
     return ContractExecutableRuntime.make(makeAdaptedRuntimeLayer(zkConfigProvider, new Map(config)));

--- a/packages/types/src/test/contract.test.ts
+++ b/packages/types/src/test/contract.test.ts
@@ -1,0 +1,61 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { sampleSigningKey, type SigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import * as Configuration from '@midnight-ntwrk/midnight-js-protocol/platform-js/effect/Configuration';
+import { Effect, Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+
+import { makeContractExecutableRuntime } from '../contract';
+import { type ProverKey, type VerifierKey, type ZKIR } from '../midnight-types';
+import { ZKConfigProvider } from '../zk-config-provider';
+
+class UnusedZKConfigProvider extends ZKConfigProvider<string> {
+  getZKIR(): Promise<ZKIR> {
+    return Promise.reject(new Error('zk config provider is not exercised by configuration reads'));
+  }
+  getProverKey(): Promise<ProverKey> {
+    return Promise.reject(new Error('zk config provider is not exercised by configuration reads'));
+  }
+  getVerifierKey(): Promise<VerifierKey> {
+    return Promise.reject(new Error('zk config provider is not exercised by configuration reads'));
+  }
+}
+
+const COIN_PUBLIC_KEY = '00'.repeat(32);
+
+const readConfiguredSigningKey = (signingKey: SigningKey): Promise<Option.Option<SigningKey>> =>
+  makeContractExecutableRuntime(new UnusedZKConfigProvider(), {
+    coinPublicKey: COIN_PUBLIC_KEY,
+    signingKey
+  }).runPromise(Configuration.Keys.pipe(Effect.map((keys) => keys.getSigningKey())));
+
+describe('makeContractExecutableRuntime', () => {
+  it('preserves the kind of a schnorr signing key', async () => {
+    const signingKey = sampleSigningKey('schnorr');
+
+    const configured = await readConfiguredSigningKey(signingKey);
+
+    expect(Option.getOrNull(configured)).toEqual(signingKey);
+  });
+
+  it('preserves the kind of an ecdsa signing key', async () => {
+    const signingKey = sampleSigningKey('ecdsa');
+
+    const configured = await readConfiguredSigningKey(signingKey);
+
+    expect(Option.getOrNull(configured)).toEqual(signingKey);
+  });
+});

--- a/testkit-js/testkit-js-e2e/test/contracts.signing-key.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/contracts.signing-key.it.test.ts
@@ -1,0 +1,151 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { deployContract, submitReplaceAuthorityTx } from '@midnight-ntwrk/midnight-js-contracts';
+import { sampleSigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import { type ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import { SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
+import type { EnvironmentConfiguration, MidnightWalletProvider, TestEnvironment } from '@midnight-ntwrk/testkit-js';
+import {
+  createLogger,
+  expectSuccessfulDeployTx,
+  getTestEnvironment,
+  initializeMidnightProviders
+} from '@midnight-ntwrk/testkit-js';
+import path from 'path';
+
+import { SLOW_TEST_TIMEOUT } from '@/constants';
+import { CompiledCounterContract } from '@/contract';
+import { CounterConfiguration } from '@/counter-api';
+import { CounterPrivateStateId, type CounterProviders, privateStateZero } from '@/types/counter-types';
+
+const logger = createLogger(
+  path.resolve(`${process.cwd()}`, 'logs', 'tests', `signing-key_${new Date().toISOString()}.log`)
+);
+
+describe('Contract maintenance authority signing keys', () => {
+  let providers: CounterProviders;
+  let testEnvironment: TestEnvironment;
+  let wallet: MidnightWalletProvider;
+  let environmentConfiguration: EnvironmentConfiguration;
+  let contractConfiguration: CounterConfiguration;
+
+  beforeEach(() => {
+    logger.info(`Running test=${expect.getState().currentTestName}`);
+  });
+
+  beforeAll(async () => {
+    testEnvironment = getTestEnvironment(logger);
+    environmentConfiguration = await testEnvironment.start();
+    contractConfiguration = new CounterConfiguration();
+    wallet = await testEnvironment.getMidnightWalletProvider();
+    providers = initializeMidnightProviders(wallet, environmentConfiguration, contractConfiguration);
+  });
+
+  afterAll(async () => {
+    await testEnvironment.shutdown();
+  });
+
+  /**
+   * Smoke test that both Schnorr and ECDSA contract maintenance authority keys can authorize a
+   * maintenance update on a live node.
+   *
+   * The maintenance authority key is the only key that signs contract maintenance updates; ordinary
+   * circuit calls are signed by the wallet, not the authority key. A successful
+   * {@link submitReplaceAuthorityTx} therefore proves the current authority key's kind signed the
+   * update and was verified by the node.
+   *
+   * @given A Counter contract deployed with a Schnorr maintenance authority key
+   * @when Replacing the authority with an ECDSA key, then replacing it again with a Schnorr key
+   * @then Both replacements succeed entirely, proving Schnorr then ECDSA keys each signed a
+   *       maintenance update, and the stored authority reflects each new key
+   */
+  test(
+    'should replace the contract maintenance authority across schnorr and ecdsa signing keys [@slow]',
+    async () => {
+      const schnorrKey = sampleSigningKey('schnorr');
+      const deployTxOptions = {
+        compiledContract: CompiledCounterContract,
+        signingKey: schnorrKey,
+        privateStateId: CounterPrivateStateId,
+        initialPrivateState: privateStateZero
+      };
+      const deployedContract = await deployContract(providers, deployTxOptions);
+      await expectSuccessfulDeployTx(providers, deployedContract.deployTxData, deployTxOptions);
+
+      const contractAddress: ContractAddress = deployedContract.deployTxData.public.contractAddress;
+      providers.privateStateProvider.setContractAddress(contractAddress);
+      expect(await providers.privateStateProvider.getSigningKey(contractAddress)).toEqual(schnorrKey);
+
+      const ecdsaKey = sampleSigningKey('ecdsa');
+      const replaceWithEcdsa = await submitReplaceAuthorityTx(
+        providers,
+        CompiledCounterContract,
+        contractAddress
+      )(ecdsaKey);
+      expect(replaceWithEcdsa.status).toBe(SucceedEntirely);
+      expect(await providers.privateStateProvider.getSigningKey(contractAddress)).toEqual(ecdsaKey);
+
+      const nextSchnorrKey = sampleSigningKey('schnorr');
+      const replaceWithSchnorr = await submitReplaceAuthorityTx(
+        providers,
+        CompiledCounterContract,
+        contractAddress
+      )(nextSchnorrKey);
+      expect(replaceWithSchnorr.status).toBe(SucceedEntirely);
+      expect(await providers.privateStateProvider.getSigningKey(contractAddress)).toEqual(nextSchnorrKey);
+    },
+    SLOW_TEST_TIMEOUT
+  );
+
+  /**
+   * Smoke test that an ECDSA maintenance authority key can authorize a maintenance update without
+   * any change of key kind. Isolates ECDSA signing from the cross-kind transition: the contract is
+   * deployed with an ECDSA authority and the authority is replaced with another ECDSA key.
+   *
+   * @given A Counter contract deployed with an ECDSA maintenance authority key
+   * @when Replacing the authority with another ECDSA key
+   * @then The replacement succeeds entirely, proving an ECDSA key signed a maintenance update that
+   *       the node accepted, and the stored authority reflects the new key
+   */
+  test(
+    'should replace the contract maintenance authority using ecdsa signing keys [@slow]',
+    async () => {
+      const ecdsaKey = sampleSigningKey('ecdsa');
+      const deployTxOptions = {
+        compiledContract: CompiledCounterContract,
+        signingKey: ecdsaKey,
+        privateStateId: CounterPrivateStateId,
+        initialPrivateState: privateStateZero
+      };
+      const deployedContract = await deployContract(providers, deployTxOptions);
+      await expectSuccessfulDeployTx(providers, deployedContract.deployTxData, deployTxOptions);
+
+      const contractAddress: ContractAddress = deployedContract.deployTxData.public.contractAddress;
+      providers.privateStateProvider.setContractAddress(contractAddress);
+      expect(await providers.privateStateProvider.getSigningKey(contractAddress)).toEqual(ecdsaKey);
+
+      const nextEcdsaKey = sampleSigningKey('ecdsa');
+      const replaceWithEcdsa = await submitReplaceAuthorityTx(
+        providers,
+        CompiledCounterContract,
+        contractAddress
+      )(nextEcdsaKey);
+      expect(replaceWithEcdsa.status).toBe(SucceedEntirely);
+      expect(await providers.privateStateProvider.getSigningKey(contractAddress)).toEqual(nextEcdsaKey);
+    },
+    SLOW_TEST_TIMEOUT
+  );
+});


### PR DESCRIPTION
# Overview

ECDSA contract maintenance authority (CMA) signing keys were silently broken end-to-end, while Schnorr worked.

**Root cause** — `makeContractExecutableRuntime` (`packages/types/src/contract.ts`) mapped the signing key kind under config key `KEYS_SIGNINGKIND`. The consumer (`platform-js` `Configuration`) reads the nested path `keys.signingKind`, which the runtime's `ConfigProvider.constantCase` resolves to **`KEYS_SIGNING_KIND`** (with a word-separating underscore). The keys never matched, so `signingKind` always fell back to its default (`schnorr`) and any non-schnorr signing key was silently downgraded.

Consequences observed on a live node (devnet images):
- Deploying with `sampleSigningKey('ecdsa')` stored a `schnorr` authority — `deployTxData.private.signingKey` came back `schnorr`.
- A later ECDSA-signed maintenance update was rejected by the node as `Malformed(InvalidCommitteeSignature)` (txpool error 135), crashing the node's txpool task.

`KEYS_SIGNING` and `KEYS_COIN_PUBLIC` were unaffected because their config paths are single words (no internal camelCase boundary).

**Fix** — one-line config key correction: `KEYS_SIGNINGKIND` → `KEYS_SIGNING_KIND`. The native `onchain-runtime` primitives (`sampleSigningKey`/`signatureVerifyingKey`/`signData`/`verifySignature`) were already correct for both kinds; only the midnight-js→platform-js config wiring was wrong.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant)
- [ ] Update documentation (if relevant)
- [x] No new todos introduced

## Test plan

- **Unit** (`packages/types/src/test/contract.test.ts`): asserts both `schnorr` and `ecdsa` signing keys round-trip through the runtime configuration. The `ecdsa` case fails before the fix (returns `schnorr`) and passes after — verified red→green.
- **E2E** (`testkit-js/testkit-js-e2e/test/contracts.signing-key.it.test.ts`): `submitReplaceAuthorityTx` across kinds (schnorr↔ecdsa) and within ecdsa (ecdsa→ecdsa), each asserting `SucceedEntirely` and the stored authority kind. Both fail before the fix (node rejects ECDSA-signed update) and pass after — verified on devnet images.
- Build green (`yarn build`, 16/16); lint clean; `packages/types` typecheck clean.

## Links

Closes #1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)
