### PR TITLE
fix(types): replace unsafe Option.some cast with Option.fromNullable in asEffectOption

### DIFF
--- a/packages/types/src/contract.ts
+++ b/packages/types/src/contract.ts
@@ -122,10 +122,10 @@ export const exitResultOrError: <A, E>(exit: Exit.Exit<A, E>) => A =
  * Wraps an object into an `Option.some`.
  *
  * @param obj The value that should be wrapped into an `Option`.
- * @returns An `Option.some` for `obj`.
+ * @returns An `Option.some` for `obj`, or `Option.none` if `obj` is null or undefined.
  */
-export const asEffectOption = <T>(obj: unknown): Option.Option<T> => {
-  return Option.some(obj) as Option.Option<T>;
+export const asEffectOption = <T>(obj: T | null | undefined): Option.Option<T> => {
+  return Option.fromNullable(obj);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes `asEffectOption` to correctly return `None` for null/undefined
instead of wrapping them as `Some(null)` / `Some(undefined)`.

Fixes #1202

## Problem

`asEffectOption` in `packages/types/src/contract.ts:127-129` unconditionally
calls `Option.some(obj)` and casts `unknown` to `Option<T>`. This means
null/undefined pass `Option.isSome()` checks as true, which defeats the
purpose of the Option type.

## Solution

- Replace `Option.some(obj) as Option.Option<T>` with `Option.fromNullable(obj)`
- Narrow input type from `unknown` to `T | null | undefined`

`Option.fromNullable` returns `None` for null/undefined and `Some(value)`
for everything else, matching the semantic contract of the Option type.

## Testing

The existing governance call site (`packages/contracts/src/governance/unproven-tx.ts:68`)
passes `SigningKey` (non-nullable), so this change is backward-compatible
for current callers. Any caller that was passing null and relying on getting
`Some(null)` was already in a broken state.