### PR TITLE
docs: add ADRs 0004-0009 for ledger v8/v9 hard-fork decisions

### DIFF
--- a/docs/adr/0004-ledger-support-window-current-plus-previous.md
+++ b/docs/adr/0004-ledger-support-window-current-plus-previous.md
@@ -1,0 +1,60 @@
+# 0004. Support the current and previous ledger version only; construct/submit stays current-version-only
+
+- Status: Proposed (pending OQ10 — product/team ruling on the standing window policy)
+- Date: 2026-08-07
+- Deciders: Szymon Paluchowski
+- Related: [HF design spec v3.9](https://github.com/midnightntwrk/midnight-js/blob/docs/superpowers-specs/docs/superpowers/specs/2026-07-09-ledger-v8-v9-dual-support-design.md) (D8, D9, D12), [#1005 upstream answers](https://github.com/midnightntwrk/midnight-js/issues/1005#issuecomment-5190024611) (confirmed [here](https://github.com/midnightntwrk/midnight-js/issues/1005#issuecomment-5202692002))
+
+## Context
+
+The Midnight blockchain hard-forks between ledger protocol versions (currently
+v8 → v9). A dApp session may read history encoded with the previous version
+while submitting transactions in the current one. Upstream imposes **no
+ceiling** on how long old versions stay serviceable: there is no plan to drop
+V2 proofs or ZKIR-v2 contract support (#1005 answers 2/4). Any support window
+is therefore a midnight-js maintenance-policy choice, not an upstream
+constraint. Midnight.js has no pre-fork construct pipeline: the
+construct→prove→submit flow is statically pinned to the current ledger via
+`packages/protocol`. Building an old-version construct pipeline would be a
+major hidden workstream serving only a shrinking pre-fork window.
+
+## Decision
+
+We will support **exactly two ledger versions at a time: current + previous.**
+
+- **Construct/submit is current-version-only.** Operating against a pre-fork
+  network head fail-fasts with a typed error; dApps that must transact
+  pre-fork stay on the last previous-version-based major.
+- **Decode/read covers current + previous.** Previous-version records surface
+  as raw bytes plus version int (ADR 0008) and decode dApp-side.
+- **Keep-state soundness is re-validated per fork via a spike, never
+  assumed.** Each fork window gets its own validation of the
+  state-migration/byte-identity facts before any compat mechanism ships.
+- **The fork date is not a design or scheduling driver.** Delivery is
+  sequenced by dependency order only.
+
+## Consequences
+
+- **Positive:** dependency and test growth is bounded (at most two ledger
+  stacks live at once); every version dispatch is a two-case switch; no
+  pre-fork pipeline to build or maintain.
+- **Negative:** during the pre-fork window a newly released major is
+  read-capable only; retiring the previous version strands
+  not-yet-graduated keep-state contracts on the last supporting major
+  (the sanctioned graduation mechanism — key rotation installing
+  current-version artifacts — is still unconfirmed upstream, tracked with
+  OQ10). If policy ever widens to three live versions, the `contracts`
+  routing table and the keep-state config shape need rework (localized,
+  but real).
+- **Follow-ups:** OQ10 ruling converts this ADR to Accepted (or revises
+  it); compat-package retirement at each new fork is a deliberate policy
+  act (`npm deprecate` + shrinking the `LedgerVersion` union).
+
+## Alternatives considered
+
+- **Support N versions indefinitely (upstream permits it):** rejected —
+  unbounded dependency/test matrix growth for a framework that never needs
+  more than one fork transition at a time.
+- **Full pre-fork operation in the new major (v8-native construct):**
+  rejected — no such pipeline exists in the codebase; the effort would serve
+  only the pre-fork window and die at the fork.

--- a/docs/adr/0005-per-fork-transitional-compat-package.md
+++ b/docs/adr/0005-per-fork-transitional-compat-package.md
@@ -1,0 +1,62 @@
+# 0005. Ship cross-fork compatibility as a per-fork transitional package named for the version it retires with
+
+- Status: Accepted
+- Date: 2026-08-07
+- Deciders: Szymon Paluchowski
+- Related: [HF design spec v3.9](https://github.com/midnightntwrk/midnight-js/blob/docs/superpowers-specs/docs/superpowers/specs/2026-07-09-ledger-v8-v9-dual-support-design.md) (D11), ADR 0004
+
+## Context
+
+Under the current + previous support window (ADR 0004), each hard fork needs
+previous-version capability somewhere: decoders for historical records and —
+when the fork's spike shows it is needed — a keep-state execution bridge for
+contracts compiled against the previous toolchain. Placing that capability in
+core packages would force every consumer to carry a second WASM stack, widen
+the supply-chain surface of the whole tree, and make removal at the next fork
+a breaking `exports`-map change on `protocol`. The capability is inherently
+**one-fork-scoped**: it solves exactly one (previous, current) pair, and the
+next fork's needs are unknown until its own spike runs.
+
+## Decision
+
+We will ship all previous-version capability in a **dedicated transitional
+package, one per fork window, named for the version it retires with** — for
+the v8→v9 fork: `@midnight-ntwrk/midnight-js-ledger-v8-compat`.
+
+- The package is a **leaf**: consumed only by dApps and injected inward
+  (config object / codec import). No core package may depend on it —
+  CI-gated.
+- Entry points split the cost: the root entry carries keep-state; a separate
+  `./codec` entry carries the previous-version decoders and is the **only
+  place in the tree** with a direct previous-ledger dependency. Importing
+  `./codec` instantiates that WASM — the import itself is the opt-in.
+- Retirement at the next fork is a package deprecation (`npm deprecate`),
+  pre-announced in the package README from day one — not a change to any
+  core package. Whether the next fork needs its own compat package is
+  decided by that fork's spike, never assumed.
+
+## Consequences
+
+- **Positive:** bundle isolation is structural (don't install it, don't pay
+  for it); the previous-version supply-chain surface is confined to one
+  `package.json`; deletion is non-breaking for everyone who never installed
+  it; the version-in-name makes the lifecycle self-documenting.
+- **Negative:** one more published package to version and release (it
+  versions independently and fast during the window); transition-window
+  dApps must add a dependency and wire a config object.
+- **Follow-ups:** CI dependency-graph gates (no core package resolves the
+  previous ledger or the compat package); supply-chain checklist scoped to
+  this package's tree (two near-identical npm scopes exist — exact pins,
+  lockfile integrity, scope/version gate).
+
+## Alternatives considered
+
+- **A `protocol/v8` subpath:** rejected — removal becomes a breaking
+  `exports`-map change on a core package, and every `protocol` consumer
+  inherits the v8 supply-chain surface.
+- **A permanent multi-version core:** rejected — contradicts ADR 0004 and
+  ADR 0006; pays an N-version cost for N ≤ 2.
+- **dApp-side copy-paste (no package):** rejected — keep-state's
+  down-convert/rehash/wrap logic is too subtle to duplicate per dApp, and
+  instance-identity requirements (ADR 0007) need a controlled dependency
+  shape.

--- a/docs/adr/0006-no-generic-version-dispatch-layer.md
+++ b/docs/adr/0006-no-generic-version-dispatch-layer.md
@@ -1,0 +1,61 @@
+# 0006. Handle ledger versions with explicit parameters and two-case switches, not a generic dispatch layer
+
+- Status: Accepted
+- Date: 2026-08-07
+- Deciders: Szymon Paluchowski
+- Related: [HF design spec v3.9](https://github.com/midnightntwrk/midnight-js/blob/docs/superpowers-specs/docs/superpowers/specs/2026-07-09-ledger-v8-v9-dual-support-design.md) (D1, D10), ADR 0004
+
+## Context
+
+Supporting two ledger versions invites generic machinery: a
+version-parameterised accessor (`getLedger<V>`), a unified dispatch facade,
+branded type buckets, per-version ACL parity lists. Early spec drafts designed
+exactly that and successive reviews removed it all: under ADR 0004 the
+construct→prove→submit pipeline is statically current-version, the
+previous-version decode surface is a handful of functions, and N never
+exceeds 2. A generic facade would encode an assumed axis of variation that an
+unknown future fork will not honour — the v8→v9 spike itself invalidated the
+previous fork model (dual compiled artifacts) that any prematurely built
+facade would have frozen in.
+
+## Decision
+
+We will keep version handling **concrete and explicit**:
+
+- A closed union type (`LedgerVersion`, currently `'v8' | 'v9'`) is the
+  single compile-time signal downstream code keys on. It widens at a fork
+  and shrinks at retirement — every switch over it stops compiling at both
+  events, which is the intended change-discovery mechanism.
+- Version values are **passed as explicit arguments** (per-record version,
+  network-head version); no hidden mutable global — cross-version
+  operations coexist in one session and a shared global is racy.
+- Dispatch points are **plain two-case switches** in the few places that
+  need them. No unified facade, no branded types, no runtime version
+  registry. Abstraction is added *when* a future fork's real shape is
+  known, not before.
+
+## Consequences
+
+- **Positive:** the version-handling surface is small enough to audit by
+  reading; the compiler mechanically finds every dispatch point when the
+  union changes; nothing generic exists to misfit the next fork's actual
+  needs.
+- **Negative:** a third live version (if ADR 0004's window ever widens)
+  means touching each switch by hand — accepted, because the compiler
+  enumerates them and the alternative is speculative machinery carried
+  forever.
+- **Follow-ups:** the sourcing distinction (per-record vs network-head
+  version) is convention enforced by review and spy tests, not by the type
+  system — a deliberate trade recorded here.
+
+## Alternatives considered
+
+- **Version-parameterised accessor / unified facade (early spec drafts):**
+  rejected after review — every consumer paid indirection for a pipeline
+  that is statically single-version.
+- **Branded types and a type-bucket taxonomy for divergent shapes:**
+  rejected — solved a problem that current-version-only construct/submit
+  had already removed; raw-bytes surfacing (ADR 0008) closes the one place
+  the two type worlds would have met.
+- **Mutable module-level "active version" global:** rejected — racy across
+  concurrent operations and hostile to fail-fast behaviour.

--- a/docs/adr/0007-protocol-single-ledger-seam-peer-dependency.md
+++ b/docs/adr/0007-protocol-single-ledger-seam-peer-dependency.md
@@ -1,0 +1,66 @@
+# 0007. Keep `protocol` the single seam for the ledger implementation; satellite packages consume it as a peerDependency
+
+- Status: Accepted
+- Date: 2026-08-07
+- Deciders: Szymon Paluchowski
+- Related: [HF design spec v3.9](https://github.com/midnightntwrk/midnight-js/blob/docs/superpowers-specs/docs/superpowers/specs/2026-07-09-ledger-v8-v9-dual-support-design.md) (D2, D3), [#1052](https://github.com/midnightntwrk/midnight-js/issues/1052) (WASM dual instantiation), ADR 0005
+
+## Context
+
+`@midnight-ntwrk/midnight-js-protocol` re-exports the current ledger WASM
+packages, and every core package imports ledger symbols through it. WASM
+modules make module identity load-bearing: two copies of the same ledger
+package in one process produce objects that fail `instanceof` checks across
+the copy boundary (#1052) — failures surface far from their cause, e.g. as
+proof errors minutes into an operation. Any new package that needs current
+ledger types (such as a per-fork compat package, ADR 0005) could declare its
+own direct ledger dependency, which would open a second instantiation axis
+and couple it to ledger RC pin churn.
+
+## Decision
+
+We will keep `protocol` the **only** package that depends on the current
+ledger implementation directly. Any satellite package needing current-ledger
+symbols:
+
+- declares `@midnight-ntwrk/midnight-js-protocol` as a **peerDependency**
+  (range = the framework major; workspace devDependency for local
+  build/tests) and imports every ledger symbol through `protocol`'s
+  subpaths;
+- declares **no direct dependency** on the ledger packages — enforced by a
+  packaging lint;
+- when it hands ledger-native objects across a package boundary at runtime,
+  exposes an **instance-identity check** performed at configuration time:
+  both sides reference the same constructor exported from
+  `protocol/ledger`, compared by reference equality, with a typed error on
+  mismatch (bundler misconfiguration can defeat module resolution even
+  when packaging is correct).
+
+Existing `protocol` subpath exports stay as-is across fork work: nothing is
+re-pointed because nothing moves.
+
+## Consequences
+
+- **Positive:** exactly one current-ledger WASM instance per process by
+  construction; objects produced by satellite packages pass `instanceof`
+  in the core pipeline; satellite packages are decoupled from ledger RC
+  pin churn (they follow whatever the host app's `protocol` resolves).
+- **Negative:** peerDependencies push an installation obligation onto the
+  dApp; the identity check adds one config-time step for packages that
+  hand over runtime objects.
+- **Follow-ups:** CI dependency-graph gate asserting satellite packages
+  resolve no direct ledger dependency; the typed mismatch error links the
+  dual-instantiation troubleshooting guide.
+
+## Alternatives considered
+
+- **Direct ledger dependency in each package that needs it:** rejected —
+  reopens #1052 per package and multiplies RC-pin maintenance.
+- **Runtime injection of ledger handles instead of peer resolution:**
+  rejected as the primary mechanism — moves a packaging invariant into
+  every call site; kept only where the dApp legitimately owns the instance
+  (the retained previous-version stack in keep-state).
+- **Trusting module resolution without an identity check:** rejected —
+  bundler misconfiguration produces two module contexts with correct
+  packaging; a one-`===` config-time check converts a mysterious late
+  proof failure into an immediate typed error.

--- a/docs/adr/0008-foreign-version-records-raw-bytes-plus-version.md
+++ b/docs/adr/0008-foreign-version-records-raw-bytes-plus-version.md
@@ -1,0 +1,68 @@
+# 0008. Surface previous-version records as raw bytes plus version int; name record helpers on the raw/decoded axis
+
+- Status: Accepted
+- Date: 2026-08-07
+- Deciders: Szymon Paluchowski
+- Related: [HF design spec v3.9](https://github.com/midnightntwrk/midnight-js/blob/docs/superpowers-specs/docs/superpowers/specs/2026-07-09-ledger-v8-v9-dual-support-design.md) (D5, v3.6/v3.8 rulings), ADR 0005, ADR 0006
+
+## Context
+
+After a fork, providers return historical records encoded with the previous
+ledger version alongside current ones. Core interfaces (e.g.
+`FinalizedTxData.tx`) are typed against the current ledger; a decoded
+previous-version object cannot inhabit them without a union, a brand, or a
+banned cast — exactly the machinery ADR 0006 rejects. Decoding
+previous-version records requires the previous WASM stack, which core
+packages must not carry (ADR 0005). Every record already carries a
+`protocolVersion` int.
+
+## Decision
+
+We will surface previous-version records across core APIs as **raw bytes plus
+their version int**, decoded dApp-side with the compat codec (ADR 0005):
+
+- One additive field: `rawTx: Uint8Array`, populated on previous-version
+  records **only** — its presence/absence is the runtime discriminant.
+- The declared `tx` field stays required (a documented lying type on
+  previous-version records). Reading it on such a record throws a typed
+  error naming the compat codec, via a **non-enumerable accessor** —
+  serialization, spread, `structuredClone`, deep equality and logging never
+  trip it; only a direct read at the version seam does.
+- Runtime helpers live in `utils` (`types` stays declarations-only):
+  - `isDecodedTxData()` — type guard narrowing on `rawTx` absence,
+    re-exported by the `midnight-js` barrel;
+  - `createRawFinalizedTxData()` — the mandatory factory installing the
+    throwing accessor; providers **and testkit mocks** must construct
+    previous-version records through it, because an object literal
+    silently satisfies the interface without the throw (tests pass on
+    mocks, production throws).
+- Helper names use the **raw/decoded vocabulary, never a version number**:
+  the discriminant is payload form, the helpers carry no previous-version
+  code (bytes + int + a `defineProperty` accessor), and the same mechanism
+  serves the next fork window without a public-API rename. The record's
+  version lives in the data (`protocolVersion`), not in function names.
+
+## Consequences
+
+- **Positive:** core interfaces stay single-version-typed with zero
+  previous-version knowledge in providers; no unions/brands/casts; the
+  compile surface is consumer-compile-compatible (additive field only);
+  the mechanism is fork-generic.
+- **Negative:** the `tx` type lies on previous-version records — a weak
+  compile-time signal by design, mitigated by the guard and a documented
+  runtime break; copies made by spread/clone drop the accessor (`tx`
+  silently `undefined`), so consumers must re-guard after cloning.
+- **Follow-ups:** descriptor-parity test between provider and mock records;
+  TROUBLESHOOTING entries for the throw and the copy caveat.
+
+## Alternatives considered
+
+- **Decode previous-version records in the provider behind an injected
+  codec:** rejected — puts an injection seam and version knowledge into a
+  core package; kept as a recorded fallback only if provider-internal
+  logic is found to need decoded fields.
+- **Union / branded type for `tx`:** rejected — spreads two-version
+  complexity to every consumer forever (ADR 0006).
+- **Version-named helpers (`isV9TxData`, `createV8FinalizedTxData`):**
+  rejected — falsely implies version-specific code in core and forces a
+  public-API rename every fork window.

--- a/docs/adr/0009-protocol-version-to-ledger-per-major-ranges.md
+++ b/docs/adr/0009-protocol-version-to-ledger-per-major-ranges.md
@@ -1,0 +1,69 @@
+# 0009. Map protocolVersion to ledger eras via closed per-major ranges, failing fast only on unknown majors
+
+- Status: Accepted
+- Date: 2026-08-07
+- Deciders: Szymon Paluchowski
+- Related: [HF design spec v3.9](https://github.com/midnightntwrk/midnight-js/blob/docs/superpowers-specs/docs/superpowers/specs/2026-07-09-ledger-v8-v9-dual-support-design.md) (OQ1/BC-1, QA-1), [#1005 answer 6](https://github.com/midnightntwrk/midnight-js/issues/1005#issuecomment-5190024611) (confirmed [here](https://github.com/midnightntwrk/midnight-js/issues/1005#issuecomment-5202692002)), [indexer mapping](https://github.com/midnightntwrk/midnight-indexer/blob/main/indexer-common/src/domain/protocol_version.rs)
+
+## Context
+
+The indexer tags every record with a `protocolVersion` int encoding the
+**node** version (`major·1_000_000 + minor·1_000`); midnight-js must narrow
+that untrusted int to a ledger era (`LedgerVersion`). Upstream confirmed the
+governing invariant: **a ledger era change always requires a node major
+change, but node majors may rise faster than eras** — so same major ⇒ same
+era, while an unknown major may genuinely be a new era. The indexer's own
+mapping table is per-minor and fail-fasts on unmapped minors; mirroring that
+client-side would mean a routine node minor upgrade (e.g. 2.2) bricks
+construct/submit for every dApp until a framework patch ships.
+
+## Decision
+
+We will map with **closed, bounded per-major ranges**, e.g.:
+
+```
+22_000 ≤ v < 23_000  (node 0.22)  → v8
+1_000_000 ≤ v < 2_000_000 (node 1.x) → v8
+2_000_000 ≤ v < 3_000_000 (node 2.x) → v9
+```
+
+- An **unseen minor within a known major maps without error** (same-major ⇒
+  same-era): routine node upgrades never brick dApps.
+- The fail-fast else-branch fires **only on an unknown major** — where a new
+  era is genuinely possible. No open-ended `>=`: the invariant's converse
+  does not hold, so node 3.x must not silently map to v9.
+- **Major 0 is exempt** from the whole-major rule: 0.x minors are
+  semver-breaking and only node 0.22 is attested; a hypothetical 0.23
+  fail-fasts by design.
+- This mapping is the **sole narrowing point** from the untrusted int to the
+  closed `LedgerVersion` set; the unknown-major error names the observed
+  int and the supported set.
+
+The table is extended once per node **major**, after confirming that major's
+era. That fail-fast is the designed maintenance signal — not a bug.
+
+## Consequences
+
+- **Positive:** routine node minor upgrades are provably same-era and need
+  no framework release; a possible new era can never be silently
+  mis-mapped to the current one; the deliberate divergence from the
+  indexer's per-minor table avoids amplifying its operational choice
+  client-side.
+- **Negative:** each new node major requires a small framework release to
+  extend the table even when the era is unchanged; a malicious indexer
+  reporting a wrong-but-*known* version still passes narrowing (bounded to
+  DoS/griefing by the ledger's effects-equality backstop; an independent
+  cross-check signal is tracked separately).
+- **Follow-ups:** table test over boundary values including the major-0
+  exemption; extend-per-major documented as the maintenance procedure.
+
+## Alternatives considered
+
+- **Mirror the indexer's per-minor table:** rejected — a routine node minor
+  upgrade would hit the fail-fast branch and brick construct/submit for
+  every dApp until a patch shipped.
+- **Open-ended ranges (`>= 2_000_000 → v9`):** rejected — node majors may
+  outpace eras, so a v10-era major would silently map to v9.
+- **Trust the int without narrowing:** rejected — the indexer is outside
+  the trust boundary; an unknown int must produce a typed error, never a
+  silent default.


### PR DESCRIPTION
## Summary

Extracts the durable architecture decisions from the [HF design spec v3.9](https://github.com/midnightntwrk/midnight-js/blob/docs/superpowers-specs/docs/superpowers/specs/2026-07-09-ledger-v8-v9-dual-support-design.md) into ADRs. The spec is one-fork-scoped (it retires with the compat package at v10); these decisions are the rules that must survive it and govern future forks:

- **ADR 0004** — support window: current + previous ledger version; construct/submit stays current-only (D8/D9/D12). **Status: Proposed** — pending the OQ10 product ruling on the standing window policy; all other ADRs are Accepted.
- **ADR 0005** — cross-fork compatibility ships as a per-fork transitional package named for the version it retires with (D11).
- **ADR 0006** — no generic version-dispatch layer; closed `LedgerVersion` union + explicit parameters + two-case switches (D1/D10).
- **ADR 0007** — `protocol` stays the single seam for the ledger implementation; satellite packages consume it as a peerDependency with a config-time instance-identity check (D2/D3, #1052).
- **ADR 0008** — previous-version records surface as raw bytes + version int; record helpers named on the raw/decoded axis (`isDecodedTxData` / `createRawFinalizedTxData`) (D5, spec v3.6/v3.8 rulings).
- **ADR 0009** — `protocolVersion`→ledger mapping via closed per-major ranges with the major-0 exemption; fail-fast only on unknown majors (OQ1/BC-1, #1005 answer 6 — upstream-confirmed).

Rejected alternatives in each ADR come from the spec's revision history (v1 dual-artifact model, v2 type-bucket taxonomy, v3 injection seam), so the reasoning survives beyond the spec branch.

## Test plan

- [x] Docs-only change — no code, no tests affected
- [x] ADR numbering sequential after 0003; MADR-lite template followed; no index to update (per ADR 0001)
- [x] Links to spec, upstream answers, and related ADRs verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)