### PR TITLE
ci: fix GPG signing failure in docs and release-prepare workflows

### DIFF
--- a/.github/workflows/docs-api.yml
+++ b/.github/workflows/docs-api.yml
@@ -53,6 +53,15 @@ jobs:
           yarn run build:markdown-docs
           cd testkit-js/testkit-js && yarn run build:markdown-docs
 
+      # `.envrc` (loaded by setup-build-env via direnv) sets `commit.gpgSign=true`
+      # for local contributors, but the runner has no GPG secret key. Without
+      # this override, create-pull-request's local commit fails with
+      # "gpg: signing failed: No secret key". Overridden locally so it does not
+      # affect contributors. For verified branch commits, switch to a GitHub App
+      # token and re-add sign-commits (see the note on the PR step below).
+      - name: Disable local commit signing (no GPG key on runner)
+        run: git config commit.gpgsign false
+
       # Both typedoc generators write under docs/, so staging that path captures
       # every generated change. create-pull-request no-ops when the tree is clean,
       # so the previous explicit `git status ./docs` guard is no longer needed.

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -65,6 +65,15 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: bash scripts/release.sh "$VERSION" --files-only
 
+      # `.envrc` (loaded by setup-build-env via direnv) sets `commit.gpgSign=true`
+      # for local contributors, but the runner has no GPG secret key. Without
+      # this override, create-pull-request's local commit fails with
+      # "gpg: signing failed: No secret key". Overridden locally so it does not
+      # affect contributors. For verified branch commits, switch to a GitHub App
+      # token and re-add sign-commits.
+      - name: Disable local commit signing (no GPG key on runner)
+        run: git config commit.gpgsign false
+
       - name: Create release PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # ratchet:peter-evans/create-pull-request@v8.1.1
         with:


### PR DESCRIPTION
## Summary

- Both `docs-api.yml` and `release-prepare.yml` load `.envrc` via `setup-build-env`, which runs `git config --local commit.gpgSign true`. `peter-evans/create-pull-request` makes a **local** `git commit`, so it inherits that setting and fails on the runner (no GPG secret key) with `gpg: signing failed: No secret key` → `fatal: failed to write commit object`.
- **docs-api**: failing on every push to `main` whose regenerated docs differ (e.g. [run 29084538033](https://github.com/midnightntwrk/midnight-js/actions/runs/29084538033)); passes only when the tree is clean (create-pull-request no-ops).
- **release-prepare**: new + `workflow_dispatch`-only, so never run yet — but would fail on first dispatch for the same reason.
- Fix: add a `git config commit.gpgsign false` step just before the `create-pull-request` step in both workflows. Overridden locally so contributors' signing config is untouched.

The automatic `publish` job in `ci.yml` and `publish-manual.yml` are **not affected** — they never do a local commit/tag; the release tag is created server-side via the GitHub API (`softprops/action-gh-release`).

### Follow-up (not in this PR)
For *verified* branch commits, switch these workflows to a GitHub App token (`actions/create-github-app-token`) + `sign-commits: true`, which commits via the GitHub API (bot-signed, no local key). Requires an App + secrets that aren't available yet. Documented inline.

## Test plan
- [x] Root cause confirmed from the failing run log (`No secret key`) and traced to `.envrc:25` + local-commit path in create-pull-request.
- [ ] docs-api: verified green on next push to `main` that changes generated docs (post-merge).
- [ ] release-prepare: verified green on manual dispatch (post-merge).
- No app code touched; lint/build unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)