### PR TITLE
test(testkit-js): add the spike 0.16-compiled counter fixture with golden transcript

### DIFF
--- a/testkit-js/testkit-js/src/fixtures/hf/README.md
+++ b/testkit-js/testkit-js/src/fixtures/hf/README.md
@@ -187,6 +187,60 @@ key in the smoke test, to confirm `state-co-v2-only-foreign.hex`'s embedded
 key is genuinely foreign (see "The A4 mis-dispatch fixture" above) — that
 fixture is NOT keyed with it.
 
+## `counter-016/`
+
+`counter-016/compiled/contract/index.js` is the spike's own `counter.compact` recompiled
+with the spike's **original, pre-fork toolchain** (`compiler-version: 0.31.1`,
+`language-version: 0.23.0`, `runtime-version: 0.16.0` — from the spike's own
+`island-3/tests/tester/fixtures/counter/out/compiler/contract-info.json`), as
+opposed to `twin-contract/compiled/`, which is the SAME source recompiled with
+THIS repo's current toolchain (`compactc 0.33.0-rc.2`, `runtime-version:
+0.18.0-rc.1`). The two are not interchangeable: `twin-contract/compiled/` emits
+0.18-era (async) codegen and cannot run against a `compact-runtime@0.16`
+instance; `counter-016/` emits the sync codegen the retained pre-fork engine
+(`packages/protocol/src/engine/execute.ts`) actually exercises, and is the
+fixture `engine-execute.test.ts` runs `increment` against.
+
+Ported verbatim (byte-for-byte, only source-map generation trimmed — same
+"drop the map, keep the module minimal" precedent as `twin-contract/`) from
+`spike-dapp-hf/island-3/tests/tester/fixtures/counter/out/contract/index.js`
+(git blob `405a68179e4cfb3fb6307486461df7879ab508f3`). The contract source
+itself is unchanged from `../twin-contract/counter.compact` — a single
+`round: Counter` ledger cell with one nullary circuit `increment()` — so it is
+not duplicated here.
+
+Only the compiled contract module is ported — no `.d.ts`, no
+`compiler/contract-info.json`, no `keys/`, no `zkir/`. None of those are read
+at import time; the module's only own-time dependency is a bare
+`@midnight-ntwrk/compact-runtime` import, satisfied in tests by redirecting
+that specifier (module-registry-scoped to the one test file that imports this
+fixture) to this repo's own `compact-runtime-ledger8` — the same retained
+`@midnight-ntwrk/compact-runtime@0.16.0`, installed under an alias so it can
+coexist with the root's `0.18.0-rc.1` pin (see
+`packages/protocol/package.json`).
+
+The `compiled/` path segment (mirroring `twin-contract/compiled/`) is not
+cosmetic: `.licenserc.yaml`'s `paths-ignore` excludes `**/compiled/**` from
+the Apache-2.0 license-header check, which this ported-verbatim upstream
+artifact — same as `twin-contract/compiled/contract/index.js` — must not
+carry.
+
+`counter-016/increment-transcript.golden.json` is a golden regression
+reference for the transcript `executeCircuit` (`engine/execute.ts`) produces
+when running `increment()` against this contract's freshly-constructed
+initial state (`round: 0`). The spike carries no recorded transcript fixture
+of its own to port, so this one was minted once, directly from
+`engine-execute.test.ts`'s own real execution against this ported artifact
+(no proving involved — circuit execution through `compact-runtime@0.16` is
+fully deterministic), and is committed as JSON with bigints written as
+`` `${n}n` ``-suffixed strings and byte arrays as lower-case hex (the two
+value kinds an `AlignedValue`/`Op` tree carries that JSON has no native
+encoding for). `preContractState`/`postContractState`/`privateStateAfter` are
+excluded from the golden — they carry live `ChargedState` WASM objects, not
+plain data — the transcript's post-state is instead asserted directly in the
+same test via the contract's own `ledger()` projector (`round` goes `0n` →
+`1n`).
+
 ## Regenerating
 
 ```

--- a/testkit-js/testkit-js/src/fixtures/hf/counter-016/compiled/contract/index.js
+++ b/testkit-js/testkit-js/src/fixtures/hf/counter-016/compiled/contract/index.js
@@ -1,0 +1,189 @@
+import * as __compactRuntime from '@midnight-ntwrk/compact-runtime';
+__compactRuntime.checkRuntimeVersion('0.16.0');
+
+const _descriptor_0 = new __compactRuntime.CompactTypeUnsignedInteger(65535n, 2);
+
+const _descriptor_1 = new __compactRuntime.CompactTypeUnsignedInteger(18446744073709551615n, 8);
+
+const _descriptor_2 = __compactRuntime.CompactTypeBoolean;
+
+const _descriptor_3 = new __compactRuntime.CompactTypeBytes(32);
+
+class _Either_0 {
+  alignment() {
+    return _descriptor_2.alignment().concat(_descriptor_3.alignment().concat(_descriptor_3.alignment()));
+  }
+  fromValue(value_0) {
+    return {
+      is_left: _descriptor_2.fromValue(value_0),
+      left: _descriptor_3.fromValue(value_0),
+      right: _descriptor_3.fromValue(value_0)
+    }
+  }
+  toValue(value_0) {
+    return _descriptor_2.toValue(value_0.is_left).concat(_descriptor_3.toValue(value_0.left).concat(_descriptor_3.toValue(value_0.right)));
+  }
+}
+
+const _descriptor_4 = new _Either_0();
+
+const _descriptor_5 = new __compactRuntime.CompactTypeUnsignedInteger(340282366920938463463374607431768211455n, 16);
+
+class _ContractAddress_0 {
+  alignment() {
+    return _descriptor_3.alignment();
+  }
+  fromValue(value_0) {
+    return {
+      bytes: _descriptor_3.fromValue(value_0)
+    }
+  }
+  toValue(value_0) {
+    return _descriptor_3.toValue(value_0.bytes);
+  }
+}
+
+const _descriptor_6 = new _ContractAddress_0();
+
+const _descriptor_7 = new __compactRuntime.CompactTypeUnsignedInteger(255n, 1);
+
+export class Contract {
+  witnesses;
+  constructor(...args_0) {
+    if (args_0.length !== 1) {
+      throw new __compactRuntime.CompactError(`Contract constructor: expected 1 argument, received ${args_0.length}`);
+    }
+    const witnesses_0 = args_0[0];
+    if (typeof(witnesses_0) !== 'object') {
+      throw new __compactRuntime.CompactError('first (witnesses) argument to Contract constructor is not an object');
+    }
+    this.witnesses = witnesses_0;
+    this.circuits = {
+      increment: (...args_1) => {
+        if (args_1.length !== 1) {
+          throw new __compactRuntime.CompactError(`increment: expected 1 argument (as invoked from Typescript), received ${args_1.length}`);
+        }
+        const contextOrig_0 = args_1[0];
+        if (!(typeof(contextOrig_0) === 'object' && contextOrig_0.currentQueryContext != undefined)) {
+          __compactRuntime.typeError('increment',
+                                     'argument 1 (as invoked from Typescript)',
+                                     'counter.compact line 13 char 1',
+                                     'CircuitContext',
+                                     contextOrig_0)
+        }
+        const context = { ...contextOrig_0, gasCost: __compactRuntime.emptyRunningCost() };
+        const partialProofData = {
+          input: { value: [], alignment: [] },
+          output: undefined,
+          publicTranscript: [],
+          privateTranscriptOutputs: []
+        };
+        const result_0 = this._increment_0(context, partialProofData);
+        partialProofData.output = { value: [], alignment: [] };
+        return { result: result_0, context: context, proofData: partialProofData, gasCost: context.gasCost };
+      }
+    };
+    this.impureCircuits = { increment: this.circuits.increment };
+    this.provableCircuits = { increment: this.circuits.increment };
+  }
+  initialState(...args_0) {
+    if (args_0.length !== 1) {
+      throw new __compactRuntime.CompactError(`Contract state constructor: expected 1 argument (as invoked from Typescript), received ${args_0.length}`);
+    }
+    const constructorContext_0 = args_0[0];
+    if (typeof(constructorContext_0) !== 'object') {
+      throw new __compactRuntime.CompactError(`Contract state constructor: expected 'constructorContext' in argument 1 (as invoked from Typescript) to be an object`);
+    }
+    if (!('initialZswapLocalState' in constructorContext_0)) {
+      throw new __compactRuntime.CompactError(`Contract state constructor: expected 'initialZswapLocalState' in argument 1 (as invoked from Typescript)`);
+    }
+    if (typeof(constructorContext_0.initialZswapLocalState) !== 'object') {
+      throw new __compactRuntime.CompactError(`Contract state constructor: expected 'initialZswapLocalState' in argument 1 (as invoked from Typescript) to be an object`);
+    }
+    const state_0 = new __compactRuntime.ContractState();
+    let stateValue_0 = __compactRuntime.StateValue.newArray();
+    stateValue_0 = stateValue_0.arrayPush(__compactRuntime.StateValue.newNull());
+    state_0.data = new __compactRuntime.ChargedState(stateValue_0);
+    state_0.setOperation('increment', new __compactRuntime.ContractOperation());
+    const context = __compactRuntime.createCircuitContext(__compactRuntime.dummyContractAddress(), constructorContext_0.initialZswapLocalState.coinPublicKey, state_0.data, constructorContext_0.initialPrivateState);
+    const partialProofData = {
+      input: { value: [], alignment: [] },
+      output: undefined,
+      publicTranscript: [],
+      privateTranscriptOutputs: []
+    };
+    __compactRuntime.queryLedgerState(context,
+                                      partialProofData,
+                                      [
+                                       { push: { storage: false,
+                                                 value: __compactRuntime.StateValue.newCell({ value: _descriptor_7.toValue(0n),
+                                                                                              alignment: _descriptor_7.alignment() }).encode() } },
+                                       { push: { storage: true,
+                                                 value: __compactRuntime.StateValue.newCell({ value: _descriptor_1.toValue(0n),
+                                                                                              alignment: _descriptor_1.alignment() }).encode() } },
+                                       { ins: { cached: false, n: 1 } }]);
+    state_0.data = new __compactRuntime.ChargedState(context.currentQueryContext.state.state);
+    return {
+      currentContractState: state_0,
+      currentPrivateState: context.currentPrivateState,
+      currentZswapLocalState: context.currentZswapLocalState
+    }
+  }
+  _increment_0(context, partialProofData) {
+    const tmp_0 = 1n;
+    __compactRuntime.queryLedgerState(context,
+                                      partialProofData,
+                                      [
+                                       { idx: { cached: false,
+                                                pushPath: true,
+                                                path: [
+                                                       { tag: 'value',
+                                                         value: { value: _descriptor_7.toValue(0n),
+                                                                  alignment: _descriptor_7.alignment() } }] } },
+                                       { addi: { immediate: parseInt(__compactRuntime.valueToBigInt(
+                                                              { value: _descriptor_0.toValue(tmp_0),
+                                                                alignment: _descriptor_0.alignment() }
+                                                                .value
+                                                            )) } },
+                                       { ins: { cached: true, n: 1 } }]);
+    return [];
+  }
+}
+export function ledger(stateOrChargedState) {
+  const state = stateOrChargedState instanceof __compactRuntime.StateValue ? stateOrChargedState : stateOrChargedState.state;
+  const chargedState = stateOrChargedState instanceof __compactRuntime.StateValue ? new __compactRuntime.ChargedState(stateOrChargedState) : stateOrChargedState;
+  const context = {
+    currentQueryContext: new __compactRuntime.QueryContext(chargedState, __compactRuntime.dummyContractAddress()),
+    costModel: __compactRuntime.CostModel.initialCostModel()
+  };
+  const partialProofData = {
+    input: { value: [], alignment: [] },
+    output: undefined,
+    publicTranscript: [],
+    privateTranscriptOutputs: []
+  };
+  return {
+    get round() {
+      return _descriptor_1.fromValue(__compactRuntime.queryLedgerState(context,
+                                                                       partialProofData,
+                                                                       [
+                                                                        { dup: { n: 0 } },
+                                                                        { idx: { cached: false,
+                                                                                 pushPath: false,
+                                                                                 path: [
+                                                                                        { tag: 'value',
+                                                                                          value: { value: _descriptor_7.toValue(0n),
+                                                                                                   alignment: _descriptor_7.alignment() } }] } },
+                                                                        { popeq: { cached: true,
+                                                                                   result: undefined } }]).value);
+    }
+  };
+}
+const _emptyContext = {
+  currentQueryContext: new __compactRuntime.QueryContext(new __compactRuntime.ContractState().data, __compactRuntime.dummyContractAddress())
+};
+const _dummyContract = new Contract({ });
+export const pureCircuits = {};
+export const contractReferenceLocations =
+  { tag: 'publicLedgerArray', indices: { } };
+//# sourceMappingURL=index.js.map

--- a/testkit-js/testkit-js/src/fixtures/hf/counter-016/increment-transcript.golden.json
+++ b/testkit-js/testkit-js/src/fixtures/hf/counter-016/increment-transcript.golden.json
@@ -1,0 +1,23 @@
+{
+  "circuitId": "increment",
+  "result": [],
+  "input": { "value": [], "alignment": [] },
+  "output": { "value": [], "alignment": [] },
+  "publicTranscript": [
+    {
+      "idx": {
+        "cached": false,
+        "pushPath": true,
+        "path": [
+          {
+            "tag": "value",
+            "value": { "value": [""], "alignment": [{ "tag": "atom", "value": { "tag": "bytes", "length": 1 } }] }
+          }
+        ]
+      }
+    },
+    { "addi": { "immediate": 1 } },
+    { "ins": { "cached": true, "n": 1 } }
+  ],
+  "privateTranscriptOutputs": []
+}


### PR DESCRIPTION
# Overview

**PR 1004-E0 of the MJS-01 series (#1004)** — fixture assets only, no logic. First of three PRs carved out of the original 1004-E for reviewability (the three sum to a byte-identical tree with the fully reviewed original; see the series note below).

## Summary

- `testkit-js/.../fixtures/hf/counter-016/` — the HF spike's **0.16-compiled** counter contract, ported byte-verbatim (git-blob-hash-verifiable; provenance in the fixtures README). Needed because the repo toolchain (compactc 0.33 → 0.18-era async codegen) cannot mint an artifact executable on the retained 0.16 runtime — the existing `twin-contract/` is decode-tier only.
- `increment-transcript.golden.json` — golden execution transcript for `increment` (the spike recorded none; minted once, deterministic — no proving involved), consumed by the engine tests in 1004-E1.
- Fixtures README extended with the `counter-016/` provenance section.

## Series

Merge order: #1155 → #1156 → #1159 → #1164 → **this** → 1004-E1 → 1004-E2 (#1165). The three E-PRs replace the original single 1004-E; their combined tree is byte-identical to the reviewed original head.

## Test plan
- [x] testkit-js unit suite green (fixtures smoke test unaffected)
- [x] Lint clean on touched files

## Submission Checklist
- [x] Useful pull request description
- [x] Tests are provided (if possible) — fixture assets consumed by 1004-E1 tests
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README.md file (if relevant)
- [x] No new todos introduced

## Links
- Part of #1004 (MJS-01). Depends on #1164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
