### PR TITLE
fix(midnight-js): throw import-specific error for invalid import password

### DIFF
--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -19,6 +19,7 @@ import {
   type ExportPrivateStatesOptions,
   type ExportSigningKeysOptions,
   ImportConflictError,
+  ImportPasswordValidationError,
   type ImportPrivateStatesOptions,
   type ImportPrivateStatesResult,
   type ImportSigningKeysOptions,
@@ -93,9 +94,9 @@ export interface LevelPrivateStateProviderConfig {
    * The same policy is applied to custom passwords passed to
    * {@link PrivateStateProvider.exportPrivateStates} / `exportSigningKeys` and
    * their `importPrivateStates` / `importSigningKeys` counterparts. Violations
-   * surface as `PasswordValidationError` on storage paths, or wrapped as
-   * `PrivateStateExportError` / `SigningKeyExportError` (with `cause`) on
-   * export/import paths.
+   * surface as `PasswordValidationError` on storage paths, wrapped as
+   * `PrivateStateExportError` / `SigningKeyExportError` (with `cause`) on export
+   * paths, or as `ImportPasswordValidationError` on import paths.
    *
    * SECURITY: Use a strong, secret password. Never use public key material
    * or other non-secret values as the password source.
@@ -618,21 +619,15 @@ const CURRENT_EXPORT_VERSION = 1;
 const SUPPORTED_EXPORT_VERSIONS = [1];
 const EXPECTED_SALT_LENGTH = 64; // 32 bytes as hex
 
-const validateExportPassword = (password: string): void => {
+const validatePasswordOrThrow = (
+  password: string,
+  wrap: (message: string, cause: unknown) => Error
+): void => {
   try {
     validatePassword(password);
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Invalid export password';
-    throw new PrivateStateExportError(message, { cause: error });
-  }
-};
-
-const validateSigningKeyExportPassword = (password: string): void => {
-  try {
-    validatePassword(password);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Invalid export password';
-    throw new SigningKeyExportError(message, { cause: error });
+    const message = error instanceof Error ? error.message : 'Invalid password';
+    throw wrap(message, error);
   }
 };
 
@@ -851,7 +846,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
       // Validate custom password if provided
       if (options?.password !== undefined) {
-        validateExportPassword(options.password);
+        validatePasswordOrThrow(options.password, (message, cause) => new PrivateStateExportError(message, { cause }));
       }
 
       // Determine export password - use provided password or storage password
@@ -930,7 +925,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
 
       // Validate custom password if provided
       if (options?.password !== undefined) {
-        validateExportPassword(options.password);
+        validatePasswordOrThrow(options.password, (message) => new ImportPasswordValidationError(message));
       }
 
       // Determine import password - use provided password or storage password
@@ -1029,7 +1024,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       const maxKeys = options?.maxKeys ?? MAX_EXPORT_SIGNING_KEYS;
 
       if (options?.password !== undefined) {
-        validateSigningKeyExportPassword(options.password);
+        validatePasswordOrThrow(options.password, (message, cause) => new SigningKeyExportError(message, { cause }));
       }
 
       const exportPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);
@@ -1083,7 +1078,7 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
       validateSalt(exportData.salt);
 
       if (options?.password !== undefined) {
-        validateSigningKeyExportPassword(options.password);
+        validatePasswordOrThrow(options.password, (message) => new ImportPasswordValidationError(message));
       }
 
       const importPassword = options?.password ?? await getPasswordFromProvider(passwordProvider);

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -20,9 +20,11 @@ import { type ContractAddress, sampleSigningKey } from '@midnight-ntwrk/midnight
 import {
   ExportDecryptionError,
   ImportConflictError,
+  ImportPasswordValidationError,
   InvalidExportFormatError,
   type PrivateStateExport,
   PrivateStateExportError,
+  PrivateStateImportError,
   type SigningKeyExport,
   SigningKeyExportError
 } from '@midnight-ntwrk/midnight-js-types';
@@ -54,6 +56,15 @@ const expectPasswordValidationCause = (
     if (error.cause instanceof PasswordValidationError) {
       expect(error.cause.reason).toBe(reason);
     }
+  }
+};
+
+const expectImportPasswordError = (error: unknown): void => {
+  expect(error).toBeInstanceOf(ImportPasswordValidationError);
+  expect(error).toBeInstanceOf(PrivateStateImportError);
+  if (error instanceof ImportPasswordValidationError) {
+    expect(error.cause).toBe('invalid_password');
+    expect(error.message.length).toBeGreaterThan(0);
   }
 };
 
@@ -475,7 +486,7 @@ describe('Level Private State Provider', (): void => {
       ).rejects.toThrow(PrivateStateExportError);
     });
 
-    test('throws PrivateStateExportError for short import password', async () => {
+    test('throws ImportPasswordValidationError for short import password', async () => {
       const db = levelPrivateStateProvider<PID, PS>(testConfig);
       db.setContractAddress(TEST_CONTRACT_ADDRESS);
       await db.set('stringValue', testStates.stringValue);
@@ -485,7 +496,7 @@ describe('Level Private State Provider', (): void => {
 
       await expect(
         db.importPrivateStates(exportData, { password: 'short' })
-      ).rejects.toThrow(PrivateStateExportError);
+      ).rejects.toThrow(ImportPasswordValidationError);
     });
 
     describe('strict password policy on export/import', () => {
@@ -512,7 +523,7 @@ describe('Level Private State Provider', (): void => {
         ['repeated_characters', 'aaaaaaaaaaaaaaaa'],
         ['insufficient_classes', 'abcdefghjkmnpqrs'],
         ['sequential_pattern', 'Password-123456!']
-      ])('importPrivateStates rejects weak password (%s)', async (reason, weakPassword) => {
+      ])('importPrivateStates rejects weak password (%s)', async (_reason, weakPassword) => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
         db.setContractAddress(TEST_CONTRACT_ADDRESS);
         await db.set('stringValue', testStates.stringValue);
@@ -523,8 +534,7 @@ describe('Level Private State Provider', (): void => {
           db.importPrivateStates(exportData, { password: weakPassword })
         );
 
-        expect(error).toBeInstanceOf(PrivateStateExportError);
-        expectPasswordValidationCause(error, reason);
+        expectImportPasswordError(error);
       });
     });
 
@@ -1072,7 +1082,7 @@ describe('Level Private State Provider', (): void => {
       ).rejects.toThrow(SigningKeyExportError);
     });
 
-    test('throws SigningKeyExportError for short import password', async () => {
+    test('throws ImportPasswordValidationError for short import password', async () => {
       const db = levelPrivateStateProvider<PID, PS>(testConfig);
       const signingKey = sampleSigningKey();
       await db.setSigningKey(CONTRACT_ADDRESS_1, signingKey);
@@ -1082,7 +1092,7 @@ describe('Level Private State Provider', (): void => {
 
       await expect(
         db.importSigningKeys(exportData, { password: 'short' })
-      ).rejects.toThrow(SigningKeyExportError);
+      ).rejects.toThrow(ImportPasswordValidationError);
     });
 
     describe('strict password policy on signing keys export/import', () => {
@@ -1108,7 +1118,7 @@ describe('Level Private State Provider', (): void => {
         ['repeated_characters', 'aaaaaaaaaaaaaaaa'],
         ['insufficient_classes', 'abcdefghjkmnpqrs'],
         ['sequential_pattern', 'Password-123456!']
-      ])('importSigningKeys rejects weak password (%s)', async (reason, weakPassword) => {
+      ])('importSigningKeys rejects weak password (%s)', async (_reason, weakPassword) => {
         const db = levelPrivateStateProvider<PID, PS>(testConfig);
         await db.setSigningKey(CONTRACT_ADDRESS_1, sampleSigningKey());
         const exportData = await db.exportSigningKeys({ password: EXPORT_PASSWORD });
@@ -1118,8 +1128,7 @@ describe('Level Private State Provider', (): void => {
           db.importSigningKeys(exportData, { password: weakPassword })
         );
 
-        expect(error).toBeInstanceOf(SigningKeyExportError);
-        expectPasswordValidationCause(error, reason);
+        expectImportPasswordError(error);
       });
     });
 

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -56,6 +56,7 @@ export type PrivateStateImportErrorCause =
   | 'decryption_failed'
   | 'invalid_format'
   | 'conflict'
+  | 'invalid_password'
   | 'unknown';
 
 /**
@@ -93,6 +94,20 @@ export class InvalidExportFormatError extends PrivateStateImportError {
   constructor(message = 'Invalid export format') {
     super(message, 'invalid_format');
     this.name = 'InvalidExportFormatError';
+  }
+}
+
+/**
+ * Error thrown when the password supplied for an import operation does not
+ * satisfy the password strength policy. Extends {@link PrivateStateImportError}
+ * so callers can catch every import failure via a single base type, while the
+ * `'invalid_password'` cause distinguishes a policy violation from a failed
+ * decryption or malformed payload.
+ */
+export class ImportPasswordValidationError extends PrivateStateImportError {
+  constructor(message: string) {
+    super(message, 'invalid_password');
+    this.name = 'ImportPasswordValidationError';
   }
 }
 

--- a/packages/types/src/test/errors.test.ts
+++ b/packages/types/src/test/errors.test.ts
@@ -1,0 +1,33 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ImportPasswordValidationError, PrivateStateImportError } from '../errors';
+
+describe('ImportPasswordValidationError', () => {
+  it('is a PrivateStateImportError so callers can catch all import failures via one base type', () => {
+    const error = new ImportPasswordValidationError('Password is shorter than 16 characters');
+
+    expect(error).toBeInstanceOf(PrivateStateImportError);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('carries the invalid_password cause discriminant and preserves the message', () => {
+    const error = new ImportPasswordValidationError('Password is shorter than 16 characters');
+
+    expect(error.name).toBe('ImportPasswordValidationError');
+    expect(error.cause).toBe('invalid_password');
+    expect(error.message).toBe('Password is shorter than 16 characters');
+  });
+});

--- a/testkit-js/testkit-js/src/contract/in-memory-private-state-provider.ts
+++ b/testkit-js/testkit-js/src/contract/in-memory-private-state-provider.ts
@@ -21,6 +21,7 @@ import {
   type ExportPrivateStatesOptions,
   type ExportSigningKeysOptions,
   ImportConflictError,
+  ImportPasswordValidationError,
   type ImportPrivateStatesOptions,
   type ImportPrivateStatesResult,
   type ImportSigningKeysOptions,
@@ -123,6 +124,12 @@ const validateExportPassword = (password: string): void => {
 const validateSigningKeyExportPassword = (password: string): void => {
   if (password.length < MIN_PASSWORD_LENGTH) {
     throw new SigningKeyExportError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
+  }
+};
+
+const validateImportPassword = (password: string): void => {
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    throw new ImportPasswordValidationError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
   }
 };
 
@@ -320,7 +327,7 @@ export const inMemoryPrivateStateProvider = <
         throw new InvalidExportFormatError('Password is required for in-memory provider import');
       }
 
-      validateExportPassword(options.password);
+      validateImportPassword(options.password);
 
       let payload: PrivateStatePayload<PSI>;
       try {
@@ -461,7 +468,7 @@ export const inMemoryPrivateStateProvider = <
         throw new InvalidExportFormatError('Password is required for in-memory provider import');
       }
 
-      validateSigningKeyExportPassword(options.password);
+      validateImportPassword(options.password);
 
       let payload: SigningKeyPayload;
       try {

--- a/testkit-js/testkit-js/test/in-memory-private-state-provider.ut.test.ts
+++ b/testkit-js/testkit-js/test/in-memory-private-state-provider.ut.test.ts
@@ -16,7 +16,9 @@
 import type { Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import type { ContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import {
+  ImportPasswordValidationError,
   InvalidExportFormatError,
+  type PrivateStateExport,
   type SigningKeyExport
 } from '@midnight-ntwrk/midnight-js-types';
 import { createCipheriv, pbkdf2Sync, randomBytes } from 'crypto';
@@ -112,5 +114,36 @@ describe('[Unit tests] inMemoryPrivateStateProvider importSigningKeys validation
 
     expect(result.imported).toBe(1);
     expect(await provider.getSigningKey(CONTRACT_ADDRESS_1)).toEqual(VALID_SIGNING_KEY);
+  });
+});
+
+describe('[Unit tests] inMemoryPrivateStateProvider rejects weak import passwords', () => {
+  const WEAK_PASSWORD = 'short';
+
+  it('importSigningKeys throws ImportPasswordValidationError, not an export error', async () => {
+    const provider = inMemoryPrivateStateProvider<PSI, PS>();
+    const goodExport = buildExport({ [CONTRACT_ADDRESS_1]: VALID_SIGNING_KEY });
+
+    await expect(
+      provider.importSigningKeys(goodExport, { password: WEAK_PASSWORD })
+    ).rejects.toThrow(ImportPasswordValidationError);
+  });
+
+  it('importPrivateStates throws ImportPasswordValidationError, not an export error', async () => {
+    const provider = inMemoryPrivateStateProvider<PSI, PS>();
+    const salt = randomBytes(SALT_LENGTH);
+    const stateExport: PrivateStateExport = {
+      format: 'midnight-private-state-export',
+      encryptedPayload: encryptPayload(
+        JSON.stringify({ version: 1, exportedAt: new Date().toISOString(), stateCount: 0, states: {} }),
+        VALID_PASSWORD,
+        salt
+      ),
+      salt: salt.toString('hex')
+    };
+
+    await expect(
+      provider.importPrivateStates(stateExport, { password: WEAK_PASSWORD })
+    ).rejects.toThrow(ImportPasswordValidationError);
   });
 });


### PR DESCRIPTION
# Overview

Password strength validation during **import** operations threw export-named errors — `PrivateStateExportError` / `SigningKeyExportError` — even though no export was happening. Getting an "export error" while importing is confusing (issue #825).

Import paths now throw a new `ImportPasswordValidationError` that **extends `PrivateStateImportError`**, so callers can catch every import failure via a single base type, while the `'invalid_password'` cause distinguishes a policy violation from a failed decryption or malformed payload. Export paths are unchanged.

## Changes

- **`packages/types`**: added `ImportPasswordValidationError extends PrivateStateImportError` and an `'invalid_password'` member to `PrivateStateImportErrorCause` (both additive/non-breaking).
- **`packages/level-private-state-provider`**: collapsed the two export wrappers into one parameterized `validatePasswordOrThrow`; import paths now throw `ImportPasswordValidationError`. Fixed the password-policy doc comment.
- **`testkit-js` in-memory provider**: fixed the identical bug on its two import paths (surfaced by impact analysis).

## Behavior change

Callers catching `PrivateStateExportError` / `SigningKeyExportError` **on import** must switch to `ImportPasswordValidationError` (or its base `PrivateStateImportError`). Export-path behavior is unchanged.

## Test plan

- [x] Tests written first (TDD), verified RED before the fix
- [x] All existing tests pass (types 33, level-provider 276, testkit in-memory 17)
- [x] Lint clean, full workspace build succeeds

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant)
- [ ] Update documentation (if relevant)
- [x] No new todos introduced

## Links

Closes #825

🤖 Generated with [Claude Code](https://claude.com/claude-code)