### PR TITLE
docs(midnight-js): author ADRs as Accepted and drop the shared index table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,7 +347,7 @@ This is a hard workflow requirement, not a suggestion.
 
 ### Read — MUST, before any architecture-affecting change
 
-1. Read the index in [`docs/adr/README.md`](./docs/adr/README.md).
+1. Browse the ADRs in [`docs/adr/`](./docs/adr/) — the files are the list.
 2. Find any **Accepted** ADR relevant to what you are about to change.
 3. Follow it. If your change would contradict an Accepted ADR, do **not**
    silently diverge — either keep the decision, or write a new ADR that
@@ -367,11 +367,12 @@ If unsure whether a change qualifies, it probably does — write the ADR.
 ### How
 
 1. Copy [`docs/adr/template.md`](./docs/adr/template.md) to
-   `docs/adr/NNNN-kebab-title.md` using the next sequential zero-padded number.
+   `docs/adr/NNNN-kebab-title.md` using the next sequential zero-padded number
+   (list the directory to find the highest existing one).
 2. Fill in Context / Decision / Consequences / Alternatives, marked `Accepted` —
    approving the PR is the acceptance, so ADRs land `Accepted`, not `Proposed`.
-3. Add a row to the index table in `docs/adr/README.md` in the same PR.
-4. To reverse a past decision, add a new ADR and mark the old one
+   There is no shared index to update, so ADR PRs never conflict with each other.
+3. To reverse a past decision, add a new ADR and mark the old one
    `Superseded by ADR-NNNN`.
 
 <!-- gitnexus:start -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,10 +368,11 @@ If unsure whether a change qualifies, it probably does — write the ADR.
 
 1. Copy [`docs/adr/template.md`](./docs/adr/template.md) to
    `docs/adr/NNNN-kebab-title.md` using the next sequential zero-padded number.
-2. Open it as `Proposed`, fill in Context / Decision / Consequences / Alternatives.
-3. Add a row to the index table in `docs/adr/README.md`.
-4. Flip the status to `Accepted` when the decision lands. To reverse a past
-   decision, add a new ADR and mark the old one `Superseded by ADR-NNNN`.
+2. Fill in Context / Decision / Consequences / Alternatives, marked `Accepted` —
+   approving the PR is the acceptance, so ADRs land `Accepted`, not `Proposed`.
+3. Add a row to the index table in `docs/adr/README.md` in the same PR.
+4. To reverse a past decision, add a new ADR and mark the old one
+   `Superseded by ADR-NNNN`.
 
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -18,8 +18,8 @@ record of *why* the architecture is the way it is, not just *what* it is.
 We will record architecturally significant decisions as Architecture Decision
 Records (ADRs) stored in `docs/adr/`, one Markdown file per decision, using the
 MADR-lite template in [`template.md`](./template.md). Files are named
-`NNNN-kebab-title.md` with a zero-padded sequential number. The index in
-[`README.md`](./README.md) lists every ADR and its status.
+`NNNN-kebab-title.md` with a zero-padded sequential number. The files in
+`docs/adr/` are themselves the list, so there is no separately maintained index.
 
 ## Consequences
 
@@ -27,7 +27,7 @@ MADR-lite template in [`template.md`](./template.md). Files are named
   in PRs, and discoverable by grep or the repo's documentation skills, which
   already look under `docs/adr/`.
 - **Negative:** contributors must spend time writing an ADR for qualifying
-  changes; the index must be kept in sync by hand.
+  changes.
 - **Follow-ups:** enforcement guidance for contributors and agents lives in
   [AGENTS.md](../../AGENTS.md); a CI gate could be added later if manual
   discipline proves insufficient.

--- a/docs/adr/0002-compact-js-owns-local-execution-events.md
+++ b/docs/adr/0002-compact-js-owns-local-execution-events.md
@@ -1,6 +1,6 @@
 # 0002. Forward contract log events from local execution; keep the indexer path independent
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-07-09
 - Deciders: Szymon Paluchowski
 - Related: [MIP-0002](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-0002-public-contract-log-emission.md), PR #1083, PR #1081

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,21 +21,17 @@ The full contributor/agent rules live in [AGENTS.md](../../AGENTS.md#architectur
 ## How to add one
 
 1. Copy [`template.md`](./template.md) to `NNNN-kebab-title.md`, where `NNNN`
-   is the next sequential zero-padded number.
-2. Fill it in as `Accepted` and add its row to the index below — all in the
-   same PR. Approving the PR *is* the acceptance, so there is no separate
-   status flip after merge.
+   is the next sequential zero-padded number — list this directory to find the
+   highest existing one.
+2. Fill it in as `Accepted`: approving the PR *is* the acceptance, so there is
+   no separate status flip after merge.
 3. To reverse a past decision, write a new ADR and mark the old one
    `Superseded by ADR-NNNN`.
+
+There is no index to maintain — the ADR files in this directory are the list.
+This keeps each ADR PR limited to its own new file, so concurrent PRs never
+conflict on a shared table.
 
 ## Statuses
 
 `Proposed` · `Accepted` · `Deprecated` · `Superseded by ADR-NNNN`
-
-## Index
-
-| ADR | Title | Status |
-|-----|-------|--------|
-| [0001](./0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
-| [0002](./0002-compact-js-owns-local-execution-events.md) | Forward contract log events from local execution; keep the indexer path independent | Accepted |
-| [0003](./0003-prefer-interfaces-over-object-type-aliases.md) | Prefer interfaces over object-type aliases for named object types | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,9 +22,10 @@ The full contributor/agent rules live in [AGENTS.md](../../AGENTS.md#architectur
 
 1. Copy [`template.md`](./template.md) to `NNNN-kebab-title.md`, where `NNNN`
    is the next sequential zero-padded number.
-2. Fill it in and open the PR with the ADR marked `Proposed`.
-3. On merge/approval, change the status to `Accepted` and add a row below.
-4. To reverse a past decision, write a new ADR and mark the old one
+2. Fill it in as `Accepted` and add its row to the index below — all in the
+   same PR. Approving the PR *is* the acceptance, so there is no separate
+   status flip after merge.
+3. To reverse a past decision, write a new ADR and mark the old one
    `Superseded by ADR-NNNN`.
 
 ## Statuses

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,3 +36,4 @@ The full contributor/agent rules live in [AGENTS.md](../../AGENTS.md#architectur
 | ADR | Title | Status |
 |-----|-------|--------|
 | [0001](./0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
+| [0002](./0002-compact-js-owns-local-execution-events.md) | Forward contract log events from local execution; keep the indexer path independent | Accepted |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,6 +1,6 @@
 # NNNN. <short title in imperative mood>
 
-- Status: Proposed
+- Status: Accepted
 - Date: YYYY-MM-DD
 - Deciders: <names>
 


### PR DESCRIPTION
## Summary
- **Author ADRs as `Accepted`, not `Proposed`.** Approving the PR *is* the acceptance, so an ADR lands on `main` as `Accepted` instead of merging as `Proposed` and needing a second PR to flip the status. Updates `docs/adr/template.md` (default status), `docs/adr/README.md`, and `AGENTS.md` authoring steps. Marks ADR 0002 `Accepted`.
- **Drop the manually-maintained index table.** The index table in `docs/adr/README.md` forced every ADR PR to edit the same shared lines, so concurrent ADR PRs conflicted on it (this PR was itself an instance — slotting `0002` between an already-merged `0001` and `0003`). The ADR files in `docs/adr/` are self-describing and sequentially numbered, so the directory listing *is* the list. Removes the table and rewrites the authoring steps; updates ADR-0001's mechanism description and drops its now-obsolete "keep the index in sync by hand" consequence.

## Test plan
- [x] Docs-only change; no code affected.
- [x] No remaining references to the removed index section anywhere in the repo.
