### PR TITLE
feat(protocol): add ledger version identity utilities

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -13,6 +13,16 @@
  * limitations under the License.
  */
 
+export type { LedgerVersion, ProtocolVersionErrorCode, SupportedProtocolVersionRange } from './version';
+export {
+  LEDGER_VERSIONS,
+  networkHeadVersion,
+  protocolVersionToLedger,
+  UnknownNetworkHeadProtocolVersionError,
+  UnknownProtocolVersionError,
+  UnknownRecordProtocolVersionError,
+  versionOfRecord,
+} from './version';
 export * as compactJs from '@midnight-ntwrk/compact-js';
 export * as compactRuntime from '@midnight-ntwrk/compact-runtime';
 export * as platform from '@midnight-ntwrk/platform-js';

--- a/packages/protocol/src/test/protocol-acl.test.ts
+++ b/packages/protocol/src/test/protocol-acl.test.ts
@@ -60,14 +60,24 @@ describe('Protocol ACL package', () => {
       expect(Object.keys(ns).length).toBeGreaterThan(0);
     });
 
-    it('exposes exactly the documented namespaces', () => {
-      // If this fails after adding a new protocol namespace, update the expected list.
+    it('exposes exactly the documented namespaces and version-identity exports', () => {
+      // Strict-equality pin of the full root surface: the five subpath-paired
+      // namespaces plus the flat version-identity exports (root-only by design —
+      // no ./version subpath). If this fails after an intentional surface
+      // change, update the expected list.
       expect(sortedKeys(protocol)).toEqual([
         'compactJs',
         'compactRuntime',
         'ledger',
+        'LEDGER_VERSIONS',
+        'networkHeadVersion',
         'onchainRuntime',
         'platform',
+        'protocolVersionToLedger',
+        'UnknownNetworkHeadProtocolVersionError',
+        'UnknownProtocolVersionError',
+        'UnknownRecordProtocolVersionError',
+        'versionOfRecord',
       ]);
     });
   });

--- a/packages/protocol/src/test/version.test-d.ts
+++ b/packages/protocol/src/test/version.test-d.ts
@@ -1,0 +1,38 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type { LedgerVersion, ProtocolVersionErrorCode, SupportedProtocolVersionRange } from '../index';
+
+describe('protocol version identity type surface', () => {
+  it('LedgerVersion is exactly the closed v8/v9 union', () => {
+    expectTypeOf<LedgerVersion>().toEqualTypeOf<'v8' | 'v9'>();
+  });
+
+  it('ProtocolVersionErrorCode is exactly the closed code union', () => {
+    expectTypeOf<ProtocolVersionErrorCode>().toEqualTypeOf<
+      'UNKNOWN_PROTOCOL_VERSION' | 'UNKNOWN_RECORD_PROTOCOL_VERSION' | 'UNKNOWN_NETWORK_HEAD_PROTOCOL_VERSION'
+    >();
+  });
+
+  it('SupportedProtocolVersionRange keeps its structural shape', () => {
+    expectTypeOf<SupportedProtocolVersionRange>().toEqualTypeOf<{
+      readonly min: number;
+      readonly max: number;
+      readonly version: LedgerVersion;
+    }>();
+  });
+});

--- a/packages/protocol/src/test/version.test.ts
+++ b/packages/protocol/src/test/version.test.ts
@@ -13,9 +13,17 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { LEDGER_VERSIONS, protocolVersionToLedger, UnknownProtocolVersionError } from '../version';
+import {
+  LEDGER_VERSIONS,
+  networkHeadVersion,
+  protocolVersionToLedger,
+  UnknownNetworkHeadProtocolVersionError,
+  UnknownProtocolVersionError,
+  UnknownRecordProtocolVersionError,
+  versionOfRecord
+} from '../version';
 
 const MAX_ERROR_MESSAGE_LENGTH = 256;
 
@@ -124,5 +132,84 @@ describe('runtime immutability', () => {
       // @ts-expect-error — mutation must fail at compile time and at runtime
       error.supportedRanges[0].version = 'v9';
     }).toThrow(TypeError);
+  });
+});
+
+describe('versionOfRecord', () => {
+  it('maps a historical record protocolVersion on the read path', () => {
+    expect(versionOfRecord({ protocolVersion: 1_000_000 })).toBe('v8');
+  });
+
+  it('throws UnknownRecordProtocolVersionError with full payload for an unknown major', () => {
+    const error = expectProtocolVersionError(() => versionOfRecord({ protocolVersion: 23_000 }));
+    expect(error).toBeInstanceOf(UnknownRecordProtocolVersionError);
+    expect(error.code).toBe('UNKNOWN_RECORD_PROTOCOL_VERSION');
+    expect(error.protocolVersion).toBe(23_000);
+    expect(error.supportedRanges).toEqual(EXPECTED_SUPPORTED_RANGES);
+  });
+
+  it('throws the record error, never the base error, for adversarial input through the helper', () => {
+    // @ts-expect-error — adversarial runtime input, signature is number
+    const error = expectProtocolVersionError(() => versionOfRecord({ protocolVersion: '2500000' }));
+    expect(error).toBeInstanceOf(UnknownRecordProtocolVersionError);
+    expect(error.protocolVersion).toBeUndefined();
+  });
+
+  it('never queries a record that structurally could be queried', () => {
+    const queryLatestProtocolVersion = vi.fn().mockResolvedValue(2_000_000);
+    const record = { protocolVersion: 1_000_000, queryLatestProtocolVersion };
+    expect(versionOfRecord(record)).toBe('v8');
+    expect(queryLatestProtocolVersion).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('networkHeadVersion', () => {
+  const rejectionOf = async (promise: Promise<unknown>): Promise<UnknownProtocolVersionError> => {
+    const outcome = await promise.then(
+      () => {
+        throw new Error('expected the construct path to reject');
+      },
+      (caught: unknown) => caught
+    );
+    if (outcome instanceof UnknownProtocolVersionError) {
+      return outcome;
+    }
+    throw new Error('expected a protocol version error rejection');
+  };
+
+  it('resolves the ledger version of the network head with exactly one query', async () => {
+    const source = { queryLatestProtocolVersion: vi.fn().mockResolvedValue(2_000_000) };
+    await expect(networkHeadVersion(source)).resolves.toBe('v9');
+    expect(source.queryLatestProtocolVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it('queries once per invocation with no cross-call caching', async () => {
+    const source = { queryLatestProtocolVersion: vi.fn().mockResolvedValue(1_000_000) };
+    await networkHeadVersion(source);
+    await networkHeadVersion(source);
+    expect(source.queryLatestProtocolVersion).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects with UnknownNetworkHeadProtocolVersionError with full payload for an unknown major', async () => {
+    const source = { queryLatestProtocolVersion: vi.fn().mockResolvedValue(23_000) };
+    const error = await rejectionOf(networkHeadVersion(source));
+    expect(error).toBeInstanceOf(UnknownNetworkHeadProtocolVersionError);
+    expect(error.code).toBe('UNKNOWN_NETWORK_HEAD_PROTOCOL_VERSION');
+    expect(error.protocolVersion).toBe(23_000);
+    expect(error.supportedRanges).toEqual(EXPECTED_SUPPORTED_RANGES);
+  });
+
+  it('rejects with the network-head error and undefined field when the source resolves NaN', async () => {
+    const source = { queryLatestProtocolVersion: vi.fn().mockResolvedValue(Number.NaN) };
+    const error = await rejectionOf(networkHeadVersion(source));
+    expect(error).toBeInstanceOf(UnknownNetworkHeadProtocolVersionError);
+    expect(error.protocolVersion).toBeUndefined();
+  });
+
+  it('propagates the underlying query rejection unchanged — no wrap, no retry, no fallback', async () => {
+    const failure = new Error('indexer unreachable');
+    const source = { queryLatestProtocolVersion: vi.fn().mockRejectedValue(failure) };
+    await expect(networkHeadVersion(source)).rejects.toBe(failure);
+    expect(source.queryLatestProtocolVersion).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/protocol/src/test/version.test.ts
+++ b/packages/protocol/src/test/version.test.ts
@@ -1,0 +1,128 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { LEDGER_VERSIONS, protocolVersionToLedger, UnknownProtocolVersionError } from '../version';
+
+const MAX_ERROR_MESSAGE_LENGTH = 256;
+
+const EXPECTED_SUPPORTED_RANGES = [
+  { min: 22_000, max: 23_000, version: 'v8' },
+  { min: 1_000_000, max: 2_000_000, version: 'v8' },
+  { min: 2_000_000, max: 3_000_000, version: 'v9' }
+];
+
+const expectProtocolVersionError = (act: () => unknown): UnknownProtocolVersionError => {
+  try {
+    act();
+  } catch (error) {
+    if (error instanceof UnknownProtocolVersionError) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error('expected a protocol version error to be thrown');
+};
+
+describe('protocolVersionToLedger', () => {
+  it.each([
+    [22_000, 'v8'],
+    [22_999, 'v8'],
+    [1_000_000, 'v8'],
+    [1_005_000, 'v8'],
+    [1_999_999, 'v8'],
+    [2_000_000, 'v9'],
+    [2_002_000, 'v9'],
+    [2_999_999, 'v9']
+  ])('maps attested protocolVersion %d to %s (unseen minors never error)', (protocolVersion, expected) => {
+    expect(protocolVersionToLedger(protocolVersion)).toBe(expected);
+  });
+
+  it.each([0, 21_999, 23_000, 999_999, 3_000_000, Number.MAX_SAFE_INTEGER, -1])(
+    'throws UnknownProtocolVersionError for unattested integer %d',
+    (protocolVersion) => {
+      expect(() => protocolVersionToLedger(protocolVersion)).toThrow(UnknownProtocolVersionError);
+    }
+  );
+
+  it.each([Number.NaN, 2_000_000.5, Number.POSITIVE_INFINITY])(
+    'throws UnknownProtocolVersionError for malformed number %d without coercion or rounding',
+    (protocolVersion) => {
+      expect(() => protocolVersionToLedger(protocolVersion)).toThrow(UnknownProtocolVersionError);
+    }
+  );
+
+  it.each([
+    ['string', '2500000'],
+    ['null', null],
+    ['undefined', undefined]
+  ])('throws UnknownProtocolVersionError for adversarial non-number input (%s)', (_label, adversarial) => {
+    // @ts-expect-error — adversarial runtime input, signature is number
+    expect(() => protocolVersionToLedger(adversarial)).toThrow(UnknownProtocolVersionError);
+  });
+
+  it('carries the observed int, stable code and structured supported ranges', () => {
+    const error = expectProtocolVersionError(() => protocolVersionToLedger(23_000));
+    expect(error.code).toBe('UNKNOWN_PROTOCOL_VERSION');
+    expect(error.protocolVersion).toBe(23_000);
+    expect(error.supportedRanges).toEqual(EXPECTED_SUPPORTED_RANGES);
+  });
+
+  it('renders a diagnosable message: observed int, every range boundary, remediation', () => {
+    const error = expectProtocolVersionError(() => protocolVersionToLedger(23_000));
+    expect(error.message).toContain('23000');
+    expect(error.message).toContain('22000');
+    expect(error.message).toContain('1000000');
+    expect(error.message).toContain('2000000');
+    expect(error.message).toContain('3000000');
+    expect(error.message).toContain('upgrade midnight-js');
+  });
+
+  it('sanitises adversarial non-number input: capped, control-char-free message, undefined field', () => {
+    const adversarial = `\u001b[31mforged\nlog line${'A'.repeat(4_000_000)}`;
+    // @ts-expect-error — adversarial runtime input, signature is number
+    const error = expectProtocolVersionError(() => protocolVersionToLedger(adversarial));
+    expect(error.message.length).toBeLessThan(MAX_ERROR_MESSAGE_LENGTH);
+    // eslint-disable-next-line no-control-regex
+    expect(error.message).not.toMatch(/[\u0000-\u001f\u007f]/);
+    expect(error.protocolVersion).toBeUndefined();
+  });
+});
+
+describe('runtime immutability', () => {
+  it('pins the LEDGER_VERSIONS value', () => {
+    expect(LEDGER_VERSIONS).toEqual(['v8', 'v9']);
+  });
+
+  it('rejects mutation of LEDGER_VERSIONS', () => {
+    expect(() => {
+      // @ts-expect-error — mutation must fail at compile time and at runtime
+      LEDGER_VERSIONS.push('v10');
+    }).toThrow(TypeError);
+  });
+
+  it('rejects mutation of a caught error supportedRanges array and its range objects', () => {
+    const error = expectProtocolVersionError(() => protocolVersionToLedger(0));
+    expect(() => {
+      // @ts-expect-error — mutation must fail at compile time and at runtime
+      error.supportedRanges.push({ min: 0, max: 1, version: 'v8' });
+    }).toThrow(TypeError);
+    expect(() => {
+      // @ts-expect-error — mutation must fail at compile time and at runtime
+      error.supportedRanges[0].version = 'v9';
+    }).toThrow(TypeError);
+  });
+});

--- a/packages/protocol/src/version.ts
+++ b/packages/protocol/src/version.ts
@@ -1,0 +1,106 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const LEDGER_VERSIONS = Object.freeze(['v8', 'v9'] as const);
+export type LedgerVersion = (typeof LEDGER_VERSIONS)[number];
+
+export type ProtocolVersionErrorCode =
+  | 'UNKNOWN_PROTOCOL_VERSION'
+  | 'UNKNOWN_RECORD_PROTOCOL_VERSION'
+  | 'UNKNOWN_NETWORK_HEAD_PROTOCOL_VERSION';
+
+export interface SupportedProtocolVersionRange {
+  /** Inclusive. */
+  readonly min: number;
+  /** Exclusive. */
+  readonly max: number;
+  readonly version: LedgerVersion;
+}
+
+/**
+ * Attested node-major ranges (encoding: nodeMajor * 1_000_000 + nodeMinor * 1_000).
+ * Major 0 is exempt from the per-major rule: 0.x minors are semver-breaking and
+ * only node 0.22 is attested as v8. Extending this table for a future node major
+ * is a one-line diff, made only after that major's ledger era is confirmed.
+ */
+const SUPPORTED_PROTOCOL_VERSION_RANGES: readonly SupportedProtocolVersionRange[] = Object.freeze([
+  Object.freeze({ min: 22_000, max: 23_000, version: 'v8' }),
+  Object.freeze({ min: 1_000_000, max: 2_000_000, version: 'v8' }),
+  Object.freeze({ min: 2_000_000, max: 3_000_000, version: 'v9' })
+] as const);
+
+const MESSAGE_OBSERVED_MAX_LENGTH = 64;
+
+const isSafeInteger = (value: unknown): value is number => Number.isSafeInteger(value);
+
+const isFiniteNumber = (value: unknown): value is number => Number.isFinite(value);
+
+/**
+ * The observed value is attacker-controlled indexer output: never interpolated
+ * raw. Non-numbers are truncated and stripped of control/ANSI characters so a
+ * multi-megabyte or newline-bearing payload can neither bloat logs nor forge
+ * log lines.
+ */
+const describeObserved = (observed: unknown): string =>
+  typeof observed === 'number'
+    ? String(observed)
+    : String(observed)
+        .slice(0, MESSAGE_OBSERVED_MAX_LENGTH)
+        // eslint-disable-next-line no-control-regex
+        .replace(/[\u0000-\u001f\u007f]/gu, '');
+
+const renderSupportedRanges = (): string =>
+  SUPPORTED_PROTOCOL_VERSION_RANGES.map((range) => `[${range.min},${range.max})=${range.version}`).join(', ');
+
+/** Thrown by protocolVersionToLedger when the major is outside the attested table. */
+export class UnknownProtocolVersionError extends Error {
+  readonly code: ProtocolVersionErrorCode = 'UNKNOWN_PROTOCOL_VERSION';
+  /** The observed value when it was a genuine number; undefined for adversarial non-number input. */
+  readonly protocolVersion: number | undefined;
+  readonly supportedRanges: readonly SupportedProtocolVersionRange[] = SUPPORTED_PROTOCOL_VERSION_RANGES;
+
+  constructor(observed: unknown) {
+    super(
+      `Unknown protocol version '${describeObserved(observed)}'. Supported: ${renderSupportedRanges()}. ` +
+        'Node major not attested by this midnight-js version; upgrade midnight-js.'
+    );
+    this.name = new.target.name;
+    this.protocolVersion = isFiniteNumber(observed) ? observed : undefined;
+  }
+}
+
+type ProtocolVersionErrorConstructor = new (observed: unknown) => UnknownProtocolVersionError;
+
+const toLedgerVersion = (observed: unknown, ProtocolVersionError: ProtocolVersionErrorConstructor): LedgerVersion => {
+  if (!isSafeInteger(observed)) {
+    throw new ProtocolVersionError(observed);
+  }
+  const match = SUPPORTED_PROTOCOL_VERSION_RANGES.find((range) => observed >= range.min && observed < range.max);
+  if (match === undefined) {
+    throw new ProtocolVersionError(observed);
+  }
+  return match.version;
+};
+
+/**
+ * Sole narrowing point: untrusted indexer int → closed LedgerVersion set.
+ * midnight-js packages source versions via versionOfRecord (read paths) /
+ * networkHeadVersion (construct paths) so the path-specific error taxonomy is
+ * never bypassed. dApp code MAY call this directly for ints obtained outside
+ * the provider flow (own queries, diagnostics); it then gets the base
+ * UnknownProtocolVersionError.
+ */
+export const protocolVersionToLedger = (protocolVersion: number): LedgerVersion =>
+  toLedgerVersion(protocolVersion, UnknownProtocolVersionError);

--- a/packages/protocol/src/version.ts
+++ b/packages/protocol/src/version.ts
@@ -81,6 +81,16 @@ export class UnknownProtocolVersionError extends Error {
   }
 }
 
+/** Read path (versionOfRecord). */
+export class UnknownRecordProtocolVersionError extends UnknownProtocolVersionError {
+  override readonly code = 'UNKNOWN_RECORD_PROTOCOL_VERSION';
+}
+
+/** Construct path (networkHeadVersion). */
+export class UnknownNetworkHeadProtocolVersionError extends UnknownProtocolVersionError {
+  override readonly code = 'UNKNOWN_NETWORK_HEAD_PROTOCOL_VERSION';
+}
+
 type ProtocolVersionErrorConstructor = new (observed: unknown) => UnknownProtocolVersionError;
 
 const toLedgerVersion = (observed: unknown, ProtocolVersionError: ProtocolVersionErrorConstructor): LedgerVersion => {
@@ -104,3 +114,13 @@ const toLedgerVersion = (observed: unknown, ProtocolVersionError: ProtocolVersio
  */
 export const protocolVersionToLedger = (protocolVersion: number): LedgerVersion =>
   toLedgerVersion(protocolVersion, UnknownProtocolVersionError);
+
+/** Read-path sourcing helper (historical records). */
+export const versionOfRecord = (record: { protocolVersion: number }): LedgerVersion =>
+  toLedgerVersion(record.protocolVersion, UnknownRecordProtocolVersionError);
+
+/** Construct-path sourcing helper (network head). Exactly one query per call. */
+export const networkHeadVersion = async (source: {
+  queryLatestProtocolVersion(): Promise<number>;
+}): Promise<LedgerVersion> =>
+  toLedgerVersion(await source.queryLatestProtocolVersion(), UnknownNetworkHeadProtocolVersionError);

--- a/packages/protocol/vitest.config.ts
+++ b/packages/protocol/vitest.config.ts
@@ -22,6 +22,11 @@ export default defineConfig({
     globals: true,
     include: ['**/test/**/*.test.ts'],
     exclude: ['node_modules', 'dist'],
+    typecheck: {
+      enabled: true,
+      include: ['**/test/**/*.test-d.ts', '**/test/version.test.ts'],
+      tsconfig: './tsconfig.json',
+    },
     coverage: {
       provider: 'v8',
       enabled: true,


### PR DESCRIPTION
## Summary
- Add `packages/protocol/src/version.ts`: the sole narrowing point from the untrusted indexer `protocolVersion` int to the closed `LedgerVersion` set (`'v8' | 'v9'`), per design spec MJS-01 (`docs/specs/2026-08-07-protocol-version-utils-design.md`)
- Bounded per-major ranges (no open-ended `>=`), major-0 exemption (only node 0.22 attested as v8; `23_000` fail-fasts by design), unseen minors within a known major map without error
- Distinct typed errors for read (`versionOfRecord`) vs construct (`networkHeadVersion`) paths with stable `code` discriminants, frozen structured `supportedRanges` payload, and sanitised messages (attacker-controlled input capped at 64 chars, control/ANSI chars stripped)
- `networkHeadVersion` queries exactly once per invocation (no caching); a rejecting query propagates unchanged
- Additive root exports only — no new subpath, no `exports`-map change, no new dependencies; export-surface strict-equality gate in `protocol-acl.test.ts` extended to 12 keys
- Type surface pinned via vitest typecheck mode (`version.test-d.ts` + `typecheck` block in `vitest.config.ts`), running inside the standard `vitest run`; `@ts-expect-error` directives in `version.test.ts` are compiler-verified by the same gate

Notes for reviewers:
- The new export block in `index.ts` sits before the five pre-existing namespace lines — placement forced by `simple-import-sort`; the namespace lines are byte-for-byte unchanged
- Spec §9 SEC-4 directive: ticket 09 should add the mechanical gate restricting `protocolVersionToLedger` usage inside `packages/*` to `packages/protocol` itself; until then it is a review-checklist item for consuming tickets (03/05/07/08)

## Test plan
- [x] Tests written first (TDD), verified they fail before implementation (red step recorded per task)
- [x] All existing tests pass — sole existing-test edit: `protocol-acl.test.ts` expected key list + truthful title
- [x] Lint clean, build succeeds, `protocol` coverage stays 100% (lines/branches/functions/statements)
- [x] Typecheck gate proven fallible (temporarily broken assertion + removed `@ts-expect-error` → 2 typecheck errors → restored → green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
