### PR TITLE
chore: fix stale contributor docs and add coverage floor gate

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -71,7 +71,14 @@ jobs:
       - name: Aggregate coverage reports
         run: |
           mkdir -p .nyc_output
-          find . -type f -name 'coverage-final.json' -exec cp {} .nyc_output/ \;
+          # Copy each coverage-final.json under a unique name so `nyc merge` sees
+          # every package — identical basenames would otherwise overwrite one
+          # another, leaving a misleading single-package report.
+          i=0
+          find . -type f -name 'coverage-final.json' -not -path '*/node_modules/*' | while IFS= read -r f; do
+            cp "$f" ".nyc_output/coverage-$i.json"
+            i=$((i + 1))
+          done
           npx --yes nyc merge .nyc_output coverage.json
           npx --yes nyc report --reporter=html --report-dir=coverage --temp-dir=.nyc_output
           rm -rf .nyc_output

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,7 +299,7 @@ feat(contracts): add batch deployment support
 fix(private-state): handle encryption key rotation edge case
 test(indexer): add integration tests for subscription reconnection
 docs(readme): update quick start example
-chore(deps): bump typescript to 5.8.3
+chore(deps): bump typescript to 6.0.3
 ```
 
 ## Package Dependencies

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -221,7 +221,7 @@ git config --local tag.gpgSign true
 Without direnv, set manually:
 
 ```bash
-export COMPACTC_VERSION=0.29.0
+export COMPACTC_VERSION=0.33.0-rc.1
 ```
 
 ### Testkit environment selection
@@ -252,8 +252,9 @@ docker compose -f testkit-js/compose.yml up
 ## Building compactc from the `compact/` submodule
 
 For feature-branch work against unreleased compactc, build the compiler from
-the `compact/` git submodule (pinned to LFDT-Minokawa/compact at the `0.31.0`
-release commit) instead of downloading the prebuilt binary.
+the `compact/` git submodule (pinned to a specific LFDT-Minokawa/compact
+commit — run `git submodule status` to see the current pin) instead of
+downloading the prebuilt binary.
 
 Two paths — pick based on what you have installed locally:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/midnightntwrk/midnight-js/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/midnightntwrk/midnight-js/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.8-blue?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D22-green?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![GitHub Release](https://img.shields.io/github/v/release/midnightntwrk/midnight-js?logo=github)](https://github.com/midnightntwrk/midnight-js/releases)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/midnightntwrk/midnight-js/pulls)
@@ -237,7 +237,7 @@ New functionality must include unit and integration tests (TDD — tests first).
 
 - `pre-commit`: Runs lint-staged
 - `commit-msg`: Validates commit message format
-- `pre-push`: Runs full check suite
+- `pre-push`: Runs `yarn lint` and `yarn typecheck:tests`
 
 ## Glossary
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -82,7 +82,7 @@ direnv status
 If you prefer not to use direnv, manually set environment:
 
 ```bash
-export COMPACTC_VERSION=0.29.0
+export COMPACTC_VERSION=0.33.0-rc.1
 nvm use
 git config --local commit.gpgSign true
 git config --local tag.gpgSign true
@@ -229,9 +229,6 @@ git push --no-verify
 git commit -m "feat(contracts): add batch deployment"
 git commit -m "fix(utils): handle empty input"
 git commit -m "docs: update README"
-
-# Or use interactive commit
-yarn commit
 ```
 
 **Valid types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert`
@@ -302,7 +299,7 @@ yarn build
 direnv allow
 
 # Without direnv
-export COMPACTC_VERSION=0.29.0
+export COMPACTC_VERSION=0.33.0-rc.1
 ```
 
 ### Docker Compose Service Unhealthy

--- a/llms.txt
+++ b/llms.txt
@@ -296,7 +296,7 @@ await testEnv.shutdown();
 
 | Variable | Values |
 |----------|--------|
-| `MN_TEST_ENVIRONMENT` | `undeployed`, `devnet`, `testnet`, `env-var-remote` |
+| `MN_TEST_ENVIRONMENT` | `undeployed`, `qanet`, `preview`, `preprod`, `env-var-remote` |
 | `MN_TEST_WALLET_SEED` | Specific seed phrase (optional) |
 | `MN_TEST_NETWORK_ID` | Network identifier |
 | `MN_TEST_INDEXER` | Custom indexer URL |
@@ -332,8 +332,8 @@ midnight-js/
 
 ### Midnight Packages
 - `@midnight-ntwrk/compact-js` - Compact language runtime
-- `@midnight-ntwrk/ledger-v8` - Ledger types
-- `@midnight-ntwrk/onchain-runtime-v3` - On-chain VM
+- `@midnightntwrk/ledger-v9` - Ledger types
+- `@midnightntwrk/onchain-runtime-v4` - On-chain VM
 - `@midnight-ntwrk/compact-runtime` - Circuit execution
 - `@midnight-ntwrk/wallet-sdk-facade` - Wallet integration
 

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -34,7 +34,13 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['**/test/**'],
       reporter: ['clover', 'json', 'json-summary', 'lcov', 'text'],
-      reportsDirectory: './coverage'
+      reportsDirectory: './coverage',
+      thresholds: {
+        lines: 30,
+        functions: 28,
+        branches: 25,
+        statements: 31
+      }
     },
     reporters: [
       'default',

--- a/packages/dapp-connector-proof-provider/vitest.config.ts
+++ b/packages/dapp-connector-proof-provider/vitest.config.ts
@@ -30,7 +30,13 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['**/test/**'],
       reporter: ['clover', 'json', 'json-summary', 'lcov', 'text'],
-      reportsDirectory: './coverage'
+      reportsDirectory: './coverage',
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        branches: 100,
+        statements: 100
+      }
     },
     reporters: [
       'default',

--- a/packages/fetch-zk-config-provider/vitest.config.ts
+++ b/packages/fetch-zk-config-provider/vitest.config.ts
@@ -29,7 +29,13 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['**/test/**'],
       reporter: ['clover', 'json', 'json-summary', 'lcov', 'text'],
-      reportsDirectory: './coverage'
+      reportsDirectory: './coverage',
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        branches: 93,
+        statements: 100
+      }
     },
     reporters: [
       'default',

--- a/packages/http-client-proof-provider/vitest.config.ts
+++ b/packages/http-client-proof-provider/vitest.config.ts
@@ -30,7 +30,13 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['**/test/**'],
       reporter: ['clover', 'json', 'json-summary', 'lcov', 'text'],
-      reportsDirectory: './coverage'
+      reportsDirectory: './coverage',
+      thresholds: {
+        lines: 80,
+        functions: 70,
+        branches: 78,
+        statements: 80
+      }
     },
     reporters: [
       'default',

--- a/packages/indexer-public-data-provider/vitest.config.ts
+++ b/packages/indexer-public-data-provider/vitest.config.ts
@@ -30,7 +30,13 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['**/test/**', 'src/gen/**'],
       reporter: ['clover', 'json', 'json-summary', 'lcov', 'text'],
-      reportsDirectory: './coverage'
+      reportsDirectory: './coverage',
+      thresholds: {
+        lines: 76,
+        functions: 65,
+        branches: 70,
+        statements: 77
+      }
     },
     reporters: [
       'default',

--- a/packages/level-private-state-provider/vitest.config.ts
+++ b/packages/level-private-state-provider/vitest.config.ts
@@ -29,7 +29,13 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['**/test/**'],
       reporter: ['clover', 'json', 'json-summary', 'lcov', 'text'],
-      reportsDirectory: './coverage'
+      reportsDirectory: './coverage',
+      thresholds: {
+        lines: 93,
+        functions: 100,
+        branches: 82,
+        statements: 93
+      }
     },
     reporters: [
       'default',

--- a/packages/logger-provider/vitest.config.ts
+++ b/packages/logger-provider/vitest.config.ts
@@ -30,7 +30,13 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['**/test/**'],
       reporter: ['clover', 'json', 'json-summary', 'lcov', 'text'],
-      reportsDirectory: './coverage'
+      reportsDirectory: './coverage',
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        branches: 100,
+        statements: 100
+      }
     },
     reporters: [
       'default',

--- a/packages/midnight-js/README.md
+++ b/packages/midnight-js/README.md
@@ -28,7 +28,6 @@ const deployed = await contracts.deployContract(providers, {
 | ------------ | ---------------------------------------- | ---------------------------------------------- |
 | `contracts`  | `@midnight-ntwrk/midnight-js-contracts`  | Contract deployment and interaction utilities   |
 | `networkId`  | `@midnight-ntwrk/midnight-js-network-id` | Network identifier management                  |
-| `protocol`   | `@midnight-ntwrk/midnight-js-protocol`   | Version-agnostic protocol type re-exports       |
 | `types`      | `@midnight-ntwrk/midnight-js-types`      | Shared types, interfaces, and provider contracts|
 | `utils`      | `@midnight-ntwrk/midnight-js-utils`      | Hex encoding, address validation, and utilities |
 

--- a/packages/midnight-js/vitest.config.ts
+++ b/packages/midnight-js/vitest.config.ts
@@ -30,6 +30,12 @@ export default defineConfig({
       exclude: ['**/test/**'],
       reporter: ['clover', 'json', 'json-summary', 'lcov', 'text'],
       reportsDirectory: './coverage',
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        branches: 100,
+        statements: 100
+      }
     },
     reporters: [
       'default',

--- a/packages/network-id/vitest.config.ts
+++ b/packages/network-id/vitest.config.ts
@@ -29,7 +29,13 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['**/test/**'],
       reporter: ['clover', 'json', 'json-summary', 'lcov', 'text'],
-      reportsDirectory: './coverage'
+      reportsDirectory: './coverage',
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        branches: 100,
+        statements: 100
+      }
     },
     reporters: [
       'default',

--- a/packages/node-zk-config-provider/vitest.config.ts
+++ b/packages/node-zk-config-provider/vitest.config.ts
@@ -29,7 +29,13 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['**/test/**'],
       reporter: ['clover', 'json', 'json-summary', 'lcov', 'text'],
-      reportsDirectory: './coverage'
+      reportsDirectory: './coverage',
+      thresholds: {
+        lines: 69,
+        functions: 62,
+        branches: 55,
+        statements: 69
+      }
     },
     reporters: [
       'default',

--- a/packages/protocol/vitest.config.ts
+++ b/packages/protocol/vitest.config.ts
@@ -30,6 +30,12 @@ export default defineConfig({
       exclude: ['**/test/**'],
       reporter: ['clover', 'json', 'json-summary', 'lcov', 'text'],
       reportsDirectory: './coverage',
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        branches: 100,
+        statements: 100
+      }
     },
     reporters: [
       'default',

--- a/packages/types/vitest.config.ts
+++ b/packages/types/vitest.config.ts
@@ -29,7 +29,13 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['**/test/**'],
       reporter: ['clover', 'json', 'json-summary', 'lcov', 'text'],
-      reportsDirectory: './coverage'
+      reportsDirectory: './coverage',
+      thresholds: {
+        lines: 49,
+        functions: 36,
+        branches: 61,
+        statements: 49
+      }
     },
     reporters: [
       'default',

--- a/packages/utils/vitest.config.ts
+++ b/packages/utils/vitest.config.ts
@@ -29,7 +29,13 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['**/test/**'],
       reporter: ['clover', 'json', 'json-summary', 'lcov', 'text'],
-      reportsDirectory: './coverage'
+      reportsDirectory: './coverage',
+      thresholds: {
+        lines: 97,
+        functions: 94,
+        branches: 93,
+        statements: 97
+      }
     },
     reporters: [
       'default',

--- a/turbo.json
+++ b/turbo.json
@@ -22,7 +22,7 @@
     "test": {
       "outputLogs": "new-only",
       "dependsOn": ["^build"],
-      "inputs": ["src/**/*.ts", "compose.yml"],
+      "inputs": ["src/**/*.ts", "vitest.config.ts", "vitest.*.config.ts", "compose.yml"],
       "outputs": ["reports/**", "coverage/**", "logs/**"]
     },
     "it": {


### PR DESCRIPTION
## Summary

Outcomes from a repository documentation/quality audit.

**Documentation** — correct contributor docs that had drifted from the codebase:
- `README`: TypeScript badge `5.8` → `6.0` (actual `^6.0.3`); accurate `pre-push` hook description (`yarn lint` + `yarn typecheck:tests`, not "full check suite")
- `AGENTS`: example commit uses current `typescript 6.0.3`
- `llms.txt`: `@midnightntwrk/ledger-v9` / `onchain-runtime-v4` (were `v8`/`v3`); `MN_TEST_ENVIRONMENT` values match the testkit `environment-provider` switch (`qanet`/`preview`/`preprod`)
- `DEVELOPMENT` / `TROUBLESHOOTING`: `COMPACTC_VERSION=0.33.0-rc.1` (was `0.29.0`); compact submodule pin now points readers to `git submodule status` instead of a stale tag
- `TROUBLESHOOTING`: drop the non-existent `yarn commit` instruction
- `midnight-js/README`: remove the `protocol` row (not a barrel module export — `index.ts` exposes only `contracts`/`networkId`/`types`/`utils`)

**Per-package coverage thresholds** — using Vitest's built-in gate, no custom script and no external service:
- Each package's `vitest.config.ts` gets `coverage.thresholds`, set to its current baseline (floored). `yarn test` now fails locally and in CI when a package regresses below its own coverage.
- `turbo.json`: added the vitest config files to the `test` task inputs so a threshold change invalidates the cache (otherwise a cached test run could bypass the gate).

**CI aggregation bug fix** — the "Aggregate coverage reports" step copied every `coverage-final.json` to the same basename, so `nyc merge` only saw one package (the HTML artifact was effectively single-package). Files are now copied under unique names; the merged report spans all packages.

## Test plan
- [x] `yarn test:unit --force` (full run, no cache) — all 20 tasks pass with the new thresholds; verified a threshold above actual fails vitest (`ERROR: Coverage ... does not meet global threshold`)
- [x] Thresholds set from measured per-package baselines (floored), so they pass today and catch regressions
- [x] `eslint` clean on changed vitest configs and `eslint.config.mjs`
- [x] CI aggregation fix verified locally — merged coverage now spans all 14 packages instead of one
- [x] Doc values verified against current `main` (`.envrc`, `packages/protocol`, testkit source); branch based on current `main`
