### PR TITLE
fix(testkit-js): increase health check timeout from 1000ms to 15000ms

### DIFF
--- a/testkit-js/testkit-js/src/client/faucet-client.ts
+++ b/testkit-js/testkit-js/src/client/faucet-client.ts
@@ -43,7 +43,7 @@ export class FaucetClient {
    */
   async health() {
     const url = buildUrlWithPath(this.faucetUrl, '/api/health');
-    const response = await axios.get(url, { timeout: 1000 });
+    const response = await axios.get(url, { timeout: 15000 });
     this.logger.info(`Connected to faucet ${url}: ${JSON.stringify(response.data)}`);
     return response;
   }

--- a/testkit-js/testkit-js/src/client/indexer-client.ts
+++ b/testkit-js/testkit-js/src/client/indexer-client.ts
@@ -39,7 +39,7 @@ export class IndexerClient {
    */
   async health() {
     const url = buildUrlWithPath(this.indexerUrl, '/ready');
-    const response = await axios.get(url, { timeout: 1000 });
+    const response = await axios.get(url, { timeout: 15000 });
     this.logger.info(`Connected to indexer ${url}: ${JSON.stringify(response.data)}`);
     return response;
   }

--- a/testkit-js/testkit-js/src/client/node-client.ts
+++ b/testkit-js/testkit-js/src/client/node-client.ts
@@ -46,7 +46,7 @@ export class NodeClient {
    */
   async health() {
     const url = buildUrlWithPath(this.nodeURL, '/health');
-    const response = await axios.get(url, { timeout: 1000 });
+    const response = await axios.get(url, { timeout: 15000 });
     this.logger.info(`Connected to node ${url}: ${JSON.stringify(response.data)}`);
     return response;
   }

--- a/testkit-js/testkit-js/src/client/proof-server-client.ts
+++ b/testkit-js/testkit-js/src/client/proof-server-client.ts
@@ -39,7 +39,7 @@ export class ProofServerClient {
    */
   async health() {
     const url = buildUrlWithPath(this.proofServer, '/health');
-    const response = await axios.get(url, { timeout: 1000 });
+    const response = await axios.get(url, { timeout: 15000 });
     this.logger.info(`Connected to proof server ${url}: ${JSON.stringify(response.data)}`);
     return response;
   }


### PR DESCRIPTION
Fixes #<issue-number-you-filed-earlier>. Increases the hardcoded 1000ms axios timeout on testkit-js's 4 environment health checks (node, indexer, proof server, faucet) to 15000ms. 

The original timeout is too tight for real-world network conditions, especially WSL2/Docker Desktop setups, causing intermittent false-negative environment startup failures even when all endpoints are genuinely healthy.

Verified locally by patching the compiled bundle before submitting this source fix.