### PR TITLE
ci(release): create release/vX from a signed staging commit (ruleset-safe)

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -90,12 +90,13 @@ jobs:
       # a bare noreply email that resolves to no account, which leaves the
       # `license/cla` check permanently "not signed". GH_TOKEN is a PAT (not
       # GITHUB_TOKEN) so the opened PR still triggers CI.
-      # Head branch is `prepare-release/*`, NOT `release/*`: a ruleset protects
-      # `release/*` (requires PR + status checks), which would reject the API
-      # commit below with "Changes must be made through a pull request". The PR
-      # still targets main and merging still triggers publish (detect-release in
-      # ci.yml compares package.json versions, independent of the branch name).
-      - name: Push release branch
+      # The release/* ruleset ALLOWS creating a branch but BLOCKS updating one
+      # ("Changes must be made through a pull request"). Creating release/vX and
+      # then adding the bump commit fails, because that second step is an update.
+      # So mirror scripts/release.sh: build the signed commit on an unprotected
+      # staging branch, then create release/vX pointing straight at it - a single
+      # creation, which the ruleset permits.
+      - name: Stage bump and push unprotected staging branch
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           REPO: ${{ github.repository }}
@@ -106,14 +107,12 @@ jobs:
           # collapsed untracked directory (which it would fail to read).
           git add -A -- package.json CHANGELOG.md packages testkit-js
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
-          # --no-verify: skip the husky pre-push hook (yarn lint + typecheck).
-          # It is a local-dev guard and needs a full build to resolve workspace
-          # imports; this job only bumps files and never builds, so the hook
-          # would fail with import/no-unresolved. The pushed ref is just the
-          # current main tip; ghcommit-action adds the release commit via API.
-          git push --no-verify --force origin "HEAD:refs/heads/prepare-release/v${VERSION}"
+          # staging/* is not matched by the release/* ruleset, so it can be
+          # committed to and deleted freely. --no-verify skips the husky pre-push
+          # hook (lint/typecheck), which needs a full build this job never runs.
+          git push --no-verify --force origin "HEAD:refs/heads/staging/release-v${VERSION}"
 
-      - name: Commit release changes via GitHub API (signed)
+      - name: Commit bump via GitHub API (signed) onto staging branch
         # planetscale/ghcommit-action commits via GitHub's GraphQL
         # createCommitOnBranch API, so the commit is GitHub-signed (Verified)
         # and attributed to the GH_TOKEN owner (MidnightCI).
@@ -121,25 +120,33 @@ jobs:
         with:
           commit_message: "chore(release): bump version to ${{ inputs.version }}"
           repo: ${{ github.repository }}
-          branch: prepare-release/v${{ inputs.version }}
+          branch: staging/release-v${{ inputs.version }}
           file_pattern: "package.json CHANGELOG.md packages testkit-js"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
-      - name: Open release PR
+      - name: Create release/v<version> at the signed commit and open PR
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          REPO: ${{ github.repository }}
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          # Idempotent: a re-dispatch for a version whose PR is already open
-          # force-pushes the branch and re-commits above, so only skip the
-          # create (which would otherwise fail with "already exists").
-          if [ -n "$(gh pr list --head "prepare-release/v${VERSION}" --state open --json number --jq '.[].number')" ]; then
-            echo "Release PR for v${VERSION} already open; the new signed commit was pushed to it."
-            exit 0
+          # release/vX is protected - once created it cannot be updated or
+          # deleted - so refuse if it already exists (bump a new version).
+          if gh api "repos/${REPO}/git/ref/heads/release/v${VERSION}" >/dev/null 2>&1; then
+            echo "::error::release/v${VERSION} already exists and is protected. Bump a new version."
+            exit 1
           fi
-          gh pr create --base main --head "prepare-release/v${VERSION}" \
+          # The signed commit the action just made on the staging branch.
+          sha=$(gh api "repos/${REPO}/git/ref/heads/staging/release-v${VERSION}" --jq '.object.sha')
+          # Create release/vX pointing at it (creation is permitted; an update
+          # would be rejected by the ruleset).
+          gh api -X POST "repos/${REPO}/git/refs" -f ref="refs/heads/release/v${VERSION}" -f sha="${sha}"
+          # Best-effort cleanup of the unprotected staging branch.
+          gh api -X DELETE "repos/${REPO}/git/refs/heads/staging/release-v${VERSION}" \
+            || echo "note: could not delete staging branch (non-fatal)"
+          gh pr create --base main --head "release/v${VERSION}" \
             --title "chore(release): bump version to ${VERSION}" \
             --body "Automated release preparation for v${VERSION}.
 

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -90,6 +90,11 @@ jobs:
       # a bare noreply email that resolves to no account, which leaves the
       # `license/cla` check permanently "not signed". GH_TOKEN is a PAT (not
       # GITHUB_TOKEN) so the opened PR still triggers CI.
+      # Head branch is `prepare-release/*`, NOT `release/*`: a ruleset protects
+      # `release/*` (requires PR + status checks), which would reject the API
+      # commit below with "Changes must be made through a pull request". The PR
+      # still targets main and merging still triggers publish (detect-release in
+      # ci.yml compares package.json versions, independent of the branch name).
       - name: Push release branch
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -106,7 +111,7 @@ jobs:
           # imports; this job only bumps files and never builds, so the hook
           # would fail with import/no-unresolved. The pushed ref is just the
           # current main tip; ghcommit-action adds the release commit via API.
-          git push --no-verify --force origin "HEAD:refs/heads/release/v${VERSION}"
+          git push --no-verify --force origin "HEAD:refs/heads/prepare-release/v${VERSION}"
 
       - name: Commit release changes via GitHub API (signed)
         # planetscale/ghcommit-action commits via GitHub's GraphQL
@@ -116,7 +121,7 @@ jobs:
         with:
           commit_message: "chore(release): bump version to ${{ inputs.version }}"
           repo: ${{ github.repository }}
-          branch: release/v${{ inputs.version }}
+          branch: prepare-release/v${{ inputs.version }}
           file_pattern: "package.json CHANGELOG.md packages testkit-js"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -130,11 +135,11 @@ jobs:
           # Idempotent: a re-dispatch for a version whose PR is already open
           # force-pushes the branch and re-commits above, so only skip the
           # create (which would otherwise fail with "already exists").
-          if [ -n "$(gh pr list --head "release/v${VERSION}" --state open --json number --jq '.[].number')" ]; then
+          if [ -n "$(gh pr list --head "prepare-release/v${VERSION}" --state open --json number --jq '.[].number')" ]; then
             echo "Release PR for v${VERSION} already open; the new signed commit was pushed to it."
             exit 0
           fi
-          gh pr create --base main --head "release/v${VERSION}" \
+          gh pr create --base main --head "prepare-release/v${VERSION}" \
             --title "chore(release): bump version to ${VERSION}" \
             --body "Automated release preparation for v${VERSION}.
 


### PR DESCRIPTION
## Summary

`release-prepare` failed at the ghcommit step because a **ruleset on `release/*`** rejected the API commit (run [29095842093](https://github.com/midnightntwrk/midnight-js/actions/runs/29095842093/job/86372084298)):

```
protected branch 'release/v5.0.0-beta.5' check failed:
  Changes must be made through a pull request. 2 of 2 required status checks are expected.
```

### Root cause (verified on the repo)
The `release/*` ruleset **allows creating** a branch but **blocks updating** one. Confirmed with live dry-runs:
- Adding a commit to an existing `release/*` branch → ⛔ `BRANCH_PROTECTION_RULE_VIOLATION` (same error as CI).
- Creating a `release/*` branch that already points at a new-content commit → ✅ allowed.
- Deleting a `release/*` branch → ⛔ `Cannot delete this branch`.

The workflow created an empty `release/vX` (allowed) and then added the bump commit (an **update** → blocked). `scripts/release.sh` never hit this because it pushes a *fresh* branch that already contains the commit — a single **creation**.

### Fix
Mirror the script, but keep the commit GitHub-signed:
1. Bump versions + changelog.
2. Push an **unprotected** `staging/release-v<version>` branch and make the signed bump commit there via `planetscale/ghcommit-action` (signed, attributed to `MidnightCI`).
3. `createRef refs/heads/release/v<version>` pointing at that signed commit — a **creation**, which the ruleset permits.
4. Delete the staging branch (unprotected) and open the PR from `release/v<version>` → `main`.

Refuses to run if `release/vX` already exists (it's protected — can't be updated or deleted; bump a new version instead).

Publishing is unchanged: merging to `main` triggers `detect-release` in ci.yml, which keys off the `package.json` version bump.

## Test plan
- [x] Ruleset behavior (create-ok / update-blocked / delete-blocked) verified live on the repo.
- [x] Signed API commit + createRef-at-commit verified via dry-run (commit shows Verified, `web-flow` committer).
- [x] YAML valid.
- [ ] Full `release-prepare` dispatch green post-merge (throwaway version, then close PR).

## Cleanup needed (admin)
Two undeletable `release/*` junk branches remain (ruleset blocks delete) — please remove via admin/bypass:
- `release/v5.0.0-beta.5` (failed CI run)
- `release/v0.0.0-dryrun-delete-me` (my diagnostic dry-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)