### PR TITLE
build(testkit-js): stop publishing testkit-js-e2e (too large, 413)

### DIFF
--- a/testkit-js/testkit-js-e2e/package.json
+++ b/testkit-js/testkit-js-e2e/package.json
@@ -2,6 +2,7 @@
   "name": "@midnight-ntwrk/testkit-js-e2e",
   "version": "5.0.0-beta.6",
   "description": "E2E tests for Midnight JS packages",
+  "private": true,
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -42,8 +43,7 @@
     "compact-unshielded": "run-compactc src/contract/unshielded.compact ./src/contract/compiled/unshielded",
     "compact-shielded": "run-compactc src/contract/shielded.compact ./src/contract/compiled/shielded",
     "compact-shielded-fallible": "run-compactc src/contract/shielded-fallible.compact ./src/contract/compiled/shielded-fallible",
-    "compact-fee-mint": "run-compactc src/contract/fee-mint.compact ./src/contract/compiled/fee-mint",
-    "deploy": "yarn npm publish --tolerate-republish"
+    "compact-fee-mint": "run-compactc src/contract/fee-mint.compact ./src/contract/compiled/fee-mint"
   },
   "dependencies": {
     "@midnight-ntwrk/midnight-js-compact": "workspace:*",


### PR DESCRIPTION
## Summary

The release `Publish release` job has been skipped on every release because it `needs: [ci-midnightjs, ci-testkit, detect-release]` and **`ci-testkit` fails** at the prerelease publish of `@midnight-ntwrk/testkit-js-e2e`:

```
YN0035: Response Code: 413 (Request Entity Too Large)
Request URL: https://npm.pkg.github.com/@midnight-ntwrk%2ftestkit-js-e2e
```

The package bundles compiled ZK contract artifacts (`dist/contract/compiled/**` — `.zkir`, `.prover` keys) and exceeds GitHub Packages' size limit. This is why **5.0.0-beta.6 merged to `main`, `detect-release` fired, but no release/tag was published** (run [29101802482](https://github.com/midnightntwrk/midnight-js/actions/runs/29101802482) — `Publish release` = skipped). It's a pre-existing, chronic failure (CI red on ~every `main` push), independent of the release-prepare automation.

`testkit-js-e2e` is a **leaf e2e test suite** — nothing depends on it — so it should not be published.

## Change (`testkit-js/testkit-js-e2e/package.json`)
- `"private": true` — semantic + blocks publication in every path (prerelease, ci.yml, publish-manual).
- Remove its `"deploy"` script — turbo's `yarn deploy --filter="./testkit-js/*"` then skips it. The publishable `testkit-js` keeps its deploy script.

Once merged, `ci-testkit` should pass on `main`, unblocking `Publish release`.

## Test plan
- [x] 413 root cause confirmed in the failed job log; `Publish release` confirmed `skipped`.
- [x] `testkit-js-e2e` is a leaf (no dependents); `testkit-js` retains its deploy script.
- [x] JSON valid.
- [ ] Next `main` push: `ci-testkit` green and (on a release) `Publish release` runs.

Note: `main` is currently at `5.0.0-beta.6` with **no `v5.0.0-beta.6` tag** — that release still needs to be published once this lands (e.g. via `publish-manual`, or the next release bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)