### PR TITLE
chore: update indexer version to 4.4.0-pre-alpha.16

### DIFF
--- a/testkit-js/env/devnet.env
+++ b/testkit-js/env/devnet.env
@@ -1,3 +1,3 @@
 PROOF_SERVER_VERSION=9.0.0-rc.4
-INDEXER_VERSION=4.4.0-pre-alpha.15-l91r3-n2r3-bridge-and-events-epics-blockhash-dust-f06af4b4
+INDEXER_VERSION=4.4.0-pre-alpha.16-l91r3-n2r3-bridge-and-events-epics-contract-zswap-16c656df
 MIDNIGHT_NODE_VERSION=2.0.0-rc.3


### PR DESCRIPTION
Bump indexer to 4.4.0-pre-alpha.16-l91r3-n2r3-bridge-and-events-epics-contract-zswap-16c656df