### PR TITLE
test: prevent CI unit-test timeout flakes

### DIFF
--- a/packages/contracts/src/test/utils/zswap-utils.test.ts
+++ b/packages/contracts/src/test/utils/zswap-utils.test.ts
@@ -386,7 +386,8 @@ describe('Zswap utilities', () => {
             expect(delta).toBeUndefined();
           }
         }
-      )
+      ),
+      { numRuns: 25 }
     ));
 
   test('should return only coins meant for provided wallet in zswapStateToNewCoins', () => {

--- a/packages/level-private-state-provider/vitest.config.ts
+++ b/packages/level-private-state-provider/vitest.config.ts
@@ -19,6 +19,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
+    testTimeout: 30_000,
     globals: true,
     include: ['**/test/**/*.test.ts'],
     exclude: ['node_modules', 'dist'],


### PR DESCRIPTION
## Summary

Two of the slowest unit test files carry a real timeout-flake risk on slower/loaded CI runners (measurements below are local, M1 Pro, with v8 coverage on — matching CI; CI runners typically run 2–4× slower, and v8 coverage slows pure-JS crypto 15–40×).

- **`contracts/utils/zswap-utils.test.ts`** — the whole file was ~21s, entirely dominated by one property test (`should create expected number of inputs, outputs, and transients [@slow]`) running fast-check's default **100 runs**, each building real WASM Zswap offers (~195ms/run). Capped it at `{ numRuns: 25 }` → file drops to **~6s** while still exercising randomized scenarios. The `[@slow]` tag was purely cosmetic (nothing filters on it), so this test runs in the normal unit-test job.
- **`level-private-state-provider`** — the package's `vitest.config.ts` set **no `testTimeout`**, so every test used vitest's **5s default**. Its slowest export/import tests run ~1.3s locally (≈5s on a 4× slower runner — right at the old limit). Set `testTimeout: 30_000`, consistent with the explicit 30s overrides the noble 600k-iteration PBKDF2 tests already use; this also hardens any future noble/crypto test against the 5s default.

No production code changed — test tuning and one vitest config value only.

### Before / after (local, coverage on)

| Suite | Before | After |
|-------|--------|-------|
| `zswap-utils.test.ts` | ~21.0s | ~5.7s |
| `level-private-state-provider` per-test cap | 5s (default) | 30s |

## Test plan

- [x] `zswap-utils.test.ts` — 54/54 pass, ~5.7s (was ~21s)
- [x] `level-private-state-provider` — 276/276 pass with new 30s cap
- [x] Lint clean on both changed files (`eslint` exit 0)
- [x] No production/source code touched — no regression surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)