### PR TITLE
test(midnight-js): deflake tampered prover key integrity test

### DIFF
--- a/packages/fetch-zk-config-provider/src/test/fetch-zk-config-provider.test.ts
+++ b/packages/fetch-zk-config-provider/src/test/fetch-zk-config-provider.test.ts
@@ -266,9 +266,19 @@ describe('Fetch ZK config Provider', () => {
       const addr = tamperServer.address();
       const url = typeof addr === 'object' && addr ? `http://localhost:${addr.port}` : '';
       try {
-        await expect(new FetchZkConfigProvider(url).getProverKey('set_topic')).rejects.toThrow(ZkArtifactIntegrityError);
-        await expect(new FetchZkConfigProvider(url).getProverKey('set_topic')).rejects.toThrow(/keys\/set_topic\.prover/);
-        await expect(new FetchZkConfigProvider(url).getProverKey('set_topic')).rejects.toThrow(new RegExp(goodHash));
+        // Single fetch: three separate getProverKey calls each pull and hash the 7.3MB key,
+        // which exceeds the 5s test timeout on slow CI runners under coverage instrumentation.
+        const rejection = await new FetchZkConfigProvider(url).getProverKey('set_topic').then(
+          () => {
+            throw new Error('expected getProverKey to reject');
+          },
+          (error: unknown) => error
+        );
+        if (!(rejection instanceof ZkArtifactIntegrityError)) {
+          throw new Error(`expected ZkArtifactIntegrityError, got: ${String(rejection)}`);
+        }
+        expect(rejection.message).toMatch(/keys\/set_topic\.prover/);
+        expect(rejection.message).toMatch(new RegExp(goodHash));
       } finally {
         tamperServer.close();
       }


### PR DESCRIPTION
# Overview

The unit test `rejects a tampered prover key (digest mismatch) and names the path and digests` in `fetch-zk-config-provider` is flaky on slow CI runners (e.g. [run 32127150299](https://github.com/midnightntwrk/midnight-js/actions/runs/32127150299): `Test timed out in 5000ms`, actual 5093ms). It passes locally.

**Root cause:** the test made **three** sequential `getProverKey('set_topic')` calls to assert three properties of the same rejection. Each call fetches the 7.3MB prover key and hashes it with pure-JS SHA-256 (`@noble/hashes`) under v8 coverage instrumentation. On CI a single call takes ~1.7s (see neighbouring single-call tests in the same log), so 3 × ~1.7s ≈ 5.1s — just over the default 5s vitest timeout. Same mechanism as the node-zk-config-provider slowdown fixed in #1075.

**Fix:** fetch once, capture the rejection, and assert error type, artifact path, and expected digest on the same error. The test now does one fetch + hash (~330ms locally, ~1.7s expected on CI) with the same assertion coverage. No timeout bump — the root cause (3× redundant work) is removed.

## Test plan
- [x] `yarn test` in `packages/fetch-zk-config-provider`: 35/35 pass, coverage thresholds met (100/100/93.54/100)
- [x] `yarn lint` clean
- [x] `yarn build` succeeds

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README.md file (if relevant) — n/a
- [x] Update documentation (if relevant) — n/a
- [x] No new todos introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)