### PR TITLE
ci: push automation branches with --no-verify (fix release-prepare)

### DIFF
--- a/.github/workflows/docs-api.yml
+++ b/.github/workflows/docs-api.yml
@@ -87,7 +87,10 @@ jobs:
           # Force the rolling branch back to the current main so the PR always
           # shows just the latest generated-docs diff (one commit on top).
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
-          git push --force origin "HEAD:refs/heads/api-docs/update"
+          # --no-verify: skip the husky pre-push hook (yarn lint + typecheck),
+          # a local-dev guard that is redundant here. The pushed ref is just the
+          # current main tip; ghcommit-action adds the docs commit via API.
+          git push --no-verify --force origin "HEAD:refs/heads/api-docs/update"
 
       - name: Commit docs via GitHub API (signed)
         if: steps.changes.outputs.changed == 'true'

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -101,7 +101,12 @@ jobs:
           # collapsed untracked directory (which it would fail to read).
           git add -A -- package.json CHANGELOG.md packages testkit-js
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
-          git push --force origin "HEAD:refs/heads/release/v${VERSION}"
+          # --no-verify: skip the husky pre-push hook (yarn lint + typecheck).
+          # It is a local-dev guard and needs a full build to resolve workspace
+          # imports; this job only bumps files and never builds, so the hook
+          # would fail with import/no-unresolved. The pushed ref is just the
+          # current main tip; ghcommit-action adds the release commit via API.
+          git push --no-verify --force origin "HEAD:refs/heads/release/v${VERSION}"
 
       - name: Commit release changes via GitHub API (signed)
         # planetscale/ghcommit-action commits via GitHub's GraphQL


### PR DESCRIPTION
## Summary

`release-prepare` failed at **Push release branch** (run [29094800746](https://github.com/midnightntwrk/midnight-js/actions/runs/29094800746/job/86368628810)):

```
✖ 309 problems (309 errors, 0 warnings)
husky - pre-push script failed (code 1)
error: failed to push some refs
```

The `git push` fires the husky **pre-push** hook (`.husky/pre-push` → `yarn lint` + `yarn typecheck:tests`). The `release-prepare` job only installs and bumps files — it never builds — so eslint's `import/no-unresolved` fails on every internal `@midnight-ntwrk/*` workspace import and blocks the push.

## Fix
Push with `--no-verify` in both automation workflows. The pre-push hook is a local-dev guard; these pushes only move a ref to the current `main` tip (the real commit is created via the GitHub API by `ghcommit-action`, which never touches local hooks).
- `release-prepare.yml`: `git push --no-verify --force …` (the actual failure).
- `docs-api.yml`: same — it only avoided the hook today because it runs `yarn build` earlier; adding `--no-verify` removes that hidden dependency and skips a wasted full-lint on every docs push.

Other release-path jobs (`ci.yml` publish, `publish-manual.yml`) are unaffected — they don't do a local `git push` (the tag is created via the API by `action-gh-release`).

## Test plan
- [x] Root cause from the run log: pre-push `yarn lint` fails with import/no-unresolved because the job doesn't build.
- [x] Both workflows parse as valid YAML.
- [ ] release-prepare: verified green on the next manual dispatch after merge.
- [ ] docs-api: still green (already re-confirmed working after #1096).

🤖 Generated with [Claude Code](https://claude.com/claude-code)