### PR TITLE
fix(level-private-state-provider): eliminate PBKDF2 re-derivation on cache hits

### DIFF
--- a/packages/level-private-state-provider/src/level-private-state-provider.ts
+++ b/packages/level-private-state-provider/src/level-private-state-provider.ts
@@ -46,8 +46,10 @@ import {
   decryptValue,
   getPasswordFromProvider,
   type PrivateStoragePasswordProvider,
-  StorageEncryption
+  StorageEncryption,
+  timingSafeEqual
 } from './storage-encryption';
+import { hmac } from '@noble/hashes/hmac.js';
 
 /**
  * The default name of the indexedDB database for Midnight.
@@ -205,6 +207,14 @@ const METADATA_KEY = '__midnight_encryption_metadata__';
 
 const DEFAULT_MAX_ROTATION_ENTRIES = 10000;
 
+// Per-process key for password fingerprinting — random at startup, never persisted.
+// Cache hits are validated with HMAC-SHA256(PROCESS_KEY, password + ":" + saltHex)
+// instead of re-running PBKDF2 (600 000 iterations) on every access.
+const PROCESS_KEY = randomBytes(32);
+
+const computePasswordFingerprint = (password: string, saltHex: string): Uint8Array =>
+  hmac(sha256, PROCESS_KEY, new TextEncoder().encode(`${password}:${saltHex}`));
+
 const encryptionInitPromises = new Map<string, Promise<Buffer>>();
 
 const passwordRotationLocks = new Map<string, Promise<void>>();
@@ -220,6 +230,7 @@ export interface PasswordRotationOptions {
 interface EncryptionCacheEntry {
   readonly encryption: StorageEncryption;
   readonly saltHex: string;
+  readonly passwordFingerprint: Uint8Array;
 }
 
 /**
@@ -279,21 +290,16 @@ const getOrCreateEncryption = async (
   const cacheKey = `${ctx.dbName}:${levelName}`;
   const salt = await getOrCreateSalt(ctx, levelName);
   const saltHex = salt.toString('hex');
+  const password = await getPasswordFromProvider(passwordProvider);
+  const fingerprint = computePasswordFingerprint(password, saltHex);
 
   const cached = encryptionCache.get(cacheKey);
-  if (cached && cached.saltHex === saltHex) {
-    const password = await getPasswordFromProvider(passwordProvider);
-    if (await cached.encryption.verifyPassword(password)) {
-      return cached.encryption;
-    }
-    const encryption = await StorageEncryption.create(password, { existingSalt: salt, cryptoBackend: ctx.cryptoBackend });
-    encryptionCache.set(cacheKey, { encryption, saltHex });
-    return encryption;
+  if (cached && cached.saltHex === saltHex && timingSafeEqual(fingerprint, cached.passwordFingerprint)) {
+    return cached.encryption;
   }
 
-  const password = await getPasswordFromProvider(passwordProvider);
   const encryption = await StorageEncryption.create(password, { existingSalt: salt, cryptoBackend: ctx.cryptoBackend });
-  encryptionCache.set(cacheKey, { encryption, saltHex });
+  encryptionCache.set(cacheKey, { encryption, saltHex, passwordFingerprint: fingerprint });
   return encryption;
 };
 

--- a/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
+++ b/packages/level-private-state-provider/src/test/level-private-state-provider.test.ts
@@ -1772,6 +1772,7 @@ describe('Level Private State Provider', (): void => {
 
     test('encryption instance is reused for multiple operations (caching works)', async () => {
       const verifyPasswordSpy = vi.spyOn(StorageEncryption.prototype, 'verifyPassword');
+      const createSpy = vi.spyOn(StorageEncryption, 'create');
       const config = {
         midnightDbName: CACHE_TEST_DB,
         privateStoragePasswordProvider: () => TEST_PASSWORD,
@@ -1781,18 +1782,22 @@ describe('Level Private State Provider', (): void => {
       const db = levelPrivateStateProvider<string, string>(config);
       db.setContractAddress(CACHE_CONTRACT_ADDRESS);
 
+      // Cold path: StorageEncryption.create called once, verifyPassword never called
       await db.set('key-0', 'value-0');
+      expect(createSpy).toHaveBeenCalledTimes(1);
       expect(verifyPasswordSpy).not.toHaveBeenCalled();
 
+      // Warm path: HMAC fingerprint used — no verifyPassword, no additional create
       await db.set('key-1', 'value-1');
-      expect(verifyPasswordSpy).toHaveBeenCalledTimes(1);
-      await expect(verifyPasswordSpy).toHaveLastResolvedWith(true);
+      expect(createSpy).toHaveBeenCalledTimes(1);
+      expect(verifyPasswordSpy).not.toHaveBeenCalled();
 
       await db.set('key-2', 'value-2');
-      expect(verifyPasswordSpy).toHaveBeenCalledTimes(2);
-      await expect(verifyPasswordSpy).toHaveLastResolvedWith(true);
+      expect(createSpy).toHaveBeenCalledTimes(1);
+      expect(verifyPasswordSpy).not.toHaveBeenCalled();
 
       verifyPasswordSpy.mockRestore();
+      createSpy.mockRestore();
     });
 
     test('cache is invalidated when password changes', async () => {


### PR DESCRIPTION
## Summary

Fixes #1174.

`getOrCreateEncryption` called `StorageEncryption.verifyPassword()` on every warm-cache access. `verifyPassword` re-derives the PBKDF2 key at 600 000 iterations (~71 ms on Apple silicon) — the same cost as a cache miss. The cache eliminated zero KDF work, contradicting the comment at line 226 that documents it.

**Root cause:** the cache stored only the `StorageEncryption` instance and the salt hex; there was no cheap way to verify the incoming password matched the cached key, so `verifyPassword` ran a full derivation on every access.

**Fix:** store an `HMAC-SHA256(PROCESS_KEY, password:saltHex)` fingerprint alongside the cached `StorageEncryption`. Cache hits now do a constant-time fingerprint comparison (~microseconds) instead of a full PBKDF2 derivation.

Security properties:
- `PROCESS_KEY` is 32 random bytes generated once at module load, never persisted or logged.
- The fingerprint is worthless outside the current process.
- A wrong password (fingerprint mismatch) falls through to `StorageEncryption.create()`, which fails on the GCM auth tag exactly as before.
- The constant-time `timingSafeEqual` (already in this package) is used for the comparison.

Measured on Apple silicon, Node 22:

| | Before | After |
|---|---|---|
| Warm cache access | ~71 ms (full PBKDF2) | ~0 ms (HMAC compare) |
| `level-private-state-provider` unit suite | ~47 s | ~25 s |

The remaining ~25 s are genuine cold-cache derivations driven by test design (DBs wiped, passwords rotated, per-`accountId` level names) — addressed separately per the issue.

## Test plan

- [x] Existing unit suite passes (`packages/level-private-state-provider`) — 276/276 tests pass
- [x] Password-rotation tests still pass (wrong password → fingerprint mismatch → new derivation)
- [x] `invalidateEncryptionCache()` continues to work (cache cleared → cold path on next access)