### PR TITLE
ci: pin npm-installed CI tool versions

### DIFF
--- a/.github/workflows/ci-testkit-js-e2e.yml
+++ b/.github/workflows/ci-testkit-js-e2e.yml
@@ -266,7 +266,7 @@ jobs:
           mkdir junit-results
           find test-results -name "*.xml" -exec cp {} junit-results/ \;
           if [ "$(ls -A junit-results)" ]; then
-            npm install -g junit-report-merger
+            npm install -g junit-report-merger@9.0.4
             jrm junit-test-results.xml junit-results/*.xml
           else
             echo "No JUnit results found"


### PR DESCRIPTION
Closes #1139

Pins floating-version npm tool installs in workflows to exact versions (vercel 58.7.1 / typedoc-plugin-markdown 4.12.0 / rimraf 6.1.3 / junit-report-merger 9.0.4 / npm 12.0.2 as applicable). Floating tags execute whatever the registry serves at run time; pinning closes that window.