### PR TITLE
chore(config): enforce packageManager and engines consistency via yarn constraints

### DIFF
--- a/packages/compact/package.json
+++ b/packages/compact/package.json
@@ -7,7 +7,7 @@
   },
   "author": "IOG",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22"
   },
   "license": "Apache-2.0",
   "version": "5.0.0-beta.3",
@@ -35,5 +35,6 @@
   ],
   "dependencies": {
     "@midnight-ntwrk/midnight-js-utils": "workspace:*"
-  }
+  },
+  "packageManager": "yarn@4.14.1"
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -16,7 +16,7 @@
     }
   },
   "repository": "git@github.com:midnight-ntwrk/artifacts",
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "author": "IOHK",
   "license": "Apache-2.0",
   "scripts": {
@@ -42,5 +42,8 @@
     "@fast-check/vitest": "^0.4.1",
     "@midnight-ntwrk/midnight-js-compact": "workspace:*",
     "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/dapp-connector-proof-provider/package.json
+++ b/packages/dapp-connector-proof-provider/package.json
@@ -16,7 +16,7 @@
     }
   },
   "repository": "git@github.com:midnight-ntwrk/artifacts",
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "author": "IOHK",
   "license": "Apache-2.0",
   "scripts": {
@@ -35,5 +35,8 @@
   },
   "devDependencies": {
     "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/fetch-zk-config-provider/package.json
+++ b/packages/fetch-zk-config-provider/package.json
@@ -16,7 +16,7 @@
     }
   },
   "repository": "git@github.com:midnight-ntwrk/artifacts",
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "author": "IOHK",
   "license": "Apache-2.0",
   "scripts": {
@@ -37,5 +37,8 @@
     "@types/express": "^5.0.6",
     "express": "^5.2.1",
     "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/http-client-proof-provider/package.json
+++ b/packages/http-client-proof-provider/package.json
@@ -16,7 +16,7 @@
     }
   },
   "repository": "git@github.com:midnight-ntwrk/artifacts",
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "author": "IOHK",
   "license": "Apache-2.0",
   "scripts": {
@@ -42,5 +42,8 @@
   "devDependencies": {
     "@midnight-ntwrk/midnight-js-compact": "workspace:*",
     "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/indexer-public-data-provider/package.json
+++ b/packages/indexer-public-data-provider/package.json
@@ -16,7 +16,7 @@
     }
   },
   "repository": "git@github.com:midnight-ntwrk/artifacts",
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "author": "IOHK",
   "license": "Apache-2.0",
   "scripts": {
@@ -51,5 +51,8 @@
   },
   "files": [
     "dist/"
-  ]
+  ],
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/packages/level-private-state-provider/package.json
+++ b/packages/level-private-state-provider/package.json
@@ -17,7 +17,7 @@
   },
   "author": "IOG",
   "repository": "git@github.com:midnight-ntwrk/artifacts",
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "license": "Apache-2.0",
   "scripts": {
     "clean": "rm -rf dist tsconfig.build.tsbuildinfo .rollup.cache reports coverage",
@@ -38,5 +38,8 @@
   },
   "devDependencies": {
     "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/logger-provider/package.json
+++ b/packages/logger-provider/package.json
@@ -17,7 +17,7 @@
   },
   "author": "IOG",
   "repository": "git@github.com:midnight-ntwrk/artifacts",
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "license": "Apache-2.0",
   "scripts": {
     "clean": "rm -rf dist tsconfig.build.tsbuildinfo .rollup.cache reports coverage",
@@ -35,5 +35,8 @@
   },
   "files": [
     "dist/"
-  ]
+  ],
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/packages/midnight-js/package.json
+++ b/packages/midnight-js/package.json
@@ -50,7 +50,7 @@
   },
   "sideEffects": false,
   "repository": "git@github.com:midnight-ntwrk/artifacts",
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "author": "IOHK",
   "license": "Apache-2.0",
   "scripts": {
@@ -75,5 +75,8 @@
   },
   "files": [
     "dist/"
-  ]
+  ],
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/packages/network-id/package.json
+++ b/packages/network-id/package.json
@@ -16,7 +16,7 @@
     }
   },
   "repository": "git@github.com:midnight-ntwrk/artifacts",
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "author": "IOHK",
   "license": "Apache-2.0",
   "scripts": {
@@ -30,5 +30,8 @@
   ],
   "devDependencies": {
     "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/node-zk-config-provider/package.json
+++ b/packages/node-zk-config-provider/package.json
@@ -17,7 +17,7 @@
   },
   "author": "IOG",
   "repository": "git@github.com:midnight-ntwrk/artifacts",
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "license": "Apache-2.0",
   "scripts": {
     "clean": "rm -rf dist tsconfig.build.tsbuildinfo .rollup.cache reports coverage",
@@ -31,5 +31,8 @@
   },
   "devDependencies": {
     "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -90,7 +90,7 @@
   },
   "sideEffects": false,
   "repository": "git@github.com:midnight-ntwrk/artifacts",
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "author": "IOHK",
   "license": "Apache-2.0",
   "scripts": {
@@ -118,5 +118,8 @@
     "rollup-plugin-dts": "^6.4.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,7 +16,7 @@
     }
   },
   "repository": "git@github.com:midnight-ntwrk/artifacts",
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "author": "IOHK",
   "license": "Apache-2.0",
   "scripts": {
@@ -36,5 +36,8 @@
   },
   "devDependencies": {
     "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,7 +16,7 @@
     }
   },
   "repository": "git@github.com:midnight-ntwrk/artifacts",
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "author": "IOHK",
   "license": "Apache-2.0",
   "scripts": {
@@ -37,5 +37,8 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/testkit-js/testkit-js-e2e/package.json
+++ b/testkit-js/testkit-js-e2e/package.json
@@ -19,7 +19,7 @@
     "type": "git",
     "url": "git+ssh://git@github.com/midnight-ntwrk/artifacts.git"
   },
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "author": "IOHK",
   "license": "Apache-2.0",
   "scripts": {
@@ -78,5 +78,8 @@
   },
   "files": [
     "dist/"
-  ]
+  ],
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/testkit-js/testkit-js/package.json
+++ b/testkit-js/testkit-js/package.json
@@ -19,7 +19,7 @@
     "type": "git",
     "url": "git+ssh://git@github.com/midnight-ntwrk/artifacts.git"
   },
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.14.1",
   "author": "IOHK",
   "license": "Apache-2.0",
   "scripts": {
@@ -70,5 +70,8 @@
   },
   "files": [
     "dist/"
-  ]
+  ],
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -23,6 +23,27 @@ function highestRange(ranges) {
 }
 
 /**
+ * Propagates a manifest field from the root workspace to every other
+ * workspace, so the monorepo has a single source of truth. Adds the field
+ * where missing and rewrites it where it drifted.
+ *
+ * @param {import('@yarnpkg/types').Yarn.Constraints.Context} ctx
+ * @param {string[]} path
+ */
+function enforceRootField({ Yarn }, path) {
+  const root = Yarn.workspace({ cwd: '.' });
+  if (!root) return;
+
+  const expected = path.reduce((node, key) => node?.[key], root.manifest);
+  if (expected === undefined) return;
+
+  for (const workspace of Yarn.workspaces()) {
+    if (workspace.cwd === root.cwd) continue;
+    workspace.set(path, expected);
+  }
+}
+
+/**
  * @param {import('@yarnpkg/types').Yarn.Constraints.Context} ctx
  */
 function enforceConsistentVersions({ Yarn }) {
@@ -55,5 +76,7 @@ function enforceConsistentVersions({ Yarn }) {
 module.exports = defineConfig({
   async constraints(ctx) {
     enforceConsistentVersions(ctx);
+    enforceRootField(ctx, ['packageManager']);
+    enforceRootField(ctx, ['engines', 'node']);
   }
 });


### PR DESCRIPTION
## Summary
- Add an `enforceRootField` yarn constraint that propagates `packageManager` and `engines.node` from the root workspace to every package.
- Fixes metadata drift: 15 packages pinned `yarn@4.12.0` (root is `yarn@4.14.1`), and `engines.node` was declared inconsistently (`>=22.0.0`) or missing entirely.
- Canonical source of truth is the root `package.json`. `engines.node` stays at `>=22` (minimum runtime); `.nvmrc` remains the dev pin and is intentionally not coupled here.
- The constraint keeps this in sync going forward — future drift fails `yarn check` in CI.

## Test plan
- [x] `yarn constraints` reports violations before the fix, clean after
- [x] `yarn constraints --fix` applied; diff touches only `packageManager`/`engines` fields (no other churn)
- [x] Lint clean, no `any` casts (config-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)