### PR TITLE
docs(midnight-js): add ADR template and create/read enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,6 +340,39 @@ Before implementing, clarify:
 - [Vitest Documentation](https://vitest.dev/)
 - [Conventional Commits](https://www.conventionalcommits.org/)
 
+## Architecture Decision Records (ADRs)
+
+Architecturally significant decisions are recorded as ADRs in [`docs/adr/`](./docs/adr/).
+This is a hard workflow requirement, not a suggestion.
+
+### Read — MUST, before any architecture-affecting change
+
+1. Read the index in [`docs/adr/README.md`](./docs/adr/README.md).
+2. Find any **Accepted** ADR relevant to what you are about to change.
+3. Follow it. If your change would contradict an Accepted ADR, do **not**
+   silently diverge — either keep the decision, or write a new ADR that
+   supersedes it (see below) and call out the reversal in your PR.
+
+### Create — MUST, when a change qualifies
+
+Write a new ADR before implementing any of:
+
+- Changes to provider interfaces in `packages/types/src` (breaks all downstream packages).
+- Adding a provider implementation, or changing a provider's public shape.
+- Adding a new runtime dependency, or swapping a core library (crypto, GraphQL client, etc.).
+- Any breaking change to a package's exported public API (major version bump).
+
+If unsure whether a change qualifies, it probably does — write the ADR.
+
+### How
+
+1. Copy [`docs/adr/template.md`](./docs/adr/template.md) to
+   `docs/adr/NNNN-kebab-title.md` using the next sequential zero-padded number.
+2. Open it as `Proposed`, fill in Context / Decision / Consequences / Alternatives.
+3. Add a row to the index table in `docs/adr/README.md`.
+4. Flip the status to `Accepted` when the decision lands. To reverse a past
+   decision, add a new ADR and mark the old one `Superseded by ADR-NNNN`.
+
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,42 @@
+# 0001. Record architecture decisions
+
+- Status: Accepted
+- Date: 2026-07-09
+- Deciders: Midnight.js maintainers
+
+## Context
+
+Midnight.js is a layered framework where a handful of decisions — provider
+interface shapes in `packages/types/src`, the transaction flow, dependency
+choices — ripple across every downstream package. These decisions were being
+made in PR threads and chat, where the reasoning is hard to find later. Both
+new contributors and AI agents working in the repo need a durable, greppable
+record of *why* the architecture is the way it is, not just *what* it is.
+
+## Decision
+
+We will record architecturally significant decisions as Architecture Decision
+Records (ADRs) stored in `docs/adr/`, one Markdown file per decision, using the
+MADR-lite template in [`template.md`](./template.md). Files are named
+`NNNN-kebab-title.md` with a zero-padded sequential number. The index in
+[`README.md`](./README.md) lists every ADR and its status.
+
+## Consequences
+
+- **Positive:** decision rationale is versioned alongside the code, reviewable
+  in PRs, and discoverable by grep or the repo's documentation skills, which
+  already look under `docs/adr/`.
+- **Negative:** contributors must spend time writing an ADR for qualifying
+  changes; the index must be kept in sync by hand.
+- **Follow-ups:** enforcement guidance for contributors and agents lives in
+  [AGENTS.md](../../AGENTS.md); a CI gate could be added later if manual
+  discipline proves insufficient.
+
+## Alternatives considered
+
+- **No ADRs (status quo):** rejected — reasoning kept leaking into ephemeral PR
+  and chat threads.
+- **A single running decisions log:** rejected — one file grows unwieldy and
+  produces merge conflicts; per-file ADRs review and diff cleanly.
+- **A wiki or external doc tool:** rejected — decisions drift out of sync with
+  the code and are invisible to in-repo tooling and agents.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,38 @@
+# Architecture Decision Records
+
+This directory records architecturally significant decisions for Midnight.js.
+Each ADR captures the context, the decision, and its consequences so the
+reasoning survives beyond the PR thread where it was made.
+
+See [ADR-0001](./0001-record-architecture-decisions.md) for why we keep ADRs.
+
+## When to write one
+
+Write an ADR for a change that is expensive to reverse or that constrains
+future work. In this repo that means, at minimum:
+
+- Changes to provider interfaces in `packages/types/src`.
+- Adding a provider implementation, or changing a provider's public shape.
+- Adding a new runtime dependency, or swapping a core library.
+- Any breaking change to a package's exported public API.
+
+The full contributor/agent rules live in [AGENTS.md](../../AGENTS.md#architecture-decision-records-adrs).
+
+## How to add one
+
+1. Copy [`template.md`](./template.md) to `NNNN-kebab-title.md`, where `NNNN`
+   is the next sequential zero-padded number.
+2. Fill it in and open the PR with the ADR marked `Proposed`.
+3. On merge/approval, change the status to `Accepted` and add a row below.
+4. To reverse a past decision, write a new ADR and mark the old one
+   `Superseded by ADR-NNNN`.
+
+## Statuses
+
+`Proposed` · `Accepted` · `Deprecated` · `Superseded by ADR-NNNN`
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](./0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,28 @@
+# NNNN. <short title in imperative mood>
+
+- Status: Proposed
+- Date: YYYY-MM-DD
+- Deciders: <names>
+
+## Context
+
+What forces are at play? What problem are we solving, and what constraints
+(technical, organizational, timeline) shape the decision? State the facts
+neutrally — no decision here yet.
+
+## Decision
+
+The choice we are making, in active voice: "We will …". Be specific enough that
+a reader can tell whether a future change contradicts it.
+
+## Consequences
+
+- **Positive:** what gets easier or safer.
+- **Negative:** what gets harder, what we give up, new risks.
+- **Follow-ups:** work this decision now requires (migrations, deprecations,
+  further ADRs).
+
+## Alternatives considered
+
+Each option we rejected and the reason. Absence of alternatives usually means
+the decision was not actually contested — say so if that is the case.


### PR DESCRIPTION
## Summary
- Add an Architecture Decision Records directory at `docs/adr/`:
  - `template.md` — MADR-lite template (Status / Context / Decision / Consequences / Alternatives)
  - `README.md` — index + how-to (numbering `NNNN-kebab-title.md`, statuses, workflow)
  - `0001-record-architecture-decisions.md` — bootstrap ADR (Accepted) explaining the practice
- Wire ADR enforcement into `AGENTS.md` under a new **Architecture Decision Records (ADRs)** section:
  - **Read (MUST):** consult `docs/adr/` before any architecture-affecting change; honor Accepted ADRs or write a superseding one — no silent divergence.
  - **Create (MUST):** required for `packages/types/src` interface changes, provider add/shape changes, new runtime dependencies, and breaking public API changes.
- Location `docs/adr/` aligns with paths the repo's `grill-with-docs` and `improve-codebase-architecture` skills already reference.

Docs-only change: no source files touched, so no license headers, build, or code-impact analysis needed.

## Test plan
- [ ] N/A — documentation only (no tests)
- [x] Relative links in `docs/adr/` and the `AGENTS.md` anchor verified
- [x] Lint clean (no `.ts/.js/.sh` files changed)
- [x] Commit GPG-signed and conventional-commit formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)