### PR TITLE
feat(midnight-js): enforce no-new-unsafe-casts via ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,19 @@ import importPlugin from 'eslint-plugin-import';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import unusedImports from 'eslint-plugin-unused-imports';
 
-
+// No-new-occurrences gate for unsafe casts in package sources. Existing,
+// reviewed occurrences carry an inline eslint-disable; test files and
+// testkit-js are exempt (see the dedicated override below).
+const unsafeCastSelectors = [
+  {
+    selector: "TSAsExpression[typeAnnotation.type='TSAnyKeyword'], TSTypeAssertion[typeAnnotation.type='TSAnyKeyword']",
+    message: "Unsafe cast to 'any'. Use a precise type or a type guard instead; a reviewed exception needs an inline eslint-disable."
+  },
+  {
+    selector: "TSAsExpression[typeAnnotation.type='TSUnknownKeyword'], TSTypeAssertion[typeAnnotation.type='TSUnknownKeyword']",
+    message: "Unsafe cast to 'unknown'. Use a precise type or a type guard instead; a reviewed exception needs an inline eslint-disable."
+  }
+];
 
 export default tseslint.config(
   {
@@ -156,6 +168,15 @@ export default tseslint.config(
           ]
         }
       ],
+      'no-restricted-syntax': ['error', ...unsafeCastSelectors],
+    }
+  },
+  {
+    // Tests and testkit-js are exempt from the unsafe-cast gate — mocking and
+    // fixtures legitimately cast.
+    files: ['packages/*/src/test/**/*.ts', 'testkit-js/**/*.ts'],
+    rules: {
+      'no-restricted-syntax': 'off'
     }
   },
   {

--- a/packages/compact/src/fetch-compact.mts
+++ b/packages/compact/src/fetch-compact.mts
@@ -75,7 +75,7 @@ const fetchCompact = async (): Promise<void> => {
   console.log(`Trying to fetch release from: ${urlString}`);
   const release: Release = await fetch(urlString, { headers: authHeaders }).then((r) => {
     if (r.ok) {
-      return r.json() as unknown as Release;
+      return r.json() as Promise<Release>;
     } else {
       console.error(`Error downloading ${urlString} ${r.status} ${r.statusText}`);
       process.exit(r.status);
@@ -83,7 +83,7 @@ const fetchCompact = async (): Promise<void> => {
   });
 
   type Asset = { name: string; url: string }
-  const assets: Asset[] = await fetch(release.assets_url, { headers: authHeaders }).then((r) => r.json() as unknown as Asset[]);
+  const assets: Asset[] = await fetch(release.assets_url, { headers: authHeaders }).then((r) => r.json() as Promise<Asset[]>);
 
   const platformToAssetSuffix = (): string => {
     if (currentPlatform === 'darwin') {

--- a/packages/contracts/src/submit-call-tx.ts
+++ b/packages/contracts/src/submit-call-tx.ts
@@ -107,7 +107,7 @@ export async function submitCallTx<C extends Contract.Any, PCK extends Contract.
   assertDefined(
     ContractExecutable.make(options.compiledContract)
       .getProvableCircuitIds()
-      .find((circuitId) => circuitId as unknown as PCK === options.circuitId),
+      .find((circuitId) => circuitId as unknown as PCK === options.circuitId), // eslint-disable-line no-restricted-syntax
     `Circuit '${options.circuitId}' is undefined`
   );
 
@@ -211,7 +211,7 @@ export async function submitCallTxAsync<C extends Contract.Any, PCK extends Cont
   assertDefined(
     ContractExecutable.make(options.compiledContract)
       .getProvableCircuitIds()
-      .find((circuitId) => circuitId as unknown as PCK === options.circuitId),
+      .find((circuitId) => circuitId as unknown as PCK === options.circuitId), // eslint-disable-line no-restricted-syntax
     `Circuit '${options.circuitId}' is undefined`
   );
 

--- a/packages/contracts/src/unproven-call-tx.ts
+++ b/packages/contracts/src/unproven-call-tx.ts
@@ -92,7 +92,7 @@ export async function createUnprovenCallTxFromInitialStates<C extends Contract.A
   assertDefined(
     ContractExecutable.make(options.compiledContract)
       .getProvableCircuitIds()
-      .find((circuitId) => circuitId as unknown as PCK === options.circuitId),
+      .find((circuitId) => circuitId as unknown as PCK === options.circuitId), // eslint-disable-line no-restricted-syntax
     `Circuit '${options.circuitId}' is undefined`
   );
 
@@ -126,9 +126,9 @@ export async function createUnprovenCallTxFromInitialStates<C extends Contract.A
       : { ...baseCircuitContext, stateProvider: calleeResolver.stateProvider, parentBlockHash: calleeResolver.blockHash };
 
   const exitResult = await contractRuntime.runPromiseExit(contractExec.circuit(
-    ProvableCircuitId<C>(options.circuitId as any), // eslint-disable-line @typescript-eslint/no-explicit-any
+    ProvableCircuitId<C>(options.circuitId as any), // eslint-disable-line @typescript-eslint/no-explicit-any, no-restricted-syntax
     circuitContext,
-    ...args as any // eslint-disable-line @typescript-eslint/no-explicit-any
+    ...args as any // eslint-disable-line @typescript-eslint/no-explicit-any, no-restricted-syntax
   ));
 
   try {
@@ -157,7 +157,7 @@ export async function createUnprovenCallTxFromInitialStates<C extends Contract.A
       private: {
         input: rootCall.private.input,
         output: rootCall.private.output,
-        result: result as unknown as Contract.CircuitReturnType<C, PCK>,
+        result: result as unknown as Contract.CircuitReturnType<C, PCK>, // eslint-disable-line no-restricted-syntax
         nextPrivateState: privateState,
         nextZswapLocalState: zswapLocalState,
         privateTranscriptOutputs: rootCall.private.privateTranscriptOutputs,
@@ -381,7 +381,7 @@ export async function createUnprovenCallTx<C extends Contract.Any, PCK extends C
   assertDefined(
     ContractExecutable.make(options.compiledContract)
       .getProvableCircuitIds()
-      .find((a) => a as unknown as PCK === options.circuitId),
+      .find((a) => a as unknown as PCK === options.circuitId), // eslint-disable-line no-restricted-syntax
     `Circuit '${options.circuitId}' is undefined`
   );
 

--- a/packages/fetch-zk-config-provider/src/fetch-zk-config-provider.ts
+++ b/packages/fetch-zk-config-provider/src/fetch-zk-config-provider.ts
@@ -96,11 +96,11 @@ export class FetchZkConfigProvider<K extends string> extends ZKConfigProvider<K>
         `Expected ZK artifact, but received text/html from ${fullUrl}. This usually means the file does not exist and the server returned an SPA fallback page.`
       );
     }
-    /* eslint-disable @typescript-eslint/no-explicit-any */
+    /* eslint-disable @typescript-eslint/no-explicit-any, no-restricted-syntax */
     return responseType === 'text'
       ? ((await response.text()) as any)
       : ((await response.arrayBuffer().then((arrayBuffer) => new Uint8Array(arrayBuffer))) as any);
-    /* eslint-enable @typescript-eslint/no-explicit-any */
+    /* eslint-enable @typescript-eslint/no-explicit-any, no-restricted-syntax */
   }
 
   private loadManifest(): Promise<ZkArtifactManifest | undefined> {

--- a/packages/indexer-public-data-provider/src/deflate-websocket.ts
+++ b/packages/indexer-public-data-provider/src/deflate-websocket.ts
@@ -63,7 +63,7 @@ export const wrapWithDeflate = <T extends typeof ws.WebSocket>(
   // lets us INVOKE the inherited setter (which has per-instance side-effects) rather
   // than overwriting a prototype slot (which would pollute all instances).
   const inheritedOnmessage = Object.getOwnPropertyDescriptor(
-    (Base as unknown as typeof WebSocket).prototype,
+    (Base as unknown as typeof WebSocket).prototype, // eslint-disable-line no-restricted-syntax
     'onmessage'
   );
 
@@ -75,7 +75,7 @@ export const wrapWithDeflate = <T extends typeof ws.WebSocket>(
    * logic. If composition is needed, invoke `wrapWithDeflate` once on the
    * outermost base.
    */
-  return class DeflateWebSocket extends (Base as unknown as typeof WebSocket) {
+  return class DeflateWebSocket extends (Base as unknown as typeof WebSocket) { // eslint-disable-line no-restricted-syntax
     /** Serializes async inflate so binary frames cannot overtake later text frames. */
     private __deliveryQueue: Promise<void> = Promise.resolve();
     private __closed = false;


### PR DESCRIPTION
## Summary
- Adds an ESLint `no-restricted-syntax` gate banning new unsafe casts — `as any` / `as unknown` plus the angle-bracket forms `<any>x` / `<unknown>x` — in package sources; test files and `testkit-js` are exempt
- Pre-existing unsafe casts (12 sites in `contracts`, `fetch-zk-config-provider`, `indexer-public-data-provider`) carry inline `eslint-disable` directives, visible at the point of use
- `packages/compact/src/fetch-compact.mts` is fixed properly instead: `r.json()` asserted as `Promise<T>` with no `unknown` hop

Independent of the HF migration — targets `main` directly. Note for the #1004 integration branch: `feat/1004-protocol-dual-ledger` also defines `no-restricted-syntax` (protocol/v8 dynamic-import ban, #1155); whichever merges second must combine both selector lists in `eslint.config.mjs`.

## Test plan
- [x] Repo-wide `eslint ./packages ./testkit-js` clean (the gate itself is the enforcement; a new unsafe cast fails `yarn lint` in CI)
- [x] Protocol ACL ESLint tests pass (28/28), `compact` typecheck clean
- [x] No runtime behaviour change — config, inline directives and one type-level fix only

🤖 Generated with [Claude Code](https://claude.com/claude-code)