### PR TITLE
ci: sign docs/release automation commits via GitHub API (fix CLA)

### DIFF
--- a/.github/workflows/docs-api.yml
+++ b/.github/workflows/docs-api.yml
@@ -12,6 +12,14 @@ on:
       - main
   workflow_dispatch:
 
+# The rolling docs branch is updated by a non-atomic sequence (force-push ->
+# API commit -> open PR). Serialize runs so overlapping pushes to main cannot
+# clobber the branch or race on `gh pr create`. Only the latest generated docs
+# matter, so cancel any in-flight run.
+concurrency:
+  group: docs-api
+  cancel-in-progress: true
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-api.yml
+++ b/.github/workflows/docs-api.yml
@@ -78,11 +78,10 @@ jobs:
 
       - name: Commit docs via GitHub API (signed)
         if: steps.changes.outputs.changed == 'true'
-        # Third-party action pinned by full commit SHA. Commits via GitHub's
-        # GraphQL createCommitOnBranch API, so the commit is GitHub-signed
-        # (Verified) and attributed to the GH_TOKEN owner. No upstream version
-        # tags exist, so it is pinned by SHA only.
-        uses: MonikaJassova/ghcommit-action@aee0efc02d3707e178c534477e5c87f70fe6678f
+        # planetscale/ghcommit-action commits via GitHub's GraphQL
+        # createCommitOnBranch API, so the commit is GitHub-signed (Verified)
+        # and attributed to the GH_TOKEN owner (MidnightCI).
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # ratchet:planetscale/ghcommit-action@v0.2.22
         with:
           commit_message: "docs: API documentation update"
           repo: ${{ github.repository }}

--- a/.github/workflows/docs-api.yml
+++ b/.github/workflows/docs-api.yml
@@ -53,35 +53,53 @@ jobs:
           yarn run build:markdown-docs
           cd testkit-js/testkit-js && yarn run build:markdown-docs
 
-      # `.envrc` (loaded by setup-build-env via direnv) sets `commit.gpgSign=true`
-      # for local contributors, but the runner has no GPG secret key. Without
-      # this override, create-pull-request's local commit fails with
-      # "gpg: signing failed: No secret key". Overridden locally so it does not
-      # affect contributors. For verified branch commits, switch to a GitHub App
-      # token and re-add sign-commits (see the note on the PR step below).
-      - name: Disable local commit signing (no GPG key on runner)
-        run: git config commit.gpgsign false
+      # The commit MUST be created via the GitHub API (not a local `git commit`)
+      # so it is signed by GitHub and attributed to the GH_TOKEN owner
+      # (MidnightCI, a real account). A local commit is unsigned and authored by
+      # a bare noreply email that resolves to no account, which leaves the
+      # `license/cla` check permanently "not signed". GH_TOKEN is a PAT (not
+      # GITHUB_TOKEN) so the opened PR still triggers CI.
+      - name: Reset rolling docs branch to main
+        id: changes
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$(git status --porcelain ./docs)" ]; then
+            echo "No documentation changes."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          # Force the rolling branch back to the current main so the PR always
+          # shows just the latest generated-docs diff (one commit on top).
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          git push --force origin "HEAD:refs/heads/api-docs/update"
 
-      # Both typedoc generators write under docs/, so staging that path captures
-      # every generated change. create-pull-request no-ops when the tree is clean,
-      # so the previous explicit `git status ./docs` guard is no longer needed.
-      # Uses a fixed branch, so repeated runs update one rolling docs PR instead
-      # of opening a fresh timestamped PR each time.
-      - name: Create API documentation PR
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # ratchet:peter-evans/create-pull-request@v8.1.1
+      - name: Commit docs via GitHub API (signed)
+        if: steps.changes.outputs.changed == 'true'
+        # Third-party action pinned by full commit SHA. Commits via GitHub's
+        # GraphQL createCommitOnBranch API, so the commit is GitHub-signed
+        # (Verified) and attributed to the GH_TOKEN owner. No upstream version
+        # tags exist, so it is pinned by SHA only.
+        uses: MonikaJassova/ghcommit-action@aee0efc02d3707e178c534477e5c87f70fe6678f
         with:
-          token: ${{ secrets.GH_TOKEN }}
-          add-paths: docs
-          commit-message: "docs: API documentation update"
-          title: "docs: API documentation update"
-          body: "Update API documentation - created by Midnight CI GitHub Action"
+          commit_message: "docs: API documentation update"
+          repo: ${{ github.repository }}
           branch: api-docs/update
-          delete-branch: true
-          # No sign-commits: it only works with GITHUB_TOKEN or a GitHub App
-          # token. GH_TOKEN is a PAT (used so the opened PR triggers CI, which a
-          # GITHUB_TOKEN-created PR cannot), and create-pull-request silently
-          # leaves PAT commits unsigned. The squash-merge into main is signed by
-          # GitHub regardless. For verified branch commits, switch to a GitHub
-          # App token via actions/create-github-app-token and re-add sign-commits.
-          author: "Midnight CI GitHub Action <midnight-ci@users.noreply.github.com>"
-          committer: "Midnight CI GitHub Action <midnight-ci@users.noreply.github.com>"
+          file_pattern: docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Open docs PR if none is open
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          if [ -z "$(gh pr list --head api-docs/update --state open --json number --jq '.[].number')" ]; then
+            gh pr create --base main --head api-docs/update \
+              --title "docs: API documentation update" \
+              --body "Update API documentation - created by Midnight CI GitHub Action"
+          else
+            echo "Docs PR already open; the new signed commit was pushed to it."
+          fi

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -68,11 +68,16 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
+          # Capture the workspace list on its own line: a failure of the yarn
+          # call inside a `for ... in $(...)` word-list is NOT caught by
+          # `set -e`, which would silently bump only the root and leave the
+          # workspaces on their old versions.
+          workspaces=$(yarn workspaces list --json)
           npm pkg set version="$VERSION"
-          for pkg in $(yarn workspaces list --json | jq -r 'select(.location | startswith("packages/")) | .name'); do
+          for pkg in $(echo "$workspaces" | jq -r 'select(.location | startswith("packages/")) | .name'); do
             npm pkg set version="$VERSION" -w "$pkg"
           done
-          for pkg in $(yarn workspaces list --json | jq -r 'select(.location | startswith("testkit-js/")) | .name'); do
+          for pkg in $(echo "$workspaces" | jq -r 'select(.location | startswith("testkit-js/")) | .name'); do
             npm pkg set version="$VERSION" -w "$pkg"
           done
 
@@ -114,6 +119,13 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
+          # Idempotent: a re-dispatch for a version whose PR is already open
+          # force-pushes the branch and re-commits above, so only skip the
+          # create (which would otherwise fail with "already exists").
+          if [ -n "$(gh pr list --head "release/v${VERSION}" --state open --json number --jq '.[].number')" ]; then
+            echo "Release PR for v${VERSION} already open; the new signed commit was pushed to it."
+            exit 0
+          fi
           gh pr create --base main --head "release/v${VERSION}" \
             --title "chore(release): bump version to ${VERSION}" \
             --body "Automated release preparation for v${VERSION}.

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -96,11 +96,10 @@ jobs:
           git push --force origin "HEAD:refs/heads/release/v${VERSION}"
 
       - name: Commit release changes via GitHub API (signed)
-        # Third-party action pinned by full commit SHA. Commits via GitHub's
-        # GraphQL createCommitOnBranch API, so the commit is GitHub-signed
-        # (Verified) and attributed to the GH_TOKEN owner. No upstream version
-        # tags exist, so it is pinned by SHA only.
-        uses: MonikaJassova/ghcommit-action@aee0efc02d3707e178c534477e5c87f70fe6678f
+        # planetscale/ghcommit-action commits via GitHub's GraphQL
+        # createCommitOnBranch API, so the commit is GitHub-signed (Verified)
+        # and attributed to the GH_TOKEN owner (MidnightCI).
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # ratchet:planetscale/ghcommit-action@v0.2.22
         with:
           commit_message: "chore(release): bump version to ${{ inputs.version }}"
           repo: ${{ github.repository }}

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -60,40 +60,66 @@ jobs:
           fi
           echo "Version '$VERSION' is valid."
 
-      - name: Bump versions and generate changelog
+      # Version bump + changelog, inline with standard tooling (previously
+      # scripts/release.sh --files-only). The script remains as a local fallback
+      # but CI no longer depends on it.
+      - name: Bump versions across workspaces
         env:
           VERSION: ${{ inputs.version }}
-        run: bash scripts/release.sh "$VERSION" --files-only
+        run: |
+          set -euo pipefail
+          npm pkg set version="$VERSION"
+          for pkg in $(yarn workspaces list --json | jq -r 'select(.location | startswith("packages/")) | .name'); do
+            npm pkg set version="$VERSION" -w "$pkg"
+          done
+          for pkg in $(yarn workspaces list --json | jq -r 'select(.location | startswith("testkit-js/")) | .name'); do
+            npm pkg set version="$VERSION" -w "$pkg"
+          done
 
-      # `.envrc` (loaded by setup-build-env via direnv) sets `commit.gpgSign=true`
-      # for local contributors, but the runner has no GPG secret key. Without
-      # this override, create-pull-request's local commit fails with
-      # "gpg: signing failed: No secret key". Overridden locally so it does not
-      # affect contributors. For verified branch commits, switch to a GitHub App
-      # token and re-add sign-commits.
-      - name: Disable local commit signing (no GPG key on runner)
-        run: git config commit.gpgsign false
+      - name: Generate changelog
+        run: yarn changelog
 
-      - name: Create release PR
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # ratchet:peter-evans/create-pull-request@v8.1.1
+      # The commit MUST be created via the GitHub API (not a local `git commit`)
+      # so it is signed by GitHub and attributed to the GH_TOKEN owner
+      # (MidnightCI, a real account). A local commit is unsigned and authored by
+      # a bare noreply email that resolves to no account, which leaves the
+      # `license/cla` check permanently "not signed". GH_TOKEN is a PAT (not
+      # GITHUB_TOKEN) so the opened PR still triggers CI.
+      - name: Push release branch
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          git push --force origin "HEAD:refs/heads/release/v${VERSION}"
+
+      - name: Commit release changes via GitHub API (signed)
+        # Third-party action pinned by full commit SHA. Commits via GitHub's
+        # GraphQL createCommitOnBranch API, so the commit is GitHub-signed
+        # (Verified) and attributed to the GH_TOKEN owner. No upstream version
+        # tags exist, so it is pinned by SHA only.
+        uses: MonikaJassova/ghcommit-action@aee0efc02d3707e178c534477e5c87f70fe6678f
         with:
-          token: ${{ secrets.GH_TOKEN }}
-          add-paths: |
-            package.json
-            packages/**/package.json
-            testkit-js/**/package.json
-            CHANGELOG.md
-          commit-message: "chore(release): bump version to ${{ inputs.version }}"
-          title: "chore(release): bump version to ${{ inputs.version }}"
-          body: |
-            Automated release preparation for v${{ inputs.version }}.
-
-            - Versions bumped across all workspaces
-            - `CHANGELOG.md` regenerated
-
-            Merging this PR to `main` triggers the `publish` job in ci.yml, which
-            publishes the packages and cuts the GitHub Release.
+          commit_message: "chore(release): bump version to ${{ inputs.version }}"
+          repo: ${{ github.repository }}
           branch: release/v${{ inputs.version }}
-          delete-branch: true
-          author: "Midnight CI GitHub Action <midnight-ci@users.noreply.github.com>"
-          committer: "Midnight CI GitHub Action <midnight-ci@users.noreply.github.com>"
+          file_pattern: "package.json CHANGELOG.md packages testkit-js"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Open release PR
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          gh pr create --base main --head "release/v${VERSION}" \
+            --title "chore(release): bump version to ${VERSION}" \
+            --body "Automated release preparation for v${VERSION}.
+
+          - Versions bumped across all workspaces
+          - \`CHANGELOG.md\` regenerated
+
+          Merging this PR to \`main\` triggers the \`publish\` job in ci.yml, which publishes the packages and cuts the GitHub Release."


### PR DESCRIPTION
## Summary

Fixes-forward on #1088. That PR stopped the `No secret key` crash by disabling local commit signing, but it shipped **unsigned** commits authored by `midnight-ci@users.noreply.github.com` — an email that resolves to **no GitHub account** — so `license/cla` stays *"not signed yet"* and the generated docs PR (e.g. #1089) can never merge.

### Root cause
`peter-evans/create-pull-request` makes a **local** `git commit` and only signs (via the API) when given a `GITHUB_TOKEN` or GitHub App token. With the `GH_TOKEN` PAT it commits locally + unsigned. The pre-#1065 flow that produced the passing #1060 created the commit **via the GitHub API** with the PAT, so it was attributed to the real `MidnightCI` account and GitHub-signed (Verified) → CLA matched.

### Change
Restore the API-commit path in both `docs-api.yml` and `release-prepare.yml` using `planetscale/ghcommit-action` (GraphQL `createCommitOnBranch`) driven by `GH_TOKEN`:
- **Signed / Verified**, authored by `MidnightCI` → `license/cla` passes.
- PAT (not `GITHUB_TOKEN`) → the opened PR still triggers CI.
- **docs-api**: rolling `api-docs/update` branch (force-reset to `main` each run so the PR shows only the latest docs diff); PR opened only if none is already open.
- **release-prepare**: also **drops `scripts/release.sh`** — the version bump + changelog are now inline workflow steps (`npm pkg set version` across root/`packages/*`/`testkit-js/*` + `yarn changelog`). The script stays on disk as the documented local fallback.
- Removes the `commit.gpgsign=false` steps from #1088 (unneeded; API commits ignore local git signing config).

Unaffected (verified earlier): the automatic `publish` job in `ci.yml` and `publish-manual.yml` — they never do a local commit/tag; the release tag is created server-side via `softprops/action-gh-release`.

## Test plan
- [x] Root cause confirmed by comparing commit metadata: #1060 (`author=MidnightCI`, `committer=web-flow`, `verified=true`, CLA pass) vs #1089 (`author_login=null`, `unsigned`, CLA stuck).
- [x] Both workflow files parse as valid YAML; all shell steps take untrusted-free env vars (version is regex-validated upstream).
- [ ] docs-api: verified on next push to `main` that changes generated docs — expect a signed, CLA-passing docs PR.
- [ ] release-prepare: verified on manual dispatch — expect a signed, CLA-passing release PR.

Broken docs PR #1089 will be closed; the first docs-api run after this merges opens a correct replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)