### PR TITLE
fix(deps): align Effect dependencies on 3.22.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@midnightntwrk/ledger-v9": "1.0.0-rc.3",
     "@midnightntwrk/onchain-runtime-v4": "4.0.0-rc.3",
     "@midnight-ntwrk/compact-runtime": "0.18.0-rc.1",
+    "effect": "3.22.1",
     "undici": ">=7.24.0",
     "tar": ">=7.5.19",
     "fast-xml-parser": ">=5.7.0",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -33,7 +33,7 @@
     "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
     "@midnight-ntwrk/midnight-js-types": "workspace:*",
     "@midnight-ntwrk/midnight-js-utils": "workspace:*",
-    "effect": "^3.20.0"
+    "effect": "^3.22.1"
   },
   "files": [
     "dist/"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@midnight-ntwrk/midnight-js-protocol": "workspace:*",
-    "effect": "^3.20.0",
+    "effect": "^3.22.1",
     "pino": "^10.3.1",
     "rxjs": "^7.8.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1868,7 +1868,7 @@ __metadata:
     "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
     "@midnight-ntwrk/midnight-js-types": "workspace:*"
     "@midnight-ntwrk/midnight-js-utils": "workspace:*"
-    effect: "npm:^3.20.0"
+    effect: "npm:^3.22.1"
     vitest: "npm:^4.1.7"
   languageName: unknown
   linkType: soft
@@ -2050,7 +2050,7 @@ __metadata:
   resolution: "@midnight-ntwrk/midnight-js-types@workspace:packages/types"
   dependencies:
     "@midnight-ntwrk/midnight-js-protocol": "workspace:*"
-    effect: "npm:^3.20.0"
+    effect: "npm:^3.22.1"
     pino: "npm:^10.3.1"
     rxjs: "npm:^7.8.2"
     vitest: "npm:^4.1.7"
@@ -6452,13 +6452,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"effect@npm:^3.19.19, effect@npm:^3.20.0, effect@npm:^3.21.0, effect@npm:^3.21.4":
-  version: 3.21.4
-  resolution: "effect@npm:3.21.4"
+"effect@npm:3.22.1":
+  version: 3.22.1
+  resolution: "effect@npm:3.22.1"
   dependencies:
     "@standard-schema/spec": "npm:^1.0.0"
     fast-check: "npm:^3.23.1"
-  checksum: 10/c95506043e070662af85963af779b3d4e9ec501e03069532888831cc268e0fd9f448dcd2a4c89809e05471e64dcd270313b196056f878d1c028037870694af11
+  checksum: 10/00575333225e2dabf0a873e993357ad0e923476db7a44f24b8a65f766683ac9cbc98b2b30a299a65b581694709d35df85f46fb6fa6f5c922c134aa5e2dea6ce5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Raise the direct Effect dependency floor in `midnight-js-contracts` and `midnight-js-types` to 3.22.1.
- Resolve Effect to 3.22.1 across the monorepo.
- Regenerate the Yarn lockfile with the aligned version.

## Why

The dynamic cross-contract E2E stack loaded Effect 3.21.4 through Midnight JS and Effect 3.22.1 through Compact JS. When values crossed that package boundary, Effect repeatedly reported:

> Executing an Effect versioned 3.21.4 with a Runtime of version 3.22.1, you may want to dedupe the effect dependencies.

The Midnight JS package ranges allowed consumers to resolve 3.21.4 even though Compact JS uses 3.22.1. Raising the direct minimum and aligning the workspace resolution prevents that runtime version skew.

## Validation

- `corepack yarn why effect` — All workspace and transitive references resolve to 3.22.1.
- `corepack yarn build:core`
- `corepack yarn turbo run build --filter=@midnight-ntwrk/testkit-js`
- `corepack yarn lint`
- `corepack yarn test` — 27/27 tasks passed.
