### PR TITLE
fix(config): pass --no-stash to lint-staged to keep GPG signatures valid

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,10 @@
 # `&&` so a non-zero exit from the leak check short-circuits the hook;
 # otherwise lint-staged's exit code overrides it and a poisoned package.json
 # can slip through unnoticed.
-node scripts/check-no-source-leak.js && npx lint-staged
+#
+# `--no-stash`: lint-staged's default backup stash rewrites the working tree
+# around the commit, which invalidates the GPG signature git computes for a
+# signed commit (producing "Unverified" commits on GitHub). Our task is
+# read-only (`eslint --cache`, no `--fix`), so it never modifies files and the
+# backup stash serves no purpose — disabling it keeps signatures valid.
+node scripts/check-no-source-leak.js && npx lint-staged --no-stash


### PR DESCRIPTION
## Summary
Fix lint-staged invalidating GPG signatures on signed commits (the cause of the "Unverified" commit on #1016).

- With `commit.gpgsign=true`, lint-staged's default backup stash rewrites the working tree around the commit, so the tree git records can diverge from the tree it signed → the commit is pushed with an **invalid signature** and shows as *Unverified* on GitHub. It's non-deterministic (depends on stash/restore timing), which is why some signed commits survive and others don't.
- The pre-commit task is read-only — `"*.ts": "eslint --cache"`, no `--fix` — so it never modifies files and the backup stash serves no purpose.
- **Fix:** pass `--no-stash` to lint-staged in `.husky/pre-commit`. Signatures stay valid; the incremental lint gate is unchanged.

```diff
-node scripts/check-no-source-leak.js && npx lint-staged
+node scripts/check-no-source-leak.js && npx lint-staged --no-stash
```

## Test plan
- [x] `.husky/pre-commit` still runs the source-leak check then lint-staged (behavior unchanged apart from stashing)
- [x] This PR's own commit is GPG-signed and verifies (proves the signing path)
- [ ] Next signed commit made through the hook shows **Verified** on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
