### PR TITLE
refactor(midnight-js): replace unsafe test casts with typed mock patterns

### DIFF
--- a/packages/contracts/src/test/deploy-contract.test.ts
+++ b/packages/contracts/src/test/deploy-contract.test.ts
@@ -17,11 +17,12 @@ import { type Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import { type ZswapLocalState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import { type UnprovenTransaction } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { AnyPrivateState } from '@midnight-ntwrk/midnight-js-types';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest';
 
 import { type ContractProviders } from '../contract-providers';
 import { deployContract, type DeployContractOptionsBase, type DeployedContract } from '../deploy-contract';
-import { type UnsubmittedDeployTxData } from '../tx-model';
+import type { submitDeployTx } from '../submit-deploy-tx';
+import { type FinalizedDeployTxData, type UnsubmittedDeployTxData } from '../tx-model';
 import {
   createMockCompiledContract,
   createMockContractState,
@@ -45,7 +46,13 @@ vi.mock('../governance/tx-interfaces', () => ({
 }));
 
 describe('deployContract', () => {
-  let mockSubmitDeployTx: ReturnType<typeof vi.fn>;
+  let mockSubmitDeployTx: MockedFunction<typeof submitDeployTx>;
+
+  // The tests resolve unsubmitted-level tx data where the real function
+  // returns finalized-level data; the code under test forwards the value
+  // opaquely, so the missing finalized fields are never read.
+  const asFinalized = (data: UnsubmittedDeployTxData<Contract.Any>): FinalizedDeployTxData<Contract.Any> =>
+    data as FinalizedDeployTxData<Contract.Any>;
   let mockDeployTxData: UnsubmittedDeployTxData<Contract.Any>;
   let providers: ContractProviders;
   let baseOptions: DeployContractOptionsBase<Contract.Any>;
@@ -75,8 +82,7 @@ describe('deployContract', () => {
 
   beforeEach(async () => {
     const { submitDeployTx } = await import('../submit-deploy-tx');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mockSubmitDeployTx = submitDeployTx as any;
+    mockSubmitDeployTx = vi.mocked(submitDeployTx);
     vi.clearAllMocks();
 
     providers = createMockProviders();
@@ -88,7 +94,7 @@ describe('deployContract', () => {
 
   it('should deploy contract without private state', async () => {
     mockDeployTxData = createMockDeployTxData();
-    mockSubmitDeployTx.mockResolvedValue(mockDeployTxData);
+    mockSubmitDeployTx.mockResolvedValue(asFinalized(mockDeployTxData));
 
     const result = await deployContract(providers, baseOptions);
 
@@ -105,7 +111,7 @@ describe('deployContract', () => {
 
   it('should deploy contract with provided signing key', async () => {
     mockDeployTxData = createMockDeployTxData();
-    mockSubmitDeployTx.mockResolvedValue(mockDeployTxData);
+    mockSubmitDeployTx.mockResolvedValue(asFinalized(mockDeployTxData));
 
     const signingKey = createMockSigningKey();
     const options = { ...baseOptions, signingKey };
@@ -126,7 +132,7 @@ describe('deployContract', () => {
   it('should deploy contract with private state', async () => {
     const initialPrivateState = { test: 'initial-private-state' };
     mockDeployTxData = createMockDeployTxData(initialPrivateState);
-    mockSubmitDeployTx.mockResolvedValue(mockDeployTxData);
+    mockSubmitDeployTx.mockResolvedValue(asFinalized(mockDeployTxData));
 
     const options = {
       ...baseOptions,
@@ -152,7 +158,7 @@ describe('deployContract', () => {
   it('should deploy contract with both custom signing key and private state', async () => {
     const initialPrivateState = { test: 'initial-private-state' };
     mockDeployTxData = createMockDeployTxData(initialPrivateState);
-    mockSubmitDeployTx.mockResolvedValue(mockDeployTxData);
+    mockSubmitDeployTx.mockResolvedValue(asFinalized(mockDeployTxData));
 
     const signingKey = createMockSigningKey();
     const options = {

--- a/packages/contracts/src/test/enc-pub-key-resolver.test.ts
+++ b/packages/contracts/src/test/enc-pub-key-resolver.test.ts
@@ -13,10 +13,9 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { getNetworkId, setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
-import { sampleCoinPublicKey, sampleEncryptionPublicKey } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import { type ZswapLocalState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import { sampleCoinPublicKey, sampleEncryptionPublicKey, type UnprovenTransaction } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { parseCoinPublicKeyToHex,parseEncPublicKeyToHex } from '@midnight-ntwrk/midnight-js-utils';
 
 import { deployContract } from '../deploy-contract';
@@ -39,7 +38,7 @@ vi.mock('../submit-call-tx', () => ({ submitCallTx: vi.fn() }));
 describe('EncryptionPublicKeyResolver with additional mappings', () => {
   it('deployContract forwards additionalCoinEncPublicKeyMappings to submitDeployTx', async () => {
     const { submitDeployTx } = await import('../submit-deploy-tx');
-    const mockSubmitDeployTx = submitDeployTx as unknown as ReturnType<typeof vi.fn>;
+    const mockSubmitDeployTx = vi.mocked(submitDeployTx, { partial: true });
     const providers = createMockProviders();
     const mappings = new Map([[createMockCoinPublicKey(), createMockEncryptionPublicKey()]]);
     const options = {
@@ -57,8 +56,8 @@ describe('EncryptionPublicKeyResolver with additional mappings', () => {
       private: {
         signingKey: createMockSigningKey(),
         initialPrivateState: undefined,
-        initialZswapState: {},
-        unprovenTx: {},
+        initialZswapState: {} as ZswapLocalState,
+        unprovenTx: {} as UnprovenTransaction,
         newCoins: []
       }
     };
@@ -74,7 +73,9 @@ describe('EncryptionPublicKeyResolver with additional mappings', () => {
 
   it('createCircuitCallTxInterface includes additional mappings from TransactionContext in call options', async () => {
     const { submitCallTx } = await import('../submit-call-tx');
-    vi.mocked(submitCallTx).mockResolvedValue({ public: {} as any, private: {} as any, calls: [] as any });
+    vi.mocked(submitCallTx).mockResolvedValue(
+      { public: {}, private: {}, calls: [] } as unknown as Awaited<ReturnType<typeof submitCallTx>>
+    );
 
     const providers = createMockProviders();
     const compiledContract = createMockCompiledContract();
@@ -85,7 +86,8 @@ describe('EncryptionPublicKeyResolver with additional mappings', () => {
     const { TransactionContextImpl } = await import('../internal/transaction');
 
     const txCtx = new TransactionContextImpl(providers, { additionalCoinEncPublicKeyMappings: mappings });
-    await (callInterface.testCircuit as unknown as (txCtx?: any, ...args: any[]) => Promise<any>)(txCtx, 'arg1');
+    const testCircuit = callInterface.testCircuit as unknown as (txCtx: unknown, ...args: unknown[]) => Promise<unknown>;
+    await testCircuit(txCtx, 'arg1');
 
     expect(submitCallTx).toHaveBeenCalledWith(
       providers,
@@ -110,7 +112,7 @@ describe('EncryptionPublicKeyResolver with additional mappings', () => {
 
     expect(resolver(queryKeyHex)).toBe(expected);
 
-    const zswapState = { coinPublicKey: walletCpk } as any;
+    const zswapState = { coinPublicKey: walletCpk } as unknown as ZswapLocalState;
     const resolver2 = encryptionPublicKeyResolverForZswapState(zswapState, walletCpk, walletEpk, mappings);
     expect(resolver2(queryKeyHex)).toBe(expected);
   });

--- a/packages/contracts/src/test/find-deployed-contract.test.ts
+++ b/packages/contracts/src/test/find-deployed-contract.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { type Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import type * as midnightJsTypes from '@midnight-ntwrk/midnight-js-types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { findDeployedContract, type FoundContract } from '../find-deployed-contract';
@@ -38,8 +39,7 @@ vi.mock('../governance/tx-interfaces', () => ({
 }));
 
 vi.mock('@midnight-ntwrk/midnight-js-types', async (importOriginal) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const actual = await importOriginal() as any;
+  const actual = await importOriginal<typeof midnightJsTypes>();
   return {
     ...actual,
     getProvableCircuitIds: vi.fn().mockReturnValue(['testCircuit'])

--- a/packages/contracts/src/test/get-unshielded-balances.test.ts
+++ b/packages/contracts/src/test/get-unshielded-balances.test.ts
@@ -22,6 +22,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { getUnshieldedBalances } from '../get-unshielded-balances';
 
 describe('getUnshieldedBalances', () => {
+  const providerWith = (queryUnshieldedBalances: PublicDataProvider['queryUnshieldedBalances']): PublicDataProvider =>
+    ({ queryUnshieldedBalances }) as PublicDataProvider;
+
   const mockContractAddress = sampleContractAddress();
   const mockUnshieldedBalances: UnshieldedBalances = [
     {
@@ -35,9 +38,7 @@ describe('getUnshieldedBalances', () => {
   ];
 
   it('should return unshielded balances when data exists', async () => {
-    const mockPublicDataProvider: PublicDataProvider = {
-      queryUnshieldedBalances: vi.fn().mockResolvedValue(mockUnshieldedBalances)
-    } as unknown as PublicDataProvider;
+    const mockPublicDataProvider = providerWith(vi.fn().mockResolvedValue(mockUnshieldedBalances));
 
     const result = await getUnshieldedBalances(mockPublicDataProvider, mockContractAddress);
 
@@ -46,9 +47,7 @@ describe('getUnshieldedBalances', () => {
   });
 
   it('should throw error when no unshielded balances found', async () => {
-    const mockPublicDataProvider: PublicDataProvider = {
-      queryUnshieldedBalances: vi.fn().mockResolvedValue(null)
-    } as unknown as PublicDataProvider;
+    const mockPublicDataProvider = providerWith(vi.fn().mockResolvedValue(null));
 
     await expect(getUnshieldedBalances(mockPublicDataProvider, mockContractAddress))
       .rejects
@@ -58,9 +57,7 @@ describe('getUnshieldedBalances', () => {
   });
 
   it('should validate contract address', async () => {
-    const mockPublicDataProvider: PublicDataProvider = {
-      queryUnshieldedBalances: vi.fn()
-    } as unknown as PublicDataProvider;
+    const mockPublicDataProvider = providerWith(vi.fn());
 
     const invalidAddress = 'invalid-address' as ContractAddress;
 
@@ -72,9 +69,7 @@ describe('getUnshieldedBalances', () => {
   });
 
   it('should return empty array when balances exist but are empty', async () => {
-    const mockPublicDataProvider: PublicDataProvider = {
-      queryUnshieldedBalances: vi.fn().mockResolvedValue([])
-    } as unknown as PublicDataProvider;
+    const mockPublicDataProvider = providerWith(vi.fn().mockResolvedValue([]));
 
     const result = await getUnshieldedBalances(mockPublicDataProvider, mockContractAddress);
 

--- a/packages/contracts/src/test/submit-call-tx.test.ts
+++ b/packages/contracts/src/test/submit-call-tx.test.ts
@@ -254,9 +254,7 @@ describe('submit-call-tx', () => {
 
     describe('configuration validation', () => {
       it('should throw IncompleteCallTxPrivateStateConfig when privateStateId provided without privateStateProvider', async () => {
-        const providersWithoutPrivateState = { ...mockProviders };
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        delete (providersWithoutPrivateState as any).privateStateProvider;
+        const { privateStateProvider: _omitted, ...providersWithoutPrivateState } = mockProviders;
         const options = createBasicCallOptions({ privateStateId: mockPrivateStateId });
 
         await expect(submitCallTx(providersWithoutPrivateState, options)).rejects.toThrow(
@@ -557,9 +555,7 @@ describe('submit-call-tx', () => {
 
     describe('configuration validation', () => {
       it('should throw IncompleteCallTxPrivateStateConfig when privateStateId provided without privateStateProvider', async () => {
-        const providersWithoutPrivateState = { ...mockProviders };
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        delete (providersWithoutPrivateState as any).privateStateProvider;
+        const { privateStateProvider: _omitted, ...providersWithoutPrivateState } = mockProviders;
         const options = createBasicCallOptions({ privateStateId: mockPrivateStateId });
 
         await expect(submitCallTxAsync(providersWithoutPrivateState, options)).rejects.toThrow(

--- a/packages/contracts/src/test/unproven-call-tx.test.ts
+++ b/packages/contracts/src/test/unproven-call-tx.test.ts
@@ -15,7 +15,7 @@
 
 import { setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 import { type ContractState, StateValue } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
-import { LedgerParameters } from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import { LedgerParameters, type ZswapChainState } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { createUnprovenCallTx, createUnprovenCallTxFromInitialStates } from '../unproven-call-tx';
@@ -171,11 +171,10 @@ describe('unproven-call-tx', () => {
 
     it('should create unproven call tx without private state provider', async () => {
       const { getPublicStates } = await import('../get-states');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const mockGetPublicStates = getPublicStates as any;
+      const mockGetPublicStates = vi.mocked(getPublicStates, { partial: true });
 
       mockGetPublicStates.mockResolvedValue({
-        zswapChainState: { test: 'zswap-chain-state' },
+        zswapChainState: { test: 'zswap-chain-state' } as unknown as ZswapChainState,
         contractState: await getInitialContractState(),
         ledgerParameters: LedgerParameters.initialParameters()
       });
@@ -206,11 +205,10 @@ describe('unproven-call-tx', () => {
 
     it('should create unproven call tx with private state provider', async () => {
       const { getStates } = await import('../get-states');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const mockGetStates = getStates as any;
+      const mockGetStates = vi.mocked(getStates, { partial: true });
 
       mockGetStates.mockResolvedValue({
-        zswapChainState: { test: 'zswap-chain-state' },
+        zswapChainState: { test: 'zswap-chain-state' } as unknown as ZswapChainState,
         contractState: await getInitialContractState(),
         privateState: { test: 'private-state' },
         ledgerParameters: LedgerParameters.initialParameters()

--- a/packages/contracts/src/test/utils/contract-state-provider.test.ts
+++ b/packages/contracts/src/test/utils/contract-state-provider.test.ts
@@ -13,7 +13,8 @@
  * limitations under the License.
  */
 
-import type { ContractAddress, ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import type { ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import { sampleContractAddress } from '@midnight-ntwrk/midnight-js-protocol/ledger';
 import type { PublicDataProvider } from '@midnight-ntwrk/midnight-js-types';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -21,13 +22,17 @@ import { makeCalleeStateResolver } from '../../utils';
 
 const BLOCK_HASH = 'ab'.repeat(32);
 const OTHER_BLOCK_HASH = 'cd'.repeat(32);
-const ADDRESS = 'a'.repeat(64) as unknown as ContractAddress;
-const OTHER_ADDRESS = 'b'.repeat(64) as unknown as ContractAddress;
-const STATE = { tag: 'callee-state' } as unknown as ContractState;
+const ADDRESS = sampleContractAddress();
+const OTHER_ADDRESS = sampleContractAddress();
+
+/** Identity sentinel standing in for the opaque WASM `ContractState`. */
+const fakeState = (tag: string): ContractState => ({ tag }) as unknown as ContractState;
+
+const STATE = fakeState('callee-state');
 
 /** A `PublicDataProvider` whose only exercised method is `queryContractState`. */
 const providerWith = (queryContractState: PublicDataProvider['queryContractState']): PublicDataProvider =>
-  ({ queryContractState } as unknown as PublicDataProvider);
+  ({ queryContractState } as PublicDataProvider);
 
 describe('makeCalleeStateResolver', () => {
   it('exposes the pinned block hash and an initially empty resolved-states map', () => {
@@ -67,7 +72,7 @@ describe('makeCalleeStateResolver', () => {
     const queryContractState = vi
       .fn()
       .mockResolvedValueOnce(STATE)
-      .mockResolvedValueOnce({ tag: 'other-state' } as unknown as ContractState);
+      .mockResolvedValueOnce(fakeState('other-state'));
     const resolver = makeCalleeStateResolver(providerWith(queryContractState), BLOCK_HASH);
 
     await resolver.stateProvider.getContractState(BLOCK_HASH, ADDRESS);

--- a/packages/dapp-connector-proof-provider/src/test/dapp-connector-proof-provider.test.ts
+++ b/packages/dapp-connector-proof-provider/src/test/dapp-connector-proof-provider.test.ts
@@ -46,9 +46,10 @@ describe('dappConnectorProofProvider', () => {
       getProvingProvider: vi.fn().mockResolvedValue(mockProvingProvider)
     };
 
-    mockZkConfigProvider = {
+    const zkConfigProviderOverrides: Partial<ZKConfigProvider<string>> = {
       asKeyMaterialProvider: vi.fn().mockReturnValue(mockKeyMaterialProvider)
-    } as unknown as ZKConfigProvider<string>;
+    };
+    mockZkConfigProvider = zkConfigProviderOverrides as ZKConfigProvider<string>;
 
     mockUnprovenTx = {
       prove: vi.fn().mockResolvedValue(mockUnboundTx)

--- a/packages/http-client-proof-provider/src/test/http-client-proving-provider.test.ts
+++ b/packages/http-client-proof-provider/src/test/http-client-proving-provider.test.ts
@@ -52,6 +52,14 @@ vi.mock('@midnight-ntwrk/midnight-js-protocol/ledger', async () => {
   };
 });
 
+/**
+ * Partial stub of the abstract provider: only the methods a test exercises are
+ * supplied, and a typo in a member name fails typechecking against
+ * `Partial<ZKConfigProvider<string>>`.
+ */
+const zkConfigProviderWith = (overrides: Partial<ZKConfigProvider<string>>): ZKConfigProvider<string> =>
+  overrides as ZKConfigProvider<string>;
+
 describe('httpClientProvingProvider', () => {
   const mockUrl = 'http://localhost:8080';
   const mockZkConfig : ZKConfig<string> = {
@@ -69,9 +77,9 @@ describe('httpClientProvingProvider', () => {
     vi.mocked(ledger.createProvingPayload).mockReset();
     vi.mocked(ledger.parseCheckResult).mockReset();
 
-    mockZkConfigProvider = {
+    mockZkConfigProvider = zkConfigProviderWith({
       get: vi.fn().mockResolvedValue(mockZkConfig)
-    } as unknown as ZKConfigProvider<string>;
+    });
 
     mockFetchRetry.mockResolvedValue({
       ok: true,
@@ -549,11 +557,11 @@ describe('httpClientProvingProvider', () => {
     const contractAddress = 'aa'.repeat(32);
 
     const registrySource = (): ZKConfigProvider<string> =>
-      ({
+      zkConfigProviderWith({
         getVerifierKey: vi.fn().mockResolvedValue(verifierKey),
         getProverKey: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
         getZKIR: vi.fn().mockResolvedValue(new Uint8Array([7, 8, 9]))
-      }) as unknown as ZKConfigProvider<string>;
+      });
 
     const locationFor = (vk: Uint8Array): string =>
       encodeContractKeyLocation({ contractAddress, circuitId: 'transfer', verifierKeyHash: hashVerifierKey(vk) });

--- a/packages/indexer-public-data-provider/src/test/deflate-websocket.test.ts
+++ b/packages/indexer-public-data-provider/src/test/deflate-websocket.test.ts
@@ -20,6 +20,15 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { DEFLATE_PROTOCOL, wrapWithDeflate } from '../deflate-websocket';
 
+/**
+ * The DOM-lib and `ws`-package WebSocket types don't structurally unify (the
+ * wrapper source performs the same adaptation); tests exercise the wrapper
+ * against minimal EventTarget-based fakes, adapted to the expected
+ * constructor type in this one place.
+ */
+const asWsCtor = (ctor: new (url: string, protocols?: string | string[]) => EventTarget): typeof ws.WebSocket =>
+  ctor as unknown as typeof ws.WebSocket;
+
 describe('wrapWithDeflate — subprotocol negotiation', () => {
   test('offers only the deflate protocol when no protocols argument is passed', () => {
     const baseCtor = vi.fn();
@@ -29,7 +38,7 @@ describe('wrapWithDeflate — subprotocol negotiation', () => {
         baseCtor(url, protocols);
       }
     }
-    const Wrapped = wrapWithDeflate(BaseWS as unknown as typeof ws.WebSocket);
+    const Wrapped = wrapWithDeflate(asWsCtor(BaseWS));
 
     new Wrapped('ws://localhost/graphql/ws');
 
@@ -47,7 +56,7 @@ describe('wrapWithDeflate — subprotocol negotiation', () => {
         baseCtor(url, protocols);
       }
     }
-    const Wrapped = wrapWithDeflate(BaseWS as unknown as typeof ws.WebSocket);
+    const Wrapped = wrapWithDeflate(asWsCtor(BaseWS));
 
     new Wrapped('ws://localhost/graphql/ws', 'graphql-transport-ws');
 
@@ -65,7 +74,7 @@ describe('wrapWithDeflate — subprotocol negotiation', () => {
         baseCtor(url, protocols);
       }
     }
-    const Wrapped = wrapWithDeflate(BaseWS as unknown as typeof ws.WebSocket);
+    const Wrapped = wrapWithDeflate(asWsCtor(BaseWS));
 
     new Wrapped('ws://localhost/graphql/ws', ['graphql-transport-ws', 'graphql-ws']);
 
@@ -83,7 +92,7 @@ describe('wrapWithDeflate — subprotocol negotiation', () => {
         baseCtor(url, protocols);
       }
     }
-    const Wrapped = wrapWithDeflate(BaseWS as unknown as typeof ws.WebSocket);
+    const Wrapped = wrapWithDeflate(asWsCtor(BaseWS));
 
     new Wrapped('ws://localhost/graphql/ws', [DEFLATE_PROTOCOL, 'graphql-transport-ws']);
 
@@ -146,12 +155,16 @@ describe('wrapWithDeflate — message delivery', () => {
   let Wrapped: typeof ws.WebSocket;
 
   beforeEach(() => {
-    Wrapped = wrapWithDeflate(FakeWS as unknown as typeof ws.WebSocket);
+    Wrapped = wrapWithDeflate(asWsCtor(FakeWS));
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
+
+  // Wrapped subclasses FakeWS at runtime; the wrapper's return type can't
+  // carry that, so instances are re-viewed as the fake in this one place.
+  const newFake = (url = 'ws://x'): FakeWS => new Wrapped(url, 'graphql-transport-ws') as unknown as FakeWS;
 
   // Awaits the wrapper's internal delivery queue to flush all pending async inflate work.
   // The cast is intentional: __deliveryQueue is a private implementation detail accessed
@@ -163,7 +176,7 @@ describe('wrapWithDeflate — message delivery', () => {
   };
 
   test('inflates binary frames when the +deflate protocol was negotiated (addEventListener path)', async () => {
-    const sock = new Wrapped('ws://x', 'graphql-transport-ws') as unknown as FakeWS;
+    const sock = newFake();
     sock.protocol = DEFLATE_PROTOCOL;
     const seen: unknown[] = [];
     sock.addEventListener('message', (ev) => seen.push((ev as MessageEvent).data));
@@ -177,7 +190,7 @@ describe('wrapWithDeflate — message delivery', () => {
   });
 
   test('inflates binary frames via the onmessage setter path', async () => {
-    const sock = new Wrapped('ws://x', 'graphql-transport-ws') as unknown as FakeWS;
+    const sock = newFake();
     sock.protocol = DEFLATE_PROTOCOL;
     const seen: unknown[] = [];
     sock.onmessage = (ev) => seen.push(ev.data);
@@ -191,7 +204,7 @@ describe('wrapWithDeflate — message delivery', () => {
   });
 
   test('passes text frames through unchanged (server skipped compression on <256 B)', async () => {
-    const sock = new Wrapped('ws://x', 'graphql-transport-ws') as unknown as FakeWS;
+    const sock = newFake();
     sock.protocol = DEFLATE_PROTOCOL;
     const seen: unknown[] = [];
     sock.addEventListener('message', (ev) => seen.push((ev as MessageEvent).data));
@@ -203,7 +216,7 @@ describe('wrapWithDeflate — message delivery', () => {
   });
 
   test('preserves delivery order when text and binary frames interleave', async () => {
-    const sock = new Wrapped('ws://x', 'graphql-transport-ws') as unknown as FakeWS;
+    const sock = newFake();
     sock.protocol = DEFLATE_PROTOCOL;
     const seen: string[] = [];
     sock.addEventListener('message', (ev) => seen.push(String((ev as MessageEvent).data)));
@@ -219,7 +232,7 @@ describe('wrapWithDeflate — message delivery', () => {
   });
 
   test('does NOT inflate when server fell back to plain graphql-transport-ws (fallback path)', async () => {
-    const sock = new Wrapped('ws://x', 'graphql-transport-ws') as unknown as FakeWS;
+    const sock = newFake();
     sock.protocol = 'graphql-transport-ws';
     const seen: unknown[] = [];
     sock.addEventListener('message', (ev) => seen.push((ev as MessageEvent).data));
@@ -233,7 +246,7 @@ describe('wrapWithDeflate — message delivery', () => {
   });
 
   test('sets binaryType to arraybuffer (so we never receive a Blob in the browser)', () => {
-    const sock = new Wrapped('ws://x', 'graphql-transport-ws') as unknown as FakeWS;
+    const sock = newFake();
 
     expect(sock.binaryType).toBe('arraybuffer');
   });
@@ -241,7 +254,7 @@ describe('wrapWithDeflate — message delivery', () => {
   test('normalizes Node Buffer / Uint8Array binary payloads to ArrayBuffer before inflating', async () => {
     // The Node `ws` package may deliver binary frames as Buffer (a Uint8Array subclass)
     // regardless of binaryType — the wrapper must handle that, not just ArrayBuffer.
-    const sock = new Wrapped('ws://x', 'graphql-transport-ws') as unknown as FakeWS;
+    const sock = newFake();
     sock.protocol = DEFLATE_PROTOCOL;
     const seen: unknown[] = [];
     sock.addEventListener('message', (ev) => seen.push((ev as MessageEvent).data));
@@ -256,7 +269,7 @@ describe('wrapWithDeflate — message delivery', () => {
   });
 
   test('drops a frame whose inflate throws and continues delivering subsequent frames (queue not poisoned, no unhandled rejection)', async () => {
-    const sock = new Wrapped('ws://x', 'graphql-transport-ws') as unknown as FakeWS;
+    const sock = newFake();
     sock.protocol = DEFLATE_PROTOCOL;
     const seen: unknown[] = [];
     sock.addEventListener('message', (ev) => seen.push((ev as MessageEvent).data));
@@ -279,7 +292,7 @@ describe('wrapWithDeflate — message delivery', () => {
   });
 
   test('drops queued frames delivered after the socket has closed (no unhandled rejection)', async () => {
-    const sock = new Wrapped('ws://x', 'graphql-transport-ws') as unknown as FakeWS;
+    const sock = newFake();
     sock.protocol = DEFLATE_PROTOCOL;
     const seen: unknown[] = [];
     sock.addEventListener('message', (ev) => seen.push((ev as MessageEvent).data));
@@ -300,7 +313,7 @@ describe('wrapWithDeflate — message delivery', () => {
   });
 
   test('routes binary frames through EventListenerObject.handleEvent with correct `this` binding', async () => {
-    const sock = new Wrapped('ws://x', 'graphql-transport-ws') as unknown as FakeWS;
+    const sock = newFake();
     sock.protocol = DEFLATE_PROTOCOL;
     const seen: unknown[] = [];
     // Use a spy so vitest records the call's `this` context via `.mock.instances`.
@@ -323,7 +336,7 @@ describe('wrapWithDeflate — message delivery', () => {
   });
 
   test('clears the installed onmessage when set to null', () => {
-    const sock = new Wrapped('ws://x', 'graphql-transport-ws') as unknown as FakeWS;
+    const sock = newFake();
     sock.onmessage = () => { /* placeholder */ };
     expect(sock.onmessage).not.toBeNull();
 
@@ -333,8 +346,8 @@ describe('wrapWithDeflate — message delivery', () => {
   });
 
   test('isolates onmessage handlers across multiple wrapped instances (no prototype pollution)', async () => {
-    const sock1 = new Wrapped('ws://x/1', 'graphql-transport-ws') as unknown as FakeWS;
-    const sock2 = new Wrapped('ws://x/2', 'graphql-transport-ws') as unknown as FakeWS;
+    const sock1 = newFake('ws://x/1');
+    const sock2 = newFake('ws://x/2');
     sock1.protocol = DEFLATE_PROTOCOL;
     sock2.protocol = DEFLATE_PROTOCOL;
 


### PR DESCRIPTION
## Summary
Follow-up to #1158/#1161: package tests were exempt from the unsafe-cast gate and held 84 `as unknown as X` / `as any` sites. This PR removes or centralizes the fixable ones — **84 → 53**, with no runtime behaviour change (test code only):

- **`vi.mocked()` replaces untyped mock handles** (`fn as any`, `as unknown as ReturnType<typeof vi.fn>`) in `deploy-contract`, `enc-pub-key-resolver`, `unproven-call-tx` — mock functions are now typed against the real signatures
- **Typed `importOriginal<typeof midnightJsTypes>()`** replaces an `as any` module passthrough in `find-deployed-contract`
- **Destructuring omit** replaces `delete (providers as any).privateStateProvider` — no cast at all
- **`Partial<T>`-based stubs** replace `as unknown as` interface/class casts for provider mocks (`get-unshielded-balances`, `http-client-proving-provider`, `dapp-connector`, `contract-state-provider`) — member-name typos now fail typechecking, and the remaining widening is a safe single-step `as`
- **`sampleContractAddress()`** replaces hex-string brand casts
- **`deflate-websocket.test.ts`: 20 inline casts collapse into 2 documented helpers** (`asWsCtor`, `newFake`) — the DOM-lib vs `ws`-package type split is genuinely uncastable and now adapted in one place
- Found & surfaced a type-level lie the old `as any` hid: `deploy-contract` mocks resolve *unsubmitted*-level tx data where `submitDeployTx` returns *finalized*-level data; now explicit in one `asFinalized()` helper with a comment

**Deliberately untouched (~30 sites):** negative tests where the cast *is* the mechanism — smuggling malformed input past the compiler to exercise runtime validation (`level-private-state-provider` import/export guards, circuit-id path-traversal checks in the ZK config providers, malformed GraphQL nodes) — plus reflection helpers over private fields and opaque WASM-class sentinels already centralized one-per-helper.

## Test plan
- [x] All existing tests pass (no regressions): `yarn test` — 27/27 tasks; per-package runs green (contracts 224, http-client 46, dapp-connector 14, deflate 16)
- [x] `tsc --noEmit` clean on all touched packages (vitest alone doesn't typecheck — esbuild strips types)
- [x] Lint clean: `eslint ./packages ./testkit-js` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)