### PR TITLE
fix(midnight-js): serialize LevelDB access in private state provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ logs
 .DS_Store
 
 midnight-concurrent-test-db
+test-concurrency-db
 .claude
 .worktrees
 .gitnexus

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -131,6 +131,12 @@ export type DatabaseLevel = AbstractLevel<string | Buffer | Uint8Array, string, 
 
 export type LevelFactory = (dbName: string) => DatabaseLevel;
 
+/**
+ * A store as this provider uses it: string keys, string values. Keys that are
+ * branded strings, such as `ContractAddress`, widen to `string` on the way in.
+ */
+type StringSubLevel = AbstractSublevel<DatabaseLevel, string | Uint8Array | Buffer, string, string>;
+
 interface StorageContext {
   readonly dbName: string;
   readonly createLevel: LevelFactory;
@@ -186,6 +192,37 @@ const defaultLevelFactory: LevelFactory = (dbName: string) =>
 const dbAccessQueues = new Map<string, Promise<void>>();
 
 /**
+ * How long one queued operation may run before it is abandoned.
+ *
+ * Without a bound, a single operation that never settles - a `levelFactory`
+ * whose `open()` hangs, a stalled iterator - would wedge every later operation
+ * on that database for the lifetime of the process, with no error to diagnose.
+ */
+const DB_OPERATION_TIMEOUT_MS = 300000; // 5 minutes
+
+const withOperationTimeout = async <A>(dbName: string, operation: () => Promise<A>): Promise<A> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation(),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new Error(
+              `Timed out after ${DB_OPERATION_TIMEOUT_MS}ms operating on private state database "${dbName}". ` +
+              `The database handle appears stuck. Operations queued behind it have been released, so the ` +
+              `next one may fail to open until that handle is released.`
+            )
+          );
+        }, DB_OPERATION_TIMEOUT_MS);
+      })
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
  * Serializes access to one database, so that overlapping callers queue instead
  * of colliding.
  *
@@ -196,6 +233,13 @@ const dbAccessQueues = new Map<string, Promise<void>>();
  * path (`browser-level`, IndexedDB) takes no such lock, but serializing there
  * is still what makes a read-modify-write sequence deterministic. The cost is
  * that throughput is one operation per database at a time.
+ *
+ * The queue slot is claimed synchronously, before this function's first `await`.
+ * That is what makes queue order equal call order, so `set(k, v)` followed by
+ * `remove(k)` applies in that order even when neither is awaited. Callers must
+ * therefore reach this function without awaiting anything first - work that
+ * needs the database, such as resolving an encryption key from the stored salt,
+ * belongs inside `operation`, which runs on the already-open handle.
  *
  * The map is module-level because the resource it guards is process-wide: a
  * per-provider map could not see a second provider opening the same database.
@@ -208,12 +252,13 @@ const dbAccessQueues = new Map<string, Promise<void>>();
  * at all - it still contends on the operating system lock.
  *
  * Not reentrant: entering the lock for a database that already holds it
- * deadlocks, and there is no timeout to break it. Callers must therefore
- * resolve encryption keys, which read the database themselves, before entering.
+ * deadlocks. Each operation is bounded by {@link DB_OPERATION_TIMEOUT_MS}, so a
+ * stuck operation surfaces as an error instead of hanging the queue forever.
  */
 const withDbLock = async <A>(dbName: string, operation: () => Promise<A>): Promise<A> => {
+  const bounded = (): Promise<A> => withOperationTimeout(dbName, operation);
   const pending = dbAccessQueues.get(dbName);
-  const current = pending === undefined ? operation() : pending.then(operation);
+  const current = pending === undefined ? bounded() : pending.then(bounded);
   // The stored tail must never reject, because a rejected tail would reject
   // every operation chained behind it. The caller still receives the real
   // outcome through `current`.
@@ -269,14 +314,14 @@ const closeDatabase = async (
   }
 };
 
-const withSubLevel = <K, V, A>(
+const withSubLevel = <A>(
   ctx: StorageContext,
   levelName: string,
-  thunk: (subLevel: AbstractSublevel<DatabaseLevel, string | Uint8Array | Buffer, K, V>) => Promise<A>,
+  thunk: (subLevel: StringSubLevel) => Promise<A>,
 ): Promise<A> =>
   withDbLock(ctx.dbName, async () => {
     const level = await openDatabase(ctx);
-    const subLevel = level.sublevel<K, V>(levelName, {
+    const subLevel = level.sublevel<string, string>(levelName, {
       valueEncoding: 'utf-8'
     });
 
@@ -285,10 +330,19 @@ const withSubLevel = <K, V, A>(
       await subLevel.open();
       result = await thunk(subLevel);
     } catch (error: unknown) {
-      try {
-        await closeDatabase(subLevel, level);
-      } catch {
-        // Don't mask the error from the operation - that is the one worth reporting.
+      const closeError = await closeDatabase(subLevel, level).then(
+        () => undefined,
+        (failure: unknown) => failure
+      );
+      if (closeError !== undefined) {
+        // Both failures matter: the operation error explains what the caller asked for,
+        // and the close error means the handle still holds the database.
+        throw new AggregateError(
+          [error, closeError],
+          `Operation on private state database "${ctx.dbName}" failed, and the database handle ` +
+          `could not be closed afterwards. The database stays locked for the rest of this process.`,
+          { cause: error }
+        );
       }
       throw error;
     }
@@ -302,8 +356,6 @@ const withSubLevel = <K, V, A>(
 const METADATA_KEY = '__midnight_encryption_metadata__';
 
 const DEFAULT_MAX_ROTATION_ENTRIES = 10000;
-
-const encryptionInitPromises = new Map<string, Promise<Buffer>>();
 
 const passwordRotationLocks = new Map<string, Promise<void>>();
 
@@ -330,52 +382,50 @@ interface EncryptionCacheEntry {
  */
 const encryptionCache = new Map<string, EncryptionCacheEntry>();
 
-const getOrCreateSalt = async (ctx: StorageContext, levelName: string): Promise<Buffer> => {
-  const lockKey = `${ctx.dbName}:${levelName}`;
-
-  const existingPromise = encryptionInitPromises.get(lockKey);
-  if (existingPromise) {
-    return existingPromise;
-  }
-
-  const initPromise = withSubLevel<string, string, Buffer>(ctx, levelName, async (subLevel) => {
-    try {
-      const metadataJson = await subLevel.get(METADATA_KEY);
-      if (metadataJson) {
-        const metadata = JSON.parse(metadataJson);
-        return Buffer.from(metadata.salt, 'hex');
-      }
-    } catch (error: unknown) {
-      if (!(error && typeof error === 'object' && 'code' in error && error.code === 'LEVEL_NOT_FOUND')) {
-        throw error;
-      }
-    }
-
-    const salt = Buffer.from(randomBytes(32));
-    const metadata = {
-      salt: salt.toString('hex'),
-      version: 1
-    };
-    await subLevel.put(METADATA_KEY, JSON.stringify(metadata));
-    return salt;
-  });
-
-  encryptionInitPromises.set(lockKey, initPromise);
-
+/**
+ * Reads the stored salt, creating and persisting one when the store has none.
+ *
+ * Takes an already-open sublevel rather than a {@link StorageContext}, so that
+ * it runs on the handle its caller has open instead of queueing a second
+ * open/close cycle of its own. That is what lets a caller claim its queue slot
+ * before doing any database work - see {@link withDbLock}.
+ */
+const readOrCreateSalt = async (subLevel: StringSubLevel): Promise<Buffer> => {
   try {
-    return await initPromise;
-  } finally {
-    encryptionInitPromises.delete(lockKey);
+    const metadataJson = await subLevel.get(METADATA_KEY);
+    if (metadataJson) {
+      const metadata = JSON.parse(metadataJson);
+      return Buffer.from(metadata.salt, 'hex');
+    }
+  } catch (error: unknown) {
+    if (!(error && typeof error === 'object' && 'code' in error && error.code === 'LEVEL_NOT_FOUND')) {
+      throw error;
+    }
   }
+
+  const salt = Buffer.from(randomBytes(32));
+  const metadata = {
+    salt: salt.toString('hex'),
+    version: 1
+  };
+  await subLevel.put(METADATA_KEY, JSON.stringify(metadata));
+  return salt;
 };
 
-const getOrCreateEncryption = async (
-  ctx: StorageContext,
-  levelName: string,
+/**
+ * Resolves the encryption for a store from the salt it currently holds.
+ *
+ * Runs inside the caller's database lock, so the salt it reads cannot change
+ * between here and the write that uses the resulting key. That is what keeps a
+ * password rotation from landing between the two.
+ */
+const resolveEncryption = async (
+  subLevel: StringSubLevel,
+  cacheKey: string,
   passwordProvider: PrivateStoragePasswordProvider,
+  cryptoBackend?: CryptoBackendType,
 ): Promise<StorageEncryption> => {
-  const cacheKey = `${ctx.dbName}:${levelName}`;
-  const salt = await getOrCreateSalt(ctx, levelName);
+  const salt = await readOrCreateSalt(subLevel);
   const saltHex = salt.toString('hex');
 
   const cached = encryptionCache.get(cacheKey);
@@ -384,13 +434,13 @@ const getOrCreateEncryption = async (
     if (await cached.encryption.verifyPassword(password)) {
       return cached.encryption;
     }
-    const encryption = await StorageEncryption.create(password, { existingSalt: salt, cryptoBackend: ctx.cryptoBackend });
+    const encryption = await StorageEncryption.create(password, { existingSalt: salt, cryptoBackend });
     encryptionCache.set(cacheKey, { encryption, saltHex });
     return encryption;
   }
 
   const password = await getPasswordFromProvider(passwordProvider);
-  const encryption = await StorageEncryption.create(password, { existingSalt: salt, cryptoBackend: ctx.cryptoBackend });
+  const encryption = await StorageEncryption.create(password, { existingSalt: salt, cryptoBackend });
   encryptionCache.set(cacheKey, { encryption, saltHex });
   return encryption;
 };
@@ -435,25 +485,6 @@ const withPasswordRotationLock = async <T>(
   }
 };
 
-const waitForRotationLock = async (
-  dbName: string,
-  levelName: string,
-  timeoutMs: number = DEFAULT_LOCK_TIMEOUT_MS
-): Promise<void> => {
-  const lockKey = `${dbName}:${levelName}`;
-  const startWait = Date.now();
-
-  while (passwordRotationLocks.has(lockKey)) {
-    if (Date.now() - startWait > timeoutMs) {
-      throw new Error(
-        `Timed out waiting for password rotation to complete on "${lockKey}". ` +
-          `The rotation may be stuck or taking longer than ${timeoutMs}ms.`
-      );
-    }
-    await passwordRotationLocks.get(lockKey);
-  }
-};
-
 interface RotateStorePasswordParams {
   readonly ctx: StorageContext;
   readonly storeName: string;
@@ -486,18 +517,20 @@ const rotateStorePassword = async (
 ): Promise<PasswordRotationResult> => {
   const { ctx, storeName, oldPasswordProvider, newPasswordProvider, maxEntries, shouldProceed } = params;
 
-  const oldPassword = await getPasswordFromProvider(oldPasswordProvider);
-  const newPassword = await getPasswordFromProvider(newPasswordProvider);
-
-  const salt = await getOrCreateSalt(ctx, storeName);
-  const oldEncryption = await StorageEncryption.create(oldPassword, { existingSalt: salt, cryptoBackend: ctx.cryptoBackend });
-  const newEncryption = await StorageEncryption.create(newPassword, { cryptoBackend: ctx.cryptoBackend });
-  const newSalt = newEncryption.getSalt();
-
-  return withSubLevel<string, string, PasswordRotationResult>(
+  return withSubLevel<PasswordRotationResult>(
     ctx,
     storeName,
     async (subLevel) => {
+      // Resolved inside the lock, on the salt this store holds right now, so a
+      // concurrent write cannot slip in between reading the salt and rewriting it.
+      const oldPassword = await getPasswordFromProvider(oldPasswordProvider);
+      const newPassword = await getPasswordFromProvider(newPasswordProvider);
+
+      const salt = await readOrCreateSalt(subLevel);
+      const oldEncryption = await StorageEncryption.create(oldPassword, { existingSalt: salt, cryptoBackend: ctx.cryptoBackend });
+      const newEncryption = await StorageEncryption.create(newPassword, { cryptoBackend: ctx.cryptoBackend });
+      const newSalt = newEncryption.getSalt();
+
       const entriesToMigrate: { key: string; decryptedValue: string }[] = [];
       let hasMatchingData = false;
       let firstEntryValidated = false;
@@ -587,16 +620,20 @@ const rotateStorePassword = async (
   );
 };
 
-const subLevelMaybeGet = async <K, V>(
+const subLevelMaybeGet = <K extends string, V>(
   ctx: StorageContext,
   levelName: string,
   key: K,
   passwordProvider: PrivateStoragePasswordProvider,
-): Promise<V | null> => {
-  await waitForRotationLock(ctx.dbName, levelName);
-  const encryption = await getOrCreateEncryption(ctx, levelName, passwordProvider);
+): Promise<V | null> =>
+  withSubLevel<V | null>(ctx, levelName, async (subLevel) => {
+    const encryption = await resolveEncryption(
+      subLevel,
+      `${ctx.dbName}:${levelName}`,
+      passwordProvider,
+      ctx.cryptoBackend
+    );
 
-  return withSubLevel<K, string, V | null>(ctx, levelName, async (subLevel) => {
     try {
       const encryptedValue = await subLevel.get(key);
 
@@ -636,20 +673,22 @@ const subLevelMaybeGet = async <K, V>(
       throw error;
     }
   });
-};
 
 /**
  * Iterate all key-value pairs in a sublevel, excluding metadata keys.
  */
-const getAllEntries = async <K extends string, V>(
+const getAllEntries = <K extends string, V>(
   ctx: StorageContext,
   levelName: string,
   passwordProvider: PrivateStoragePasswordProvider,
-): Promise<Map<K, V>> => {
-  await waitForRotationLock(ctx.dbName, levelName);
-  const encryption = await getOrCreateEncryption(ctx, levelName, passwordProvider);
-
-  return withSubLevel<K, string, Map<K, V>>(ctx, levelName, async (subLevel) => {
+): Promise<Map<K, V>> =>
+  withSubLevel<Map<K, V>>(ctx, levelName, async (subLevel) => {
+    const encryption = await resolveEncryption(
+      subLevel,
+      `${ctx.dbName}:${levelName}`,
+      passwordProvider,
+      ctx.cryptoBackend
+    );
     const entries = new Map<K, V>();
     let password: string | null = null;
 
@@ -688,7 +727,6 @@ const getAllEntries = async <K extends string, V>(
 
     return entries;
   });
-};
 
 /**
  * Internal structure of the decrypted export payload.
@@ -881,24 +919,26 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
     /** {@inheritDoc PrivateStateProvider.remove} */
     async remove(privateStateId: PSI): Promise<void> {
       const { privateState } = scopedNames;
-      await waitForRotationLock(ctx.dbName, privateState);
       const scopedKey = getScopedKey(privateStateId);
-      return withSubLevel<string, string, void>(ctx, privateState, (subLevel) =>
+      return withSubLevel<void>(ctx, privateState, (subLevel) =>
         subLevel.del(scopedKey),
       );
     },
     /** {@inheritDoc PrivateStateProvider.set} */
     async set(privateStateId: PSI, state: PS): Promise<void> {
       const { privateState } = scopedNames;
-      await waitForRotationLock(ctx.dbName, privateState);
       const scopedKey = getScopedKey(privateStateId);
-      const encryption = await getOrCreateEncryption(ctx, privateState, passwordProvider);
       const serialized = superjson.stringify(state);
-      const encrypted = await encryption.encrypt(serialized);
 
-      return withSubLevel<string, string, void>(ctx, privateState, (subLevel) =>
-        subLevel.put(scopedKey, encrypted),
-      );
+      return withSubLevel<void>(ctx, privateState, async (subLevel) => {
+        const encryption = await resolveEncryption(
+          subLevel,
+          `${ctx.dbName}:${privateState}`,
+          passwordProvider,
+          ctx.cryptoBackend
+        );
+        await subLevel.put(scopedKey, await encryption.encrypt(serialized));
+      });
     },
     /** {@inheritDoc PrivateStateProvider.clear} */
     async clear(): Promise<void> {
@@ -916,22 +956,24 @@ export const levelPrivateStateProvider = <PSI extends PrivateStateId, PS = any>(
     /** {@inheritDoc PrivateStateProvider.removeSigningKey} */
     async removeSigningKey(address: ContractAddress): Promise<void> {
       const { signingKey } = scopedNames;
-      await waitForRotationLock(ctx.dbName, signingKey);
-      return withSubLevel<ContractAddress, string, void>(ctx, signingKey, (subLevel) =>
+      return withSubLevel<void>(ctx, signingKey, (subLevel) =>
         subLevel.del(address),
       );
     },
     /** {@inheritDoc PrivateStateProvider.setSigningKey} */
     async setSigningKey(address: ContractAddress, signingKey: SigningKey): Promise<void> {
       const { signingKey: signingKeyLevelName } = scopedNames;
-      await waitForRotationLock(ctx.dbName, signingKeyLevelName);
-      const encryption = await getOrCreateEncryption(ctx, signingKeyLevelName, passwordProvider);
       const serialized = superjson.stringify(signingKey);
-      const encrypted = await encryption.encrypt(serialized);
 
-      return withSubLevel<ContractAddress, string, void>(ctx, signingKeyLevelName, (subLevel) =>
-        subLevel.put(address, encrypted),
-      );
+      return withSubLevel<void>(ctx, signingKeyLevelName, async (subLevel) => {
+        const encryption = await resolveEncryption(
+          subLevel,
+          `${ctx.dbName}:${signingKeyLevelName}`,
+          passwordProvider,
+          ctx.cryptoBackend
+        );
+        await subLevel.put(address, await encryption.encrypt(serialized));
+      });
     },
     /** {@inheritDoc PrivateStateProvider.clearSigningKeys} */
     async clearSigningKeys(): Promise<void> {

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -182,31 +182,41 @@ const getScopedLevelName = (baseLevelName: string, accountId: string): string =>
 const defaultLevelFactory: LevelFactory = (dbName: string) =>
   new Level(dbName, { createIfMissing: true }) as DatabaseLevel;
 
-/**
- * Queues of pending database operations, keyed by database name.
- *
- * Every operation opens and closes its own database handle, and LevelDB grants
- * the handle exclusively: a second `open()` on the same path - or an `open()`
- * racing another operation's `close()` - fails with "Database failed to open".
- * Concurrent callers therefore have to be serialized. The key is the database
- * name because the exclusive lock covers the whole database, not a sublevel.
- *
- * The queue is module-level because the resource it guards is process-wide;
- * a per-provider queue could not see a second provider opening the same path.
- * This mirrors {@link encryptionInitPromises} and {@link passwordRotationLocks}.
- * Entries are removed once a queue drains, so the map holds at most one entry
- * per database currently in use.
- *
- * Note that this cannot serialize access across separate processes; those still
- * contend on the operating system lock and surface as an open failure.
- */
+/** Tail of the pending operation chain for each database, keyed by database name. */
 const dbAccessQueues = new Map<string, Promise<void>>();
 
+/**
+ * Serializes access to one database, so that overlapping callers queue instead
+ * of colliding.
+ *
+ * Every operation opens its own database handle and closes it again. On the
+ * Node.js path (`classic-level`) LevelDB grants the database directory to a
+ * single holder, so a second `open()` - or an `open()` racing another
+ * operation's `close()` - fails with `LEVEL_DATABASE_NOT_OPEN`. The browser
+ * path (`browser-level`, IndexedDB) takes no such lock, but serializing there
+ * is still what makes a read-modify-write sequence deterministic. The cost is
+ * that throughput is one operation per database at a time.
+ *
+ * The map is module-level because the resource it guards is process-wide: a
+ * per-provider map could not see a second provider opening the same database.
+ * Each caller deletes only its own tail, so an earlier operation's cleanup
+ * cannot drop a later one's entry.
+ *
+ * Two limitations. Keying is by the configured name verbatim, so two configs
+ * naming one directory differently (`'db'` and `'./db'`) are not serialized
+ * against each other. And access from separate processes cannot be serialized
+ * at all - it still contends on the operating system lock.
+ *
+ * Not reentrant: entering the lock for a database that already holds it
+ * deadlocks, and there is no timeout to break it. Callers must therefore
+ * resolve encryption keys, which read the database themselves, before entering.
+ */
 const withDbLock = async <A>(dbName: string, operation: () => Promise<A>): Promise<A> => {
   const pending = dbAccessQueues.get(dbName);
-  // A failed operation must not prevent queued operations from running, so the
-  // same thunk serves as both fulfillment and rejection handler.
-  const current = pending === undefined ? operation() : pending.then(operation, operation);
+  const current = pending === undefined ? operation() : pending.then(operation);
+  // The stored tail must never reject, because a rejected tail would reject
+  // every operation chained behind it. The caller still receives the real
+  // outcome through `current`.
   const settled = current.then(
     () => undefined,
     () => undefined
@@ -222,35 +232,71 @@ const withDbLock = async <A>(dbName: string, operation: () => Promise<A>): Promi
   }
 };
 
+const describeOpenFailure = (error: unknown): string => {
+  if (!(error instanceof Error)) {
+    return 'Unknown error';
+  }
+  // abstract-level reports every open failure as the same
+  // `LEVEL_DATABASE_NOT_OPEN` error, so the reason is one level down.
+  return error.cause instanceof Error ? error.cause.message : error.message;
+};
+
+const openDatabase = async (ctx: StorageContext): Promise<DatabaseLevel> => {
+  const level = ctx.createLevel(ctx.dbName);
+  try {
+    await level.open();
+    return level;
+  } catch (error: unknown) {
+    throw new Error(
+      `Failed to open private state database "${ctx.dbName}": ${describeOpenFailure(error)}. ` +
+      `Possible causes: another process holds the database, ` +
+      `insufficient file permissions, or a corrupted store.`,
+      { cause: error }
+    );
+  }
+};
+
+const closeDatabase = async (
+  subLevel: { close(): Promise<void> },
+  level: DatabaseLevel
+): Promise<void> => {
+  // `level.close()` has to run even when closing the sublevel fails: an
+  // unclosed handle keeps the database locked for the rest of the process.
+  try {
+    await subLevel.close();
+  } finally {
+    await level.close();
+  }
+};
+
 const withSubLevel = <K, V, A>(
   ctx: StorageContext,
   levelName: string,
   thunk: (subLevel: AbstractSublevel<DatabaseLevel, string | Uint8Array | Buffer, K, V>) => Promise<A>,
 ): Promise<A> =>
   withDbLock(ctx.dbName, async () => {
-    const level = ctx.createLevel(ctx.dbName);
-    try {
-      await level.open();
-    } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(
-        `Failed to open private state database "${ctx.dbName}": ${errorMessage}. ` +
-        `LevelDB grants the database to a single holder at a time. ` +
-        `Ensure no other process is using it.`,
-        { cause: error }
-      );
-    }
-
+    const level = await openDatabase(ctx);
     const subLevel = level.sublevel<K, V>(levelName, {
       valueEncoding: 'utf-8'
     });
+
+    let result: A;
     try {
       await subLevel.open();
-      return await thunk(subLevel);
-    } finally {
-      await subLevel.close();
-      await level.close();
+      result = await thunk(subLevel);
+    } catch (error: unknown) {
+      try {
+        await closeDatabase(subLevel, level);
+      } catch {
+        // Don't mask the error from the operation - that is the one worth reporting.
+      }
+      throw error;
     }
+
+    // On the success path a close failure is reported rather than ignored:
+    // it can mean the write never reached disk.
+    await closeDatabase(subLevel, level);
+    return result;
   });
 
 const METADATA_KEY = '__midnight_encryption_metadata__';
@@ -1331,11 +1377,9 @@ const migrateSublevel = (
   newLevelName: string,
 ): Promise<number> =>
   withDbLock(ctx.dbName, async () => {
-    const level = ctx.createLevel(ctx.dbName);
+    const level = await openDatabase(ctx);
 
     try {
-      await level.open();
-
       const oldSubLevel = level.sublevel<string, string>(oldLevelName, {
         valueEncoding: 'utf-8'
       });

--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -182,24 +182,76 @@ const getScopedLevelName = (baseLevelName: string, accountId: string): string =>
 const defaultLevelFactory: LevelFactory = (dbName: string) =>
   new Level(dbName, { createIfMissing: true }) as DatabaseLevel;
 
-const withSubLevel = async <K, V, A>(
+/**
+ * Queues of pending database operations, keyed by database name.
+ *
+ * Every operation opens and closes its own database handle, and LevelDB grants
+ * the handle exclusively: a second `open()` on the same path - or an `open()`
+ * racing another operation's `close()` - fails with "Database failed to open".
+ * Concurrent callers therefore have to be serialized. The key is the database
+ * name because the exclusive lock covers the whole database, not a sublevel.
+ *
+ * The queue is module-level because the resource it guards is process-wide;
+ * a per-provider queue could not see a second provider opening the same path.
+ * This mirrors {@link encryptionInitPromises} and {@link passwordRotationLocks}.
+ * Entries are removed once a queue drains, so the map holds at most one entry
+ * per database currently in use.
+ *
+ * Note that this cannot serialize access across separate processes; those still
+ * contend on the operating system lock and surface as an open failure.
+ */
+const dbAccessQueues = new Map<string, Promise<void>>();
+
+const withDbLock = async <A>(dbName: string, operation: () => Promise<A>): Promise<A> => {
+  const pending = dbAccessQueues.get(dbName);
+  // A failed operation must not prevent queued operations from running, so the
+  // same thunk serves as both fulfillment and rejection handler.
+  const current = pending === undefined ? operation() : pending.then(operation, operation);
+  const settled = current.then(
+    () => undefined,
+    () => undefined
+  );
+  dbAccessQueues.set(dbName, settled);
+
+  try {
+    return await current;
+  } finally {
+    if (dbAccessQueues.get(dbName) === settled) {
+      dbAccessQueues.delete(dbName);
+    }
+  }
+};
+
+const withSubLevel = <K, V, A>(
   ctx: StorageContext,
   levelName: string,
   thunk: (subLevel: AbstractSublevel<DatabaseLevel, string | Uint8Array | Buffer, K, V>) => Promise<A>,
-): Promise<A> => {
-  const level = ctx.createLevel(ctx.dbName);
-  const subLevel = level.sublevel<K, V>(levelName, {
-    valueEncoding: 'utf-8'
+): Promise<A> =>
+  withDbLock(ctx.dbName, async () => {
+    const level = ctx.createLevel(ctx.dbName);
+    try {
+      await level.open();
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(
+        `Failed to open private state database "${ctx.dbName}": ${errorMessage}. ` +
+        `LevelDB grants the database to a single holder at a time. ` +
+        `Ensure no other process is using it.`,
+        { cause: error }
+      );
+    }
+
+    const subLevel = level.sublevel<K, V>(levelName, {
+      valueEncoding: 'utf-8'
+    });
+    try {
+      await subLevel.open();
+      return await thunk(subLevel);
+    } finally {
+      await subLevel.close();
+      await level.close();
+    }
   });
-  try {
-    await level.open();
-    await subLevel.open();
-    return await thunk(subLevel);
-  } finally {
-    await subLevel.close();
-    await level.close();
-  }
-};
 
 const METADATA_KEY = '__midnight_encryption_metadata__';
 
@@ -1273,88 +1325,89 @@ export interface MigrationResult {
   readonly signingKeysMigrated: number;
 }
 
-const migrateSublevel = async (
+const migrateSublevel = (
   ctx: StorageContext,
   oldLevelName: string,
   newLevelName: string,
-): Promise<number> => {
-  const level = ctx.createLevel(ctx.dbName);
-
-  try {
-    await level.open();
-
-    const oldSubLevel = level.sublevel<string, string>(oldLevelName, {
-      valueEncoding: 'utf-8'
-    });
-    const newSubLevel = level.sublevel<string, string>(newLevelName, {
-      valueEncoding: 'utf-8'
-    });
+): Promise<number> =>
+  withDbLock(ctx.dbName, async () => {
+    const level = ctx.createLevel(ctx.dbName);
 
     try {
-      await oldSubLevel.open();
-    } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(
-        `Failed to open source sublevel "${oldLevelName}": ${errorMessage}. ` +
-        `Ensure no other process is accessing the database.`,
-        { cause: error }
-      );
-    }
+      await level.open();
 
-    try {
-      await newSubLevel.open();
-    } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(
-        `Failed to open target sublevel "${newLevelName}": ${errorMessage}. ` +
-        `Ensure no other process is accessing the database.`,
-        { cause: error }
-      );
-    }
+      const oldSubLevel = level.sublevel<string, string>(oldLevelName, {
+        valueEncoding: 'utf-8'
+      });
+      const newSubLevel = level.sublevel<string, string>(newLevelName, {
+        valueEncoding: 'utf-8'
+      });
 
-    let count = 0;
-    const operations: { type: 'put'; key: string; value: string }[] = [];
-
-    try {
-      for await (const [key, value] of oldSubLevel.iterator()) {
-        operations.push({ type: 'put', key, value });
-        count++;
-      }
-    } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(
-        `Failed to read data from source sublevel "${oldLevelName}" after ${count} entries: ${errorMessage}. ` +
-        `Migration incomplete. Source data is unchanged.`,
-        { cause: error }
-      );
-    }
-
-    if (operations.length > 0) {
       try {
-        await newSubLevel.batch(operations);
+        await oldSubLevel.open();
       } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
         throw new Error(
-          `Failed to write ${operations.length} entries to target sublevel "${newLevelName}": ${errorMessage}. ` +
-          `Migration incomplete. Target sublevel may contain partial data. ` +
-          `Source data at "${oldLevelName}" is unchanged.`,
+          `Failed to open source sublevel "${oldLevelName}": ${errorMessage}. ` +
+          `Ensure no other process is accessing the database.`,
           { cause: error }
         );
       }
-    }
 
-    await newSubLevel.close();
-    await oldSubLevel.close();
+      try {
+        await newSubLevel.open();
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        throw new Error(
+          `Failed to open target sublevel "${newLevelName}": ${errorMessage}. ` +
+          `Ensure no other process is accessing the database.`,
+          { cause: error }
+        );
+      }
 
-    return count;
-  } finally {
-    try {
-      await level.close();
-    } catch {
-      // Don't mask the original error - just ignore the close failure
+      let count = 0;
+      const operations: { type: 'put'; key: string; value: string }[] = [];
+
+      try {
+        for await (const [key, value] of oldSubLevel.iterator()) {
+          operations.push({ type: 'put', key, value });
+          count++;
+        }
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        throw new Error(
+          `Failed to read data from source sublevel "${oldLevelName}" after ${count} entries: ${errorMessage}. ` +
+          `Migration incomplete. Source data is unchanged.`,
+          { cause: error }
+        );
+      }
+
+      if (operations.length > 0) {
+        try {
+          await newSubLevel.batch(operations);
+        } catch (error: unknown) {
+          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+          throw new Error(
+            `Failed to write ${operations.length} entries to target sublevel "${newLevelName}": ${errorMessage}. ` +
+            `Migration incomplete. Target sublevel may contain partial data. ` +
+            `Source data at "${oldLevelName}" is unchanged.`,
+            { cause: error }
+          );
+        }
+      }
+
+      await newSubLevel.close();
+      await oldSubLevel.close();
+
+      return count;
+    } finally {
+      try {
+        await level.close();
+      } catch {
+        // Don't mask the original error - just ignore the close failure
+      }
     }
-  }
-};
+  });
 
 /**
  * Migrates existing unscoped private state and signing key data to account-scoped sublevels.

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -3049,6 +3049,99 @@ describe('Level Private State Provider', (): void => {
     });
   });
 
+  describe('Concurrent operations', () => {
+    const CONCURRENCY_DB_NAME = 'test-concurrency-db';
+    const CONCURRENCY_CONTRACT_ADDRESS = 'concurrency-contract' as ContractAddress;
+
+    const concurrencyConfig = {
+      ...testConfig,
+      midnightDbName: CONCURRENCY_DB_NAME
+    };
+
+    const createProvider = () => {
+      const provider = levelPrivateStateProvider<string, unknown>(concurrencyConfig);
+      provider.setContractAddress(CONCURRENCY_CONTRACT_ADDRESS);
+      return provider;
+    };
+
+    const rejectionsOf = (results: PromiseSettledResult<unknown>[]): unknown[] =>
+      results.filter((result) => result.status === 'rejected').map((result) => result.reason);
+
+    afterAll(async () => {
+      await fs.rm(path.join('.', CONCURRENCY_DB_NAME), { recursive: true, force: true });
+    });
+
+    test('concurrent set and get on one provider instance all succeed', async () => {
+      const provider = createProvider();
+      await provider.set('warmup', { n: 0 });
+
+      const operations: Promise<unknown>[] = [];
+      for (let i = 0; i < 10; i++) {
+        operations.push(provider.set(`state${i}`, { n: i }));
+        operations.push(provider.get(`state${i}`));
+      }
+      const results = await Promise.allSettled(operations);
+
+      expect(rejectionsOf(results)).toEqual([]);
+    });
+
+    test('every concurrently written state is readable afterwards', async () => {
+      const provider = createProvider();
+
+      await Promise.all(
+        Array.from({ length: 10 }, (_, i) => provider.set(`persisted${i}`, { n: i }))
+      );
+      const values = await Promise.all(
+        Array.from({ length: 10 }, (_, i) => provider.get(`persisted${i}`))
+      );
+
+      expect(values).toEqual(Array.from({ length: 10 }, (_, i) => ({ n: i })));
+    });
+
+    test('concurrent private state and signing key operations all succeed', async () => {
+      const provider = createProvider();
+      const signingKey = sampleSigningKey();
+      await provider.set('to-remove', { n: 1 });
+
+      const results = await Promise.allSettled([
+        provider.set('mixed', { n: 2 }),
+        provider.get('mixed'),
+        provider.remove('to-remove'),
+        provider.setSigningKey('mixed-address', signingKey),
+        provider.getSigningKey('mixed-address')
+      ]);
+
+      expect(rejectionsOf(results)).toEqual([]);
+    });
+
+    test('concurrent operations on two providers sharing one database all succeed', async () => {
+      const first = createProvider();
+      const second = createProvider();
+
+      const operations: Promise<unknown>[] = [];
+      for (let i = 0; i < 5; i++) {
+        operations.push(first.set(`shared${i}`, { n: i }));
+        operations.push(second.get(`shared${i}`));
+      }
+      const results = await Promise.allSettled(operations);
+
+      expect(rejectionsOf(results)).toEqual([]);
+    });
+
+    test('concurrent writes to the same key leave one of the written values', async () => {
+      const provider = createProvider();
+
+      await Promise.all([
+        provider.set('contended', { n: 1 }),
+        provider.set('contended', { n: 2 }),
+        provider.set('contended', { n: 3 })
+      ]);
+      const value = await provider.get('contended');
+
+      expect([{ n: 1 }, { n: 2 }, { n: 3 }]).toContainEqual(value);
+    });
+  });
+
   describe('levelFactory', () => {
     const FACTORY_DB_NAME = 'test-custom-factory-db';
 

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -3067,6 +3067,10 @@ describe('Level Private State Provider', (): void => {
     const rejectionsOf = (results: PromiseSettledResult<unknown>[]): unknown[] =>
       results.filter((result) => result.status === 'rejected').map((result) => result.reason);
 
+    beforeEach(async () => {
+      await fs.rm(path.join('.', CONCURRENCY_DB_NAME), { recursive: true, force: true });
+    });
+
     afterAll(async () => {
       await fs.rm(path.join('.', CONCURRENCY_DB_NAME), { recursive: true, force: true });
     });
@@ -3098,47 +3102,64 @@ describe('Level Private State Provider', (): void => {
       expect(values).toEqual(Array.from({ length: 10 }, (_, i) => ({ n: i })));
     });
 
-    test('concurrent private state and signing key operations all succeed', async () => {
+    test('concurrent private state and signing key operations take effect', async () => {
       const provider = createProvider();
       const signingKey = sampleSigningKey();
       await provider.set('to-remove', { n: 1 });
 
       const results = await Promise.allSettled([
         provider.set('mixed', { n: 2 }),
-        provider.get('mixed'),
         provider.remove('to-remove'),
-        provider.setSigningKey('mixed-address', signingKey),
-        provider.getSigningKey('mixed-address')
+        provider.setSigningKey('mixed-address', signingKey)
       ]);
 
       expect(rejectionsOf(results)).toEqual([]);
+      expect(await provider.get('mixed')).toEqual({ n: 2 });
+      expect(await provider.get('to-remove')).toBeNull();
+      expect(await provider.getSigningKey('mixed-address')).toEqual(signingKey);
     });
 
-    test('concurrent operations on two providers sharing one database all succeed', async () => {
-      const first = createProvider();
-      const second = createProvider();
+    test('two providers sharing one database both see all concurrent writes', async () => {
+      const writer = createProvider();
+      const reader = createProvider();
 
-      const operations: Promise<unknown>[] = [];
-      for (let i = 0; i < 5; i++) {
-        operations.push(first.set(`shared${i}`, { n: i }));
-        operations.push(second.get(`shared${i}`));
-      }
-      const results = await Promise.allSettled(operations);
+      const writes = await Promise.allSettled(
+        Array.from({ length: 5 }, (_, i) => writer.set(`shared${i}`, { n: i }))
+      );
+      expect(rejectionsOf(writes)).toEqual([]);
 
-      expect(rejectionsOf(results)).toEqual([]);
+      const values = await Promise.all(
+        Array.from({ length: 5 }, (_, i) => reader.get(`shared${i}`))
+      );
+      expect(values).toEqual(Array.from({ length: 5 }, (_, i) => ({ n: i })));
     });
 
-    test('concurrent writes to the same key leave one of the written values', async () => {
-      const provider = createProvider();
+    test('a failed open reports the underlying reason and leaves the queue usable', async () => {
+      let failOpen = true;
+      const provider = levelPrivateStateProvider<string, unknown>({
+        ...concurrencyConfig,
+        levelFactory: (dbName: string): DatabaseLevel => {
+          const level = new Level(dbName, { createIfMissing: true }) as DatabaseLevel;
+          if (failOpen) {
+            // What abstract-level reports: a constant message, the real reason in `cause`.
+            level.open = () =>
+              Promise.reject(new Error('Database failed to open', { cause: new Error('disk on fire') }));
+          }
+          return level;
+        }
+      });
+      provider.setContractAddress(CONCURRENCY_CONTRACT_ADDRESS);
 
-      await Promise.all([
-        provider.set('contended', { n: 1 }),
-        provider.set('contended', { n: 2 }),
-        provider.set('contended', { n: 3 })
-      ]);
-      const value = await provider.get('contended');
+      const error = await captureError(() => provider.set('after-failure', { n: 1 }));
 
-      expect([{ n: 1 }, { n: 2 }, { n: 3 }]).toContainEqual(value);
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain('Failed to open private state database');
+      expect((error as Error).message).toContain('disk on fire');
+      expect((error as Error).cause).toBeInstanceOf(Error);
+
+      failOpen = false;
+      await provider.set('after-failure', { n: 1 });
+      expect(await provider.get('after-failure')).toEqual({ n: 1 });
     });
   });
 

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -44,6 +44,15 @@ const captureError = async (action: () => Promise<unknown>): Promise<unknown> =>
   return undefined;
 };
 
+/** Every message reachable from an error, following `cause` and `AggregateError.errors`. */
+const collectErrorMessages = (error: unknown): string[] => {
+  if (!(error instanceof Error)) {
+    return [];
+  }
+  const nested = error instanceof AggregateError ? error.errors : [];
+  return [error.message, ...nested.flatMap(collectErrorMessages), ...collectErrorMessages(error.cause)];
+};
+
 const expectPasswordValidationCause = (
   error: unknown,
   reason: PasswordValidationFailure
@@ -2394,7 +2403,7 @@ describe('Level Private State Provider', (): void => {
         expect(value).toBe('value1');
       });
 
-      test('remove waits for rotation lock before executing', async () => {
+      test('remove is not corrupted by a concurrent rotation', async () => {
         let currentPassword = OLD_PASSWORD;
         const config = {
           midnightDbName: ROTATION_TEST_DB,
@@ -2421,7 +2430,7 @@ describe('Level Private State Provider', (): void => {
         expect(value2).toBe('value2');
       });
 
-      test('removeSigningKey waits for rotation lock before executing', async () => {
+      test('removeSigningKey is not corrupted by a concurrent rotation', async () => {
         let currentPassword = OLD_PASSWORD;
         const config = {
           midnightDbName: ROTATION_TEST_DB,
@@ -2450,7 +2459,7 @@ describe('Level Private State Provider', (): void => {
         expect(key2).toEqual(signingKey2);
       });
 
-      test('get waits for rotation lock before executing', async () => {
+      test('get is not corrupted by a concurrent rotation', async () => {
         let currentPassword = OLD_PASSWORD;
         const config = {
           midnightDbName: ROTATION_TEST_DB,
@@ -2472,7 +2481,7 @@ describe('Level Private State Provider', (): void => {
         expect(value).toBe('value1');
       });
 
-      test('set waits for rotation lock before executing', async () => {
+      test('set is not corrupted by a concurrent rotation', async () => {
         let currentPassword = OLD_PASSWORD;
         const config = {
           midnightDbName: ROTATION_TEST_DB,
@@ -2498,7 +2507,7 @@ describe('Level Private State Provider', (): void => {
         expect(value2).toBe('value2');
       });
 
-      test('getSigningKey waits for rotation lock before executing', async () => {
+      test('getSigningKey is not corrupted by a concurrent rotation', async () => {
         let currentPassword = OLD_PASSWORD;
         const config = {
           midnightDbName: ROTATION_TEST_DB,
@@ -2521,7 +2530,7 @@ describe('Level Private State Provider', (): void => {
         expect(key).toEqual(signingKey);
       });
 
-      test('setSigningKey waits for rotation lock before executing', async () => {
+      test('setSigningKey is not corrupted by a concurrent rotation', async () => {
         let currentPassword = OLD_PASSWORD;
         const config = {
           midnightDbName: ROTATION_TEST_DB,
@@ -3160,6 +3169,155 @@ describe('Level Private State Provider', (): void => {
       failOpen = false;
       await provider.set('after-failure', { n: 1 });
       expect(await provider.get('after-failure')).toEqual({ n: 1 });
+    });
+
+    test('a removal called after a write wins over that write', async () => {
+      const provider = createProvider();
+
+      const write = provider.set('ordered', { n: 1 });
+      const removal = provider.remove('ordered');
+      await Promise.all([write, removal]);
+
+      expect(await provider.get('ordered')).toBeNull();
+    });
+
+    test('a clear called after a write wins over that write', async () => {
+      const provider = createProvider();
+
+      const write = provider.set('cleared', { n: 1 });
+      const clear = provider.clear();
+      await Promise.all([write, clear]);
+
+      expect(await provider.get('cleared')).toBeNull();
+    });
+
+    test('a write called after a removal wins over that removal', async () => {
+      const provider = createProvider();
+      await provider.set('rewritten', { n: 1 });
+
+      const removal = provider.remove('rewritten');
+      const write = provider.set('rewritten', { n: 2 });
+      await Promise.all([removal, write]);
+
+      expect(await provider.get('rewritten')).toEqual({ n: 2 });
+    });
+
+    test('one operation opens the database once', async () => {
+      const factory = vi.fn(
+        (dbName: string): DatabaseLevel => new Level(dbName, { createIfMissing: true }) as DatabaseLevel
+      );
+      const provider = levelPrivateStateProvider<string, unknown>({
+        ...concurrencyConfig,
+        levelFactory: factory
+      });
+      provider.setContractAddress(CONCURRENCY_CONTRACT_ADDRESS);
+      await provider.set('warmup', { n: 0 });
+
+      factory.mockClear();
+      await provider.set('counted', { n: 1 });
+
+      expect(factory).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Serialized access to password rotation', () => {
+    const RACE_DB_NAME = 'test-rotation-race-db';
+    const RACE_CONTRACT_ADDRESS = 'rotation-race-contract' as ContractAddress;
+    const RACE_OLD_PASSWORD = 'Old-Password-Race8!';
+    const RACE_NEW_PASSWORD = 'New-Password-Race8!';
+
+    beforeEach(async () => {
+      await fs.rm(path.join('.', RACE_DB_NAME), { recursive: true, force: true });
+    });
+
+    afterAll(async () => {
+      await fs.rm(path.join('.', RACE_DB_NAME), { recursive: true, force: true });
+    });
+
+    test('a write called before a rotation stays readable under the new password', async () => {
+      let currentPassword = RACE_OLD_PASSWORD;
+      const provider = levelPrivateStateProvider<string, unknown>({
+        midnightDbName: RACE_DB_NAME,
+        privateStoragePasswordProvider: () => currentPassword,
+        accountId: TEST_ACCOUNT_ID
+      });
+      provider.setContractAddress(RACE_CONTRACT_ADDRESS);
+      await provider.set('existing', { n: 0 });
+
+      const write = provider.set('racing', { n: 1 });
+      const rotation = provider.changePassword(() => RACE_OLD_PASSWORD, () => RACE_NEW_PASSWORD);
+      await Promise.all([write, rotation]);
+      currentPassword = RACE_NEW_PASSWORD;
+
+      expect(await provider.get('racing')).toEqual({ n: 1 });
+    });
+  });
+
+  describe('Stuck and failing database handles', () => {
+    const STUCK_DB_NAME = 'test-stuck-db';
+    const CLOSE_FAILURE_DB_NAME = 'test-close-failure-db';
+    const STUCK_CONTRACT_ADDRESS = 'stuck-contract' as ContractAddress;
+
+    afterAll(async () => {
+      await fs.rm(path.join('.', STUCK_DB_NAME), { recursive: true, force: true });
+      await fs.rm(path.join('.', CLOSE_FAILURE_DB_NAME), { recursive: true, force: true });
+    });
+
+    test('an operation that never settles times out instead of hanging forever', async () => {
+      vi.useFakeTimers();
+      try {
+        const provider = levelPrivateStateProvider<string, unknown>({
+          ...testConfig,
+          midnightDbName: STUCK_DB_NAME,
+          levelFactory: (dbName: string): DatabaseLevel => {
+            const level = new Level(dbName, { createIfMissing: true }) as DatabaseLevel;
+            level.open = () => new Promise<void>(() => undefined);
+            return level;
+          }
+        });
+        provider.setContractAddress(STUCK_CONTRACT_ADDRESS);
+
+        const pending = captureError(() => provider.get('never-arrives'));
+        // Well past any sane per-operation budget, so the test does not encode the exact value.
+        await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+        const error = await pending;
+
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain('Timed out');
+        expect((error as Error).message).toContain(STUCK_DB_NAME);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    test('a failing close is reported alongside the failure that triggered it', async () => {
+      const handles: { level: DatabaseLevel; restore: () => Promise<void> }[] = [];
+      const provider = levelPrivateStateProvider<string, unknown>({
+        midnightDbName: CLOSE_FAILURE_DB_NAME,
+        privateStoragePasswordProvider: () => {
+          throw new Error('password unavailable');
+        },
+        accountId: TEST_ACCOUNT_ID,
+        levelFactory: (dbName: string): DatabaseLevel => {
+          const level = new Level(dbName, { createIfMissing: true }) as DatabaseLevel;
+          handles.push({ level, restore: level.close.bind(level) });
+          level.close = () => Promise.reject(new Error('close failed'));
+          return level;
+        }
+      });
+      provider.setContractAddress(STUCK_CONTRACT_ADDRESS);
+
+      const error = await captureError(() => provider.set('unreachable', { n: 1 }));
+
+      const reported = collectErrorMessages(error).join(' | ');
+      expect(reported).toContain('password unavailable');
+      expect(reported).toContain('close failed');
+
+      // Release the handle the provider could not close, so later tests can open the directory.
+      for (const { level, restore } of handles) {
+        level.close = restore;
+        await level.close();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- Fixes #1144 — concurrent operations on one `levelPrivateStateProvider` instance failed with `Error: Database failed to open`. Two concurrent contract circuit calls sharing one providers object overlap with near certainty, so this hit any orchestrator on its first concurrent load.
- **Root cause:** `withSubLevel` creates a fresh `Level` instance per operation and does `open() → operate → close()`. All 11 provider operations funnel through it. On the Node.js path `classic-level` holds the database directory exclusively, so a second `open()` — or an `open()` racing another operation's `close()` — rejects. The package already guarded salt initialization and password rotation this way, but never general operation-level concurrency.
- **Fix:** queue database operations per database name (`withDbLock`), so overlapping callers are serialized instead of colliding. Serializing costs no throughput: each operation already held the database exclusively — today the overlap does not run in parallel, it crashes.
- The queue is module-level because the resource it guards is process-wide. A per-provider queue could not see a second provider opening the same database. Entries are removed once a queue drains, so the map holds at most one entry per database in use.
- `migrateSublevel`, which opens a `Level` directly, goes through the same queue and the same open helper.
- Also reports the real reason for a failed database open instead of surfacing a bare `Database failed to open`.

### Why not a shared open handle

A single refcounted `Level` per database would be faster (one open per process instead of per operation), but the handle then needs a lifecycle owner and neither placement works: per-provider means the first provider holds the lock indefinitely and any provider-per-request pattern deadlocks; module-level means the lock is held for the process lifetime with no way to release it short of a new `close()` method. That trades a bug fix for a change in the public contract. Not now.

### Scope

No public API change, no on-disk format change, no change to sequential behavior.

## Review follow-ups (second commit)

A four-agent review found five confirmed defects in the first commit, all fixed here:

- **The new error message was useless.** `abstract-level` reports every open failure as the same constant `'Database failed to open'` (`abstract-level.js:1113`), with the real reason one level down in `cause`. The wrapper interpolated that constant and then asserted a single confident diagnosis ("another process"), so a permissions, disk or corruption failure sent the reader hunting a phantom process. It now reads the reason from `cause` and lists the possible causes.
- **`level.close()` could be skipped.** `finally { await subLevel.close(); await level.close(); }` — a rejecting sublevel close meant the database handle was never closed, keeping the LevelDB lock held for the rest of the process and making *every* subsequent operation fail with exactly the error this branch fixes. Now `level.close()` always runs.
- **Close failures masked the error that mattered.** A close rejection replaced the operation's error — including `Old password is incorrect` and decryption failures, the most important messages in this package. Close failures are now suppressed on the error path and reported on the success path, where they can mean a write never reached disk.
- **Dead code in the queue.** In `pending.then(operation, operation)` the rejection handler is unreachable, because the stored tail can never reject. Two reviewers confirmed it independently; one instrumented both handler slots and the rejection slot ran zero times. Removed, and the comment that documented the dead mechanism corrected.
- **The doc comment was wrong about the browser.** `level` v10 resolves to `browser-level` (IndexedDB) under a bundler, which takes no exclusive lock and has no OS lock file, but the comment stated the exclusive lock as an unconditional property. Now qualified per path. The comment also records that the lock is **not reentrant** — the invariant that makes the current callers safe is that they all resolve encryption keys before entering the lock, and nothing said so.

Test changes from the same review: added coverage for the open-failure path (the only uncovered lines in the diff) and for queue recovery after a rejection; three tests that asserted only "nothing rejected" now assert observable effects; `beforeEach` isolation replaces a shared database across the block; and one nondeterministic test was dropped — a reviewer measured that queue-entry order does not follow call order, because `set` resolves the rotation lock, key derivation and encryption *before* entering the queue, so "last writer wins" cannot be asserted.

## Known limitation, not fixed here

`changePassword` racing `set` can write a value under the pre-rotation key, leaving it permanently undecryptable. `set` passes the rotation-lock check, resolves its encryption key, and only then enters the queue; rotation can complete in that window. This hazard **pre-exists on `main`** — but before this PR the racing write usually died at `Database failed to open`, and now the open succeeds and the corruption lands, so the failure mode changes from loud to silent.

It is deliberately out of scope: the same time-of-check/time-of-use gap affects every write path, including `remove` and the re-encryption writes on the read path, so a guard in `set` alone would give false confidence. It needs its own design and tests, tracked in #1169, which should land before this ships to consumers.

Two smaller documented limitations: the queue key is the configured database name verbatim, so two configs naming one directory differently (`'db'` vs `'./db'`) are not serialized against each other — normalizing would be wrong on the browser path, where the name is not a path; and concurrency across separate processes still contends on the operating system lock.

## Test plan

- [x] Tests written first (TDD), verified they fail before fix — the triage repro reproduced 17/20 rejections; a reviewer independently reverted the source and confirmed 4 of 5 tests go red with `LEVEL_LOCKED` / `lock ... already held by process`
- [x] All existing tests pass (no regressions) — 281 tests in the package, 20 packages / full `yarn test:unit` green
- [x] Coverage headroom restored: lines 93.45 vs 93 required (was 93.07)
- [x] Lint clean, build succeeds
- [x] Full CI green on the first commit (45 pass, 4 skipping, including the e2e suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
