### PR TITLE
ci: restrict to release/** and support explicit dist-tag

### DIFF
--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -1,12 +1,13 @@
 name: Publish (manual)
 #
-# Workaround to publish the current `main` on demand, WITHOUT a version-bump
-# commit and WITHOUT the full CI/e2e cycle (main is assumed already tested).
+# Ad-hoc publish of a `release/**` branch on demand, WITHOUT a version-bump
+# commit and WITHOUT the full CI/e2e cycle (the branch is assumed already tested).
 #
-# It publishes the version currently in the root package.json AS-IS, for a
-# version that has NOT yet been published — e.g. to finish a release whose
-# automatic publish never completed (CI timed out mid-run), or to publish main
-# ahead of the last release.
+# It publishes the version currently in the root package.json AS-IS, under the
+# chosen npm dist-tag (default `latest`), for a version that has NOT yet been
+# published — e.g. to finish a release whose automatic publish never completed
+# (CI timed out mid-run), or to ship a maintenance release under a side tag
+# (leaving `latest` untouched).
 #
 # The guard is an UNCONDITIONAL hard stop: if the current version is already on
 # the registry, the workflow refuses to run. There is deliberately no override —
@@ -20,6 +21,11 @@ env:
 
 on:
   workflow_dispatch:
+    inputs:
+      dist_tag:
+        description: 'npm dist-tag to publish under. Default: latest.'
+        required: false
+        default: 'latest'
 
 permissions:
   contents: write
@@ -32,14 +38,25 @@ concurrency:
 
 jobs:
   publish:
-    name: Publish current main
+    name: Publish release branch
     runs-on: ubuntu-latest
     steps:
-      - name: Guard - main only
-        if: github.ref != 'refs/heads/main'
+      - name: Guard - release branch only
+        if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
         run: |
-          echo "::error::publish-manual can only run from main (got ${{ github.ref }})."
+          echo "::error::publish-manual can only run from a release/** branch (got ${{ github.ref }})."
           exit 1
+
+      - name: Validate dist-tag
+        env:
+          DIST_TAG: ${{ inputs.dist_tag }}
+        run: |
+          set -euo pipefail
+          if ! echo "$DIST_TAG" | grep -Eq '^[a-zA-Z0-9][a-zA-Z0-9._-]*$'; then
+            echo "::error::Invalid dist-tag '$DIST_TAG' (allowed: letters, digits, '.', '-', '_'; must start alphanumeric)."
+            exit 1
+          fi
+          echo "Publishing under dist-tag '$DIST_TAG'."
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
@@ -93,7 +110,7 @@ jobs:
           ' CHANGELOG.md > release_notes.md
           # Fall back to a minimal body when CHANGELOG has no section for this version.
           if [ ! -s release_notes.md ]; then
-            echo "Manual release of v${VERSION_NUMBER} from main @ $(git rev-parse --short HEAD)." > release_notes.md
+            echo "Manual release of v${VERSION_NUMBER} from ${GITHUB_REF_NAME} @ $(git rev-parse --short HEAD)." > release_notes.md
           fi
 
       - name: Validate packages before publishing
@@ -103,9 +120,10 @@ jobs:
 
       - name: Publish packages
         run: |
-          yarn deploy --filter="./packages/*" --cache-dir ./turbo --concurrency=1
+          yarn deploy --filter="./packages/*" --cache-dir ./turbo --concurrency=1 -- --tag "$DIST_TAG"
         env:
           GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+          DIST_TAG: ${{ inputs.dist_tag }}
 
       - name: Bump testkit-js versions
         env:
@@ -119,10 +137,11 @@ jobs:
 
       - name: Publish testkit-js packages
         run: |
-          yarn deploy --filter="./testkit-js/*" --cache-dir ./turbo --concurrency=1
+          yarn deploy --filter="./testkit-js/*" --cache-dir ./turbo --concurrency=1 -- --tag "$DIST_TAG"
         env:
           GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
           NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+          DIST_TAG: ${{ inputs.dist_tag }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # ratchet:softprops/action-gh-release@v3.0.1
@@ -134,6 +153,8 @@ jobs:
           body_path: release_notes.md
           draft: false
           # A version with a pre-release identifier (e.g. 5.0.0-beta.1) is flagged
-          # as a pre-release and must NOT become the "Latest" release.
+          # as a pre-release. The GitHub Release is marked "Latest" only for a
+          # stable version published under the `latest` dist-tag — a side-tag
+          # publish (e.g. v4-lts) must not move the "Latest" badge.
           prerelease: ${{ contains(steps.guard.outputs.version, '-') }}
-          make_latest: ${{ contains(steps.guard.outputs.version, '-') && 'false' || 'true' }}
+          make_latest: ${{ (inputs.dist_tag == 'latest' && !contains(steps.guard.outputs.version, '-')) && 'true' || 'false' }}

--- a/README.md
+++ b/README.md
@@ -353,6 +353,10 @@ When the release PR is merged, the version bump on `main` triggers the `publish`
 3. Creates a GitHub Release with the extracted notes (creating the `v<VERSION>` tag on the merge commit)
 4. Publishes `testkit-js/*` if those paths changed
 
+#### Ad-hoc publish from a release branch
+
+The **Publish (manual)** workflow ([`.github/workflows/publish-manual.yml`](./.github/workflows/publish-manual.yml)) publishes the version currently in `package.json` from a `release/**` branch, on demand, without a version bump or the full CI/e2e cycle. Run it from the Actions tab against a `release/**` branch; optionally set the `dist_tag` input (default `latest`) to publish under a side tag such as `v4-lts` without moving `latest`. It refuses to run when that version is already published, and marks the GitHub Release "Latest" only for a stable version published under the `latest` tag. Use it to finish a release whose automatic publish never completed, or to ship a maintenance release under a side tag.
+
 ## Resources
 
 - [Midnight Network](https://midnight.network)


### PR DESCRIPTION
## Summary

Retargets the manual publish workflow (`.github/workflows/publish-manual.yml`) from "publish current `main`" to an ad-hoc publisher for `release/**` branches, with a selectable npm dist-tag.

- **Restricted to `release/**` refs** — the guard now fails unless `github.ref` starts with `refs/heads/release/` (was main-only).
- **Explicit dist-tag** — new optional `workflow_dispatch` input `dist_tag` (default `latest`), validated (`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`, fail-fast) and passed to `yarn deploy … -- --tag "$DIST_TAG"` (via `env:`, injection-safe) for both `packages/*` and `testkit-js/*`. Publishing under a side tag (e.g. `v4-lts`) leaves `latest` untouched.
- **`already-published` guard unchanged** — the unconditional hard stop still refuses to touch a version that's already on the registry.
- **GitHub Release "Latest" coupling** — the release is marked `make_latest` only for a stable version published under the `latest` dist-tag, so a side-tag publish never moves the "Latest" badge.
- Header comments and job name updated to match; release-notes fallback uses the actual ref name instead of "main".

## Test plan

- [x] Workflow YAML parses (ruby/psych).
- [x] `dist_tag` reaches publish only through a quoted `env:` var — no `${{ }}` interpolation in `run:` (no shell injection).
- [x] `-- --tag` passthrough matches the existing pattern in `ci-midnight-js.yml` / `ci-testkit-js-prerelease.yml`.
- [ ] Dispatch from a `release/**` branch with default tag → publishes to `latest`; with `dist_tag=v4-lts` → publishes to that tag and `latest` is untouched (verified in CI / on a throwaway version).
- [ ] Dispatch from a non-`release/**` ref → guard fails fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
