### PR TITLE
chore(deps): route dependabot/renovate PRs to canonical bot:* labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ registries:
 
 updates:
   - package-ecosystem: "github-actions"
+    labels:
+      - "bot:github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -23,6 +25,8 @@ updates:
 #      default-days: 7
 
   - package-ecosystem: "npm"
+    labels:
+      - "bot:dependencies"
     directory: "/"
     registries:
       - npm-github


### PR DESCRIPTION
Per-ecosystem `labels` added to `.github/dependabot.yml` (github-actions → `bot:github-actions`, everything else → `bot:dependencies`). Tool-default labels stop accumulating; existing history untouched.

Closes #1147