### PR TITLE
docs: update release notes for v5.0.0

### DIFF
--- a/docs/releases/v5.0.0/README.md
+++ b/docs/releases/v5.0.0/README.md
@@ -33,7 +33,8 @@ See [breaking-changes.md](./breaking-changes.md) for full rationale and before/a
 ## Headline Features
 
 - **Cross-contract call support** — assemble/prove/submit call trees spanning multiple deployed contracts; `ZKConfigRegistry` resolves per-contract artifacts by verifier-key hash (no address registration), plus a new `PublicDataProvider.queryBlock()` "as-of" endpoint (#967).
-- **MIP-0002 contract events on `PublicDataProvider`** — `queryContractEvents()` (paged point-in-time read), `contractEventsObservable()` (replay-from-cursor then live tail), and the `getAllContractEvents()` async-iterator helper, backed by an 11-variant `ContractEvent` discriminated union (#988).
+- **MIP-0002 contract events, two surfaces** — off-chain on `PublicDataProvider` via `queryContractEvents()` (paged point-in-time read), `contractEventsObservable()` (replay-from-cursor then live tail), and the `getAllContractEvents()` async-iterator helper, backed by an 11-variant `ContractEvent` discriminated union (#988); and on the local-execution path via `CallResultPublic.events` with a `contracts.ContractLog.decodeAll()` helper (#1083).
+- **Uniform `provider(options)` factories** — `httpClientProofProvider({ url, zkConfigProvider, ... })` and `nodeZkConfigProvider(options)` / `fetchZkConfigProvider(options)`; additive and backward-compatible, positional forms retained as `@deprecated` (#1078).
 - **ZK artifact integrity verification** — providers verify artifacts against the `compactc` `contract-manifest.json`; fail-closed by default with an optional `expectedManifestHash` pin (#1015).
 - **Deflate-compressed subscriptions** — `graphql-transport-ws+deflate` negotiation with transparent inflation and a 16 MiB compression-bomb cap (#977).
 - **Disposable `IndexerPublicDataProvider`** — the inner factory is now a class with a structured `IndexerProviderConfig` (`{ queryURL, subscriptionURL, ... }`), fail-fast config validation, and an explicit `dispose()` that releases the underlying WebSocket connection (#961).
@@ -41,4 +42,4 @@ See [breaking-changes.md](./breaking-changes.md) for full rationale and before/a
 
 ## Pre-release protocol note
 
-The v9 / v4 protocol packages this release targets are themselves release candidates (`@midnightntwrk/ledger-v9@1.0.0-rc.3`, `@midnightntwrk/onchain-runtime-v4@4.0.0-rc.3`), paired with `compact-runtime 0.18.0-rc.1`, `compact-js 2.5.5-rc.6`, and `compactc 0.33.0-rc.1`. The testkit wallet stack is on the `2.0.0-beta.2` line. Pin transitive copies to a single version to avoid duplicate-major type clashes (the migration guide covers the resolutions).
+The v9 / v4 protocol packages this release targets are themselves release candidates (`@midnightntwrk/ledger-v9@1.0.0-rc.3`, `@midnightntwrk/onchain-runtime-v4@4.0.0-rc.3`), paired with `compact-runtime 0.18.0-rc.1`, `compact-js 2.5.5-rc.7`, and `compactc 0.33.0-rc.1`. The testkit wallet stack is on the `2.0.0-beta.2` line. Pin transitive copies to a single version to avoid duplicate-major type clashes (the migration guide covers the resolutions).

--- a/docs/releases/v5.0.0/api-changes.md
+++ b/docs/releases/v5.0.0/api-changes.md
@@ -125,6 +125,26 @@ export const hashVerifierKey: (/* verifier key */) => string; // sha-256 hex
 
 ---
 
+## `@midnight-ntwrk/midnight-js-contracts`
+
+### `CallResultPublic.events` + `ContractLog` re-export (#1083)
+
+```ts
+interface CallResultPublic {
+  // ...existing fields
+  readonly events: LogEvent[]; // execution-wide, in emission order, tagged by emitting contract address; carried raw
+}
+
+// re-exported from compact-js through the barrel — reachable as contracts.ContractLog
+export const ContractLog: {
+  decodeAll(events: readonly LogEvent[]): DecodedLog[]; // lenient — never throws
+};
+```
+
+The single `events` list spans the whole call tree. Decode without a direct `compact-js` dependency via `contracts.ContractLog.decodeAll(result.public.events)`.
+
+---
+
 ## `@midnight-ntwrk/midnight-js-indexer-public-data-provider`
 
 ### New / changed exports
@@ -215,9 +235,37 @@ Subpath re-exports retargeted (see [breaking-changes.md](./breaking-changes.md))
 | `/ledger` | `@midnightntwrk/ledger-v9@1.0.0-rc.3` |
 | `/onchain-runtime` | `@midnightntwrk/onchain-runtime-v4@4.0.0-rc.3` |
 | `/compact-runtime` | `@midnight-ntwrk/compact-runtime@0.18.0-rc.1` |
-| `/compact-js` | `@midnight-ntwrk/compact-js@2.5.5-rc.6` (provides the `ContractKeyLocation` grammar) |
+| `/compact-js` | `@midnight-ntwrk/compact-js@2.5.5-rc.7` (provides the `ContractKeyLocation` grammar) |
 | `/platform-js` | `@midnight-ntwrk/platform-js@3.0.0` |
+
+## `@midnight-ntwrk/midnight-js-http-client-proof-provider`
+
+### `httpClientProofProvider` — object-options form (#1078)
+
+```ts
+// new — preferred object-options form (flattened config)
+export function httpClientProofProvider(options: {
+  readonly url: string;
+  readonly zkConfigProvider: ZKConfigProvider<string>;
+  readonly timeout?: number;
+  readonly headers?: Record<string, string>;
+}): ProofProvider<string>;
+
+/** @deprecated positional form retained for one release cycle */
+export function httpClientProofProvider(url: string, zkConfigProvider: ZKConfigProvider<string>): ProofProvider<string>;
+```
+
+Additive and backward-compatible — the positional overload keeps working. Low-level `httpClientProvingProvider` remains positional (tracked as a follow-up).
 
 ## `@midnight-ntwrk/midnight-js-fetch-zk-config-provider` / `-node-zk-config-provider`
 
 Both provider constructors now accept an optional `ZkConfigIntegrityOptions` bag (see `midnight-js-utils` above) and verify artifacts against `compiler/contract-manifest.json`, defaulting to `verify: 'require'` (fail-closed). See [breaking-changes.md](./breaking-changes.md).
+
+### `provider(options)` factory functions (#1078)
+
+Thin factory functions are added alongside the existing classes (the classes stay exported for subclassing/composition):
+
+```ts
+export function nodeZkConfigProvider(options: /* ... */): NodeZkConfigProvider<string>;
+export function fetchZkConfigProvider(options: /* ... */): FetchZkConfigProvider<string>;
+```

--- a/docs/releases/v5.0.0/breaking-changes.md
+++ b/docs/releases/v5.0.0/breaking-changes.md
@@ -13,7 +13,7 @@ v5.0.0 is a protocol-level major release. The breaking surface concentrates in f
 | `@midnight-ntwrk/midnight-js-protocol/ledger` | `@midnight-ntwrk/ledger-v8@8.1.0` | `@midnightntwrk/ledger-v9@1.0.0-rc.3` |
 | `@midnight-ntwrk/midnight-js-protocol/onchain-runtime` | `@midnight-ntwrk/onchain-runtime-v3@3.0.0` | `@midnightntwrk/onchain-runtime-v4@4.0.0-rc.3` |
 
-Coordinated companions: `@midnight-ntwrk/platform-js@3.0.0`, `@midnight-ntwrk/compact-runtime@0.18.0-rc.1`, `@midnight-ntwrk/compact-js@2.5.5-rc.6`, `compactc 0.33.0-rc.1`.
+Coordinated companions: `@midnight-ntwrk/platform-js@3.0.0`, `@midnight-ntwrk/compact-runtime@0.18.0-rc.1`, `@midnight-ntwrk/compact-js@2.5.5-rc.7`, `compactc 0.33.0-rc.1`.
 
 **Impact:** Any code importing ledger / onchain-runtime types should do so **only** through the protocol package's subpath re-exports — direct imports of the old-scope packages are flagged by ESLint (`no-restricted-imports`) and resolve to incompatible type shapes.
 

--- a/docs/releases/v5.0.0/migration-guide.md
+++ b/docs/releases/v5.0.0/migration-guide.md
@@ -166,6 +166,31 @@ If you make calls that span multiple deployed contracts, resolve proving artifac
 
 ---
 
+## Step 11 — Read MIP-0002 log events from `CallResult` (optional)
+
+Local call results now surface their MIP-0002 log events on `CallResultPublic.events` (previously dropped). No change is required — the field is additive. To consume them, decode with the `ContractLog` helper re-exported through the barrel (no direct `compact-js` dependency needed):
+
+```ts
+import { contracts } from '@midnight-ntwrk/midnight-js';
+
+const logs = contracts.ContractLog.decodeAll(result.public.events); // lenient — never throws
+```
+
+---
+
+## Step 12 — Migrate to `provider(options)` factories (optional)
+
+Positional provider constructors still work but are `@deprecated` for one release cycle. Move to the object-options form at your convenience:
+
+```diff
+- httpClientProofProvider(url, zkConfigProvider);
++ httpClientProofProvider({ url, zkConfigProvider });
+```
+
+`nodeZkConfigProvider(options)` / `fetchZkConfigProvider(options)` factory functions are also available alongside the existing classes.
+
+---
+
 ## Verification checklist
 
 - [ ] `yarn install` clean with the resolutions in place (no duplicate ledger-v9 majors).

--- a/docs/releases/v5.0.0/new-features.md
+++ b/docs/releases/v5.0.0/new-features.md
@@ -108,6 +108,69 @@ Notable schema-driven decisions:
 
 ---
 
+## MIP-0002 log events on `CallResult` (#1083)
+
+The two MIP-0002 surfaces are complementary. #988 reads events **off-chain, from the indexer**, after a transaction lands. This one exposes the same events **synchronously, from the local execution result** of a call — `compact-js` already computes them on `ContractExecutable.CallResult.events`, but `midnight-js` was destructuring the executor result without `events` and dropping them.
+
+`CallResultPublic` now carries them:
+
+```ts
+interface CallResultPublic {
+  // ...existing fields
+  readonly events: LogEvent[]; // execution-wide, in emission order, tagged by emitting contract address
+}
+```
+
+Events are carried **raw** (no eager decode). Decode them with the `ContractLog` helper, re-exported from `compact-js` through the `midnight-js` barrel — so you never take a direct dependency on `compact-js`:
+
+```ts
+import { contracts } from '@midnight-ntwrk/midnight-js';
+
+const result = await callTx(/* ... */);
+
+// lenient: never throws — undecodable entries are skipped
+const logs = contracts.ContractLog.decodeAll(result.public.events);
+```
+
+The single `events` list spans the whole call tree (all contracts touched by a cross-contract call), in emission order.
+
+---
+
+## `provider(options)` factories for proof and ZK-config providers (#1078)
+
+The provider layer moves toward a uniform `provider(options)` convention: wire a provider by passing one options object instead of remembering positional-argument order. **Additive and backward-compatible** — existing positional and class-based usage keeps working.
+
+`httpClientProofProvider` gains an object-options form with a flattened config:
+
+```ts
+import { httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client-proof-provider';
+
+// new — preferred
+const proofProvider = httpClientProofProvider({
+  url: 'https://proof-server.example',
+  zkConfigProvider,
+  timeout: 30_000, // optional
+  headers: { authorization: `Bearer ${token}` }, // optional
+});
+
+// old — still works, now marked @deprecated for one release cycle
+const legacy = httpClientProofProvider('https://proof-server.example', zkConfigProvider);
+```
+
+The ZK-config providers gain thin factory functions alongside the existing classes (the classes stay exported for subclassing/composition):
+
+```ts
+import { nodeZkConfigProvider } from '@midnight-ntwrk/midnight-js-node-zk-config-provider';
+import { fetchZkConfigProvider } from '@midnight-ntwrk/midnight-js-fetch-zk-config-provider';
+
+const zkNode = nodeZkConfigProvider(options);
+const zkFetch = fetchZkConfigProvider(options);
+```
+
+> Low-level `httpClientProvingProvider` is intentionally left positional and tracked as a follow-up — converting it re-couples internal test mocks and it is a lower-traffic advanced-scenarios primitive.
+
+---
+
 ## Disposable `IndexerPublicDataProvider` with structured config (#961)
 
 Phase 2 of #808 (closes #820). The indexer provider gains a structured configuration object, becomes a class (`IndexerPublicDataProvider`), and exposes explicit resource cleanup.

--- a/docs/releases/v5.0.0/release-notes.md
+++ b/docs/releases/v5.0.0/release-notes.md
@@ -17,7 +17,7 @@ v5.0.0 is a major release. It retargets the framework's on-chain protocol bindin
 
 The subpath re-exports `@midnight-ntwrk/midnight-js-protocol/ledger` and `/onchain-runtime` now resolve to the v9 / v4 packages. The new `@midnightntwrk` scope is registered in `.yarnrc.yml` and both scope variants are flagged by the ESLint `no-restricted-imports` ACL outside `packages/protocol/src/`.
 
-This pulls through a coordinated dependency set: `@midnight-ntwrk/platform-js@3.0.0`, `@midnight-ntwrk/compact-runtime@0.18.0-rc.1`, `@midnight-ntwrk/compact-js@2.5.5-rc.6`, and `compactc 0.33.0-rc.1` (compiler 0.33.0 / language 0.25.0 / runtime 0.18.0-rc.1).
+This pulls through a coordinated dependency set: `@midnight-ntwrk/platform-js@3.0.0`, `@midnight-ntwrk/compact-runtime@0.18.0-rc.1`, `@midnight-ntwrk/compact-js@2.5.5-rc.7`, and `compactc 0.33.0-rc.1` (compiler 0.33.0 / language 0.25.0 / runtime 0.18.0-rc.1).
 
 ### `SigningKey` is now a structured object (#970)
 
@@ -67,6 +67,24 @@ The mapper fails fast on an unknown `__typename` or a missing required field, an
 
 > The query / streaming surface covers all 11 event variants. Contract-side **emission** of MIP-0002 events requires `compactc 0.33.0-rc.1` + `compact-runtime 0.18.x` and is exercised end-to-end by an emit→indexer contract-events test (#993) for all shielded events and unshielded **mint/burn**. Unshielded **spend/receive** remain skipped pending an indexer decode fix (midnight-indexer#1279); **Misc** is skipped separately because proving `emitMisc` — the suite's heaviest circuit (~5× the next-largest zkir) — needs a proof-server-side fix.
 
+### MIP-0002 log events on `CallResult` (#1083)
+
+The **local-execution path** now surfaces the MIP-0002 contract log events that `compact-js` already computes — `midnight-js` was previously discarding them:
+
+- `CallResultPublic.events` — a new `readonly LogEvent[]` field carrying the single execution-wide event list across the whole call tree, in emission order, each event tagged with its emitting contract's address. Carried **raw** (no eager decode).
+- `ContractLog` is re-exported from `compact-js` through the barrel (`contracts.ContractLog`), so consumers decode with `ContractLog.decodeAll(result.public.events)` (lenient, never throws) **without** taking a direct dependency on `compact-js`.
+
+This complements the indexer-sourced querying/streaming from #988: #988 reads events off-chain from the indexer, while this exposes them synchronously on the result of a local call.
+
+### `provider(options)` factories for proof and ZK-config providers (#1078)
+
+The provider layer moves toward a uniform `provider(options)` convention — wiring a provider means passing one options object instead of remembering positional-argument order. **Additive and backward-compatible**: existing positional/class usage keeps working.
+
+- `httpClientProofProvider({ url, zkConfigProvider, timeout?, headers? })` — new object-options form with a flattened config; the positional signature is retained as a `@deprecated` overload for one release cycle (same pattern as `indexerPublicDataProvider`).
+- `nodeZkConfigProvider(options)` / `fetchZkConfigProvider(options)` — thin factory functions alongside the existing `NodeZkConfigProvider` / `FetchZkConfigProvider` classes (the classes stay exported; only a consistent call-site is added).
+
+Low-level `httpClientProvingProvider` is intentionally left positional and tracked as a follow-up.
+
 ### Deflate-compressed subscriptions (#977)
 
 The indexer provider negotiates the `graphql-transport-ws+deflate` WebSocket subprotocol and transparently inflates compressed subscription frames (RFC 1950 zlib via the universal `DecompressionStream`, covering Node ≥ 18 and modern browsers). It falls back cleanly when the server selects the plain subprotocol, and enforces a 16 MiB hard cap on inflated payloads to guard against compression-bomb DoS.
@@ -107,6 +125,7 @@ The generated contract-event GraphQL schema gains transaction references and bet
 
 ## Refactoring
 
+- **midnight-js:** convert intersection type aliases to interfaces for clearer IDE tooltips (#629).
 - **midnight-js:** wrapper consolidation, assertion hygiene, and a `pollUntilPresent` helper (#962).
 - **midnight-js:** split the `indexer-public-data-provider` monolith into 7 layered files (#960).
 - **utils:** extract the shared structured signing-key validation into `midnight-js-utils` (#970).
@@ -114,7 +133,7 @@ The generated contract-event GraphQL schema gains transaction references and bet
 
 ## Build & CI
 
-- Bump the Compact toolchain to `compactc 0.33.0-rc.1` / `compact-runtime 0.18.0-rc.1` / `compact-js 2.5.5-rc.6` and regenerate all compiled artifacts (`runtime-version` stamps `0.18.0-rc.1`) (#1068). Follows the initial `compactc 0.33.0-rc.0` / `compact-runtime 0.18.0-rc.0` bump (#1016), which switched back to the release tag/asset prefixes and superseded the earlier `compactc 0.32.102` / `compact-runtime 0.17.102` bump (#996).
+- Bump the Compact toolchain to `compactc 0.33.0-rc.1` / `compact-runtime 0.18.0-rc.1` / `compact-js 2.5.5-rc.7` and regenerate all compiled artifacts (`runtime-version` stamps `0.18.0-rc.1`) (#1068, #1081 — `compact-js` `rc.6` → `rc.7`). Follows the initial `compactc 0.33.0-rc.0` / `compact-runtime 0.18.0-rc.0` bump (#1016), which switched back to the release tag/asset prefixes and superseded the earlier `compactc 0.32.102` / `compact-runtime 0.17.102` bump (#996).
 - Enforce `packageManager` and `engines` consistency across the workspace via yarn constraints (#1067).
 - Dedupe workflow setup, gate release concurrency, and fix coverage mapping (#1065); publish releases from CI, dropping the duplicate CD e2e run (#1033).
 - Speed up e2e env startup (#1064) and cache pinned Docker images to unblock e2e parallelism (#1062).
@@ -126,6 +145,7 @@ The generated contract-event GraphQL schema gains transaction references and bet
 ## Dependencies
 
 - `build(deps): re-apply devnet stack and wallet/ledger/connector/zkir dependency bumps` (#1045) — restores the baseline reverted in #1038: `@midnightntwrk/wallet-sdk` (+ `wallet-sdk-prover-client`) `2.0.0-beta.2`, `wallet-sdk-address-format` `4.0.0-beta.2`, `@midnightntwrk/ledger-v9` `1.0.0-rc.3`, `@midnightntwrk/dapp-connector-api` `4.1.0-beta.1` (rescoped from `@midnight-ntwrk`), devnet node `2.0.0-rc.3` / proof-server `9.0.0-rc.4`. testkit-js stays on `@midnight-ntwrk/zkir-v2` `2.1.0` so the DApp-connector local prover engine and its `WasmProver` params share one zkir version.
+- `chore(deps): bump graphql to 17 and graphql-codegen to v6/v7` (#1086) — `indexer-public-data-provider` now depends on `graphql ^17.0.1`.
 - `chore(env): update indexer to 4.4.0-pre-alpha.16` (#1053).
 - `chore(deps): bump @apollo/client 4.2.0 → 4.2.3` (#1056).
 - `chore(deps): bump lint-staged to 17 and transitive security deps` (#1051).


### PR DESCRIPTION
## Summary

Folds the changes that landed after the v5.0.0 release notes were last updated (#1074) into `docs/releases/v5.0.0/`:

- **feat #1083** — MIP-0002 log events surfaced on `CallResultPublic.events` (local-execution path) + `contracts.ContractLog` barrel re-export for `decodeAll(...)`. Documented as the complement to the indexer-sourced surface from #988.
- **feat #1078** — uniform `provider(options)` factories: `httpClientProofProvider({ url, zkConfigProvider, ... })`, `nodeZkConfigProvider(options)`, `fetchZkConfigProvider(options)`. Positional forms retained as `@deprecated`.
- **refactor #629** — intersection type aliases → interfaces (Refactoring line).
- **deps #1086** — graphql 17 / graphql-codegen v6/v7 (Dependencies).
- **deps #1081** — `compact-js 2.5.5-rc.6 → rc.7`, corrected in every place the pin appears (README, release-notes, breaking-changes, api-changes).

Both new features are additive/backward-compatible — **no new breaking changes**, so the Breaking Changes sections are unchanged.

Files touched (docs only, no code): `README.md`, `release-notes.md`, `new-features.md`, `api-changes.md`, `breaking-changes.md`, `migration-guide.md`.

## Test plan
- [x] Docs-only change — no code, tests, or build affected
- [x] Verified no stale `2.5.5-rc.6` references remain
- [x] All new PR references (#1083, #1078, #629, #1086, #1081) present in the docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)