### PR TITLE
test(testkit-js): cover ECDSA contract maintenance actions and key persistence

### DIFF
--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -1006,6 +1006,30 @@ describe('Level Private State Provider', (): void => {
       expect(await db.getSigningKey(CONTRACT_ADDRESS_2)).toEqual(signingKey2);
     });
 
+    test('exports and imports mixed schnorr and ecdsa signing keys preserving each kind', async () => {
+      const db = levelPrivateStateProvider<PID, PS>(testConfig);
+      const schnorrKey = sampleSigningKey('schnorr');
+      const ecdsaKey = sampleSigningKey('ecdsa');
+      await db.setSigningKey(CONTRACT_ADDRESS_1, schnorrKey);
+      await db.setSigningKey(CONTRACT_ADDRESS_2, ecdsaKey);
+
+      const exportData = await db.exportSigningKeys();
+
+      await db.clearSigningKeys();
+      const result = await db.importSigningKeys(exportData);
+
+      expect(result.imported).toBe(2);
+      expect(result.skipped).toBe(0);
+      expect(result.overwritten).toBe(0);
+
+      const importedSchnorr = await db.getSigningKey(CONTRACT_ADDRESS_1);
+      const importedEcdsa = await db.getSigningKey(CONTRACT_ADDRESS_2);
+      expect(importedSchnorr).toEqual(schnorrKey);
+      expect(importedSchnorr?.tag).toBe('schnorr');
+      expect(importedEcdsa).toEqual(ecdsaKey);
+      expect(importedEcdsa?.tag).toBe('ecdsa');
+    });
+
     test('exports with custom password and imports with same password', async () => {
       const db = levelPrivateStateProvider<PID, PS>(testConfig);
       const signingKey = sampleSigningKey();

--- a/testkit-js/testkit-js-e2e/test/contracts.signing-key.it.test.ts
+++ b/testkit-js/testkit-js-e2e/test/contracts.signing-key.it.test.ts
@@ -13,7 +13,12 @@
  * limitations under the License.
  */
 
-import { deployContract, submitReplaceAuthorityTx } from '@midnight-ntwrk/midnight-js-contracts';
+import {
+  deployContract,
+  submitInsertVerifierKeyTx,
+  submitRemoveVerifierKeyTx,
+  submitReplaceAuthorityTx
+} from '@midnight-ntwrk/midnight-js-contracts';
 import { sampleSigningKey } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import { type ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { SucceedEntirely } from '@midnight-ntwrk/midnight-js-types';
@@ -28,7 +33,7 @@ import path from 'path';
 
 import { SLOW_TEST_TIMEOUT } from '@/constants';
 import { CompiledCounterContract } from '@/contract';
-import { CounterConfiguration } from '@/counter-api';
+import { CIRCUIT_ID_INCREMENT, CounterConfiguration } from '@/counter-api';
 import { CounterPrivateStateId, type CounterProviders, privateStateZero } from '@/types/counter-types';
 
 const logger = createLogger(
@@ -145,6 +150,61 @@ describe('Contract maintenance authority signing keys', () => {
       )(nextEcdsaKey);
       expect(replaceWithEcdsa.status).toBe(SucceedEntirely);
       expect(await providers.privateStateProvider.getSigningKey(contractAddress)).toEqual(nextEcdsaKey);
+    },
+    SLOW_TEST_TIMEOUT
+  );
+
+  /**
+   * Proves that an ECDSA contract maintenance authority can authorize the verifier-key maintenance
+   * actions — not only {@link submitReplaceAuthorityTx}, but {@link submitRemoveVerifierKeyTx} and
+   * {@link submitInsertVerifierKeyTx} as well. Each maintenance update is signed by the ECDSA
+   * authority key; a `SucceedEntirely` status therefore proves the ECDSA signature was produced and
+   * verified by the node for both actions.
+   *
+   * @given A Counter contract deployed with an ECDSA maintenance authority key
+   * @when Removing the `increment` verifier key, then re-inserting it
+   * @then Both maintenance updates succeed entirely, proving the ECDSA authority signed each one
+   */
+  test(
+    'should remove and re-insert a verifier key authorized by an ecdsa signing key [@slow]',
+    async () => {
+      const ecdsaKey = sampleSigningKey('ecdsa');
+      const deployTxOptions = {
+        compiledContract: CompiledCounterContract,
+        signingKey: ecdsaKey,
+        privateStateId: CounterPrivateStateId,
+        initialPrivateState: privateStateZero
+      };
+      const deployedContract = await deployContract(providers, deployTxOptions);
+      await expectSuccessfulDeployTx(providers, deployedContract.deployTxData, deployTxOptions);
+
+      const contractAddress: ContractAddress = deployedContract.deployTxData.public.contractAddress;
+      providers.privateStateProvider.setContractAddress(contractAddress);
+      expect(await providers.privateStateProvider.getSigningKey(contractAddress)).toEqual(ecdsaKey);
+
+      // Capture the verifier key from the local artifacts before removing it on-chain so it can be
+      // re-inserted afterwards.
+      const incrementVk = await providers.zkConfigProvider.getVerifierKey(CIRCUIT_ID_INCREMENT);
+
+      const removeResult = await submitRemoveVerifierKeyTx(
+        providers,
+        CompiledCounterContract,
+        contractAddress,
+        CIRCUIT_ID_INCREMENT
+      );
+      expect(removeResult.status).toBe(SucceedEntirely);
+
+      const insertResult = await submitInsertVerifierKeyTx(
+        providers,
+        CompiledCounterContract,
+        contractAddress,
+        CIRCUIT_ID_INCREMENT,
+        incrementVk
+      );
+      expect(insertResult.status).toBe(SucceedEntirely);
+
+      // The authority key kind is unchanged by verifier-key maintenance actions.
+      expect(await providers.privateStateProvider.getSigningKey(contractAddress)).toEqual(ecdsaKey);
     },
     SLOW_TEST_TIMEOUT
   );


### PR DESCRIPTION
## Summary

Extends test coverage for ECDSA contract maintenance authority (CMA) keys, addressing the testing side of #901 ("Adopt possibility of ECDSA keys/signatures in Contract Maintenance Authorities"). The functional fix and the config-level regression guard already landed in #999; the remaining gap was that ECDSA was only exercised end-to-end for the *replace-authority* action, not the verifier-key maintenance actions, and never through the signing-key persistence round-trip.

- **e2e** (`testkit-js-e2e/test/contracts.signing-key.it.test.ts`): proves an ECDSA maintenance authority can authorize the verifier-key actions — `submitRemoveVerifierKeyTx` then `submitInsertVerifierKeyTx` — each asserting `SucceedEntirely`, which proves the ECDSA signature was produced and verified by the node. Folded into the existing signing-key e2e to reuse the already-running devnet (no extra container spin-up).
- **unit** (`level-private-state-provider`): a mixed schnorr+ecdsa signing-key export → clear → import round-trip, asserting each key and its `tag` survive the superjson + AES-256-GCM persistence path.

This is a deliberately minimal set: ECDSA config-key wiring is already guarded by the existing `packages/types/src/test/contract.test.ts` regression test, so redundant unit-level kind assertions were intentionally left out.

## Test plan

- [x] Unit suite green: `level-private-state-provider` (188 passed, incl. the new mixed-kind round-trip)
- [x] `packages/types` rebuilt (refreshed stale `dist` so `contracts` typechecks against current `PublicDataProvider`)
- [ ] e2e (`[@slow]`, Docker devnet required) — not run in this environment; needs a local/CI devnet before merge
- [x] No regressions in adjacent governance unit tests (6 passed)
- [x] Lint clean (pre-commit eslint passed)

Relates to #901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)