### PR TITLE
ci: stage changes before ghcommit so new doc dirs aren't read as files

### DIFF
--- a/.github/workflows/docs-api.yml
+++ b/.github/workflows/docs-api.yml
@@ -79,6 +79,11 @@ jobs:
             exit 0
           fi
           echo "changed=true" >> "$GITHUB_OUTPUT"
+          # Stage the changes so ghcommit-action enumerates individual files.
+          # git status collapses a wholly-untracked new directory into a single
+          # "docs/.../foo/" entry, which ghcommit then tries to read as a file
+          # ("is a directory"). Staging lists each file (A/M/D) individually.
+          git add -A docs
           # Force the rolling branch back to the current main so the PR always
           # shows just the latest generated-docs diff (one commit on top).
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -97,6 +97,9 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
+          # Stage so ghcommit-action enumerates individual files rather than a
+          # collapsed untracked directory (which it would fail to read).
+          git add -A -- package.json CHANGELOG.md packages testkit-js
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
           git push --force origin "HEAD:refs/heads/release/v${VERSION}"
 


### PR DESCRIPTION
## Summary

The `docs-api` job introduced in #1095 fails on `main` (run [29092859892](https://github.com/midnightntwrk/midnight-js/actions/runs/29092859892/job/86362155867)):

```
read docs/api/.../midnight-js-fetch-zk-config-provider/functions/: is a directory
```

`ghcommit-action` enumerates changes with `git status --porcelain -- docs`. Git collapses a **wholly-new, untracked directory** into a single `?? docs/.../functions/` entry (trailing slash) instead of listing its files. `ghcommit` then tries to `read` that directory path as a file → "is a directory" → step fails. `peter-evans/create-pull-request` never hit this because it ran a real `git add`, which recurses into directories.

## Fix
Run `git add -A` on the target paths **before** invoking `ghcommit-action`, so `git status` reports each file individually (`A`/`M`/`D`) rather than a collapsed untracked directory. `ghcommit` reads the working-tree content of each staged file as before.
- `docs-api.yml`: `git add -A docs` in the "Reset rolling docs branch" step.
- `release-prepare.yml`: `git add -A -- package.json CHANGELOG.md packages testkit-js` in the "Push release branch" step (version bumps only touch tracked files, so it can't hit this today — applied for a consistent, correct usage of the action).

No scope change: staging the same paths `file_pattern` already targets.

## Test plan
- [x] Root cause reproduced from the run log (collapsed `?? .../functions/` entries → `is a directory`).
- [x] Both workflows parse as valid YAML; no untrusted input in shell steps.
- [ ] docs-api: verified green on the next docs-changing push to `main` after merge.

Note: `main`'s docs-api is currently red on every docs-changing push until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)