### PR TITLE
chore(midnight-js): stop republishing vendor API docs from protocol

### DIFF
--- a/packages/protocol/typedoc.json
+++ b/packages/protocol/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -19,16 +19,19 @@
       "ZKConfigProvider.getZKIR": "#"
     },
     "@midnightntwrk/ledger-v9": {
-      "ProvingProvider": "#"
+      "*": "https://github.com/midnightntwrk/midnight-ledger"
     },
     "@midnight-ntwrk/compact-js": {
       "": "#"
+    },
+    "@midnight-ntwrk/compact-runtime": {
+      "*": "https://github.com/LFDT-Minokawa/compact"
     },
     "@midnight-ntwrk/platform-js": {
       "ContractAddress": "#"
     },
     "@midnightntwrk/onchain-runtime-v4": {
-      "ContractAddress": "#"
+      "*": "https://github.com/midnightntwrk/midnight-ledger"
     },
     "@apollo/client": {
       "ApolloClient": "#"

--- a/typedoc.json
+++ b/typedoc.json
@@ -22,13 +22,13 @@
       "*": "https://github.com/midnightntwrk/midnight-ledger"
     },
     "@midnight-ntwrk/compact-js": {
-      "": "#"
+      "*": "https://github.com/midnightntwrk/midnight-sdk"
     },
     "@midnight-ntwrk/compact-runtime": {
       "*": "https://github.com/LFDT-Minokawa/compact"
     },
     "@midnight-ntwrk/platform-js": {
-      "ContractAddress": "#"
+      "*": "https://github.com/midnightntwrk/midnight-sdk"
     },
     "@midnightntwrk/onchain-runtime-v4": {
       "*": "https://github.com/midnightntwrk/midnight-ledger"


### PR DESCRIPTION
## Summary

`packages/protocol` was the only package in the repo without its own
`typedoc.json`. It therefore inherited the root config, which does not extend
`typedoc.base.json` and so has no `excludeExternals`. TypeDoc expanded every
vendor namespace the barrel re-exports, and `docs/api` held **700 markdown
files** for this package: ledger 227, compact-runtime 149, compact-js 136,
onchain-runtime 102, platform-js 80, namespaces 5, README 1. All of it is other
projects' API documentation, republished here.

This also contradicted the repo's own configuration: root `typedoc.json`
already declares those packages external in `externalSymbolLinkMappings`, so
the config said "external, do not link" while the output published 136 pages of
compact-js.

- Add `packages/protocol/typedoc.json` extending `typedoc.base.json`, matching
  all 11 sibling packages. No `readme` key, so TypeDoc keeps using
  `packages/protocol/README.md` as the landing page. No `projectDocuments` — a
  glob matching no file emits a warning, and it belongs to the follow-up.
- Extend `externalSymbolLinkMappings` so cross-package type references keep a
  link target: `"*"` per vendor package, pointing at the public upstream.

### Measured effect

The baseline run confirmed `docs/api` on `main` is an exact reproduction of the
source (`git status --porcelain docs` = 0 before any change), so every number
below is attributable to this change alone.

| | before | after |
|---|---|---|
| protocol markdown files | 700 | 1 (`README.md`) |
| TypeDoc warnings | 54 | 34 |
| `Failed to resolve link` | 19 | 8 |

Zero new warnings (`comm -13` against the baseline set is empty). 20
pre-existing warnings were resolved, because 11 of them only existed inside
protocol's vendor pages.

### The mappings are load-bearing, not cosmetic

With the package config alone, warnings rose to 73 — **39 new ones**, each
naming the exact mapping key TypeDoc wanted, e.g.:

```
The comment for @midnight-ntwrk/midnight-js-utils.deserializeContractState
links to "LedgerContractState" which was resolved but is not included in the
documentation. To fix this warning export it or add
{ "@midnightntwrk/ledger-v9": { "ContractState": "#" }} to the
externalSymbolLinkMappings option
```

Adding the mappings removed all 39. Without them this change would have been a
regression.

### Why `"*"` rather than an enumerated symbol list

The symbol list was measured first — 707 cross-package links resolved to 45
ledger symbols, 8 onchain-runtime, 1 compact-runtime — and the enumerated
55-entry form was implemented and verified. It was then replaced by `"*"` per
package only after proving equivalence:

- `typedoc/dist/lib/converter/converter.js:282-287` performs exactly two
  lookups, the exact symbol name and then the literal key `"*"`;
- the entire 645-file generated tree is **byte-identical** between the
  enumerated and wildcard forms (`shasum -a 256` over all files);
- identical warning set, identical 369 links to `midnight-ledger` and 8 to
  `LFDT-Minokawa/compact`, and no relative link into a protocol subpage.

`"*"` also means a newly-referenced vendor symbol will not open a fresh warning
requiring another PR.

### Deliberately not changed

- Every vendor mapping now points at a real public repo. `compact-js` and
  `platform-js` *publish* from the private `midnight-ntwrk/artifacts` repo —
  which is what their `package.json` `repository` field names — but their
  SOURCES are public: `midnightntwrk/midnight-sdk` holds `compact-js/` and
  `platform-js/` directories and is a public repo. So they were given a `"*"`
  target too, in a second commit. No `](#)` anchors remain.
- Neither public upstream publishes a browsable API site (`has_pages: false`
  for both), so the mappings point at repo roots rather than fabricated deep
  links.
- **`docs/` is not committed.** It is generated and owned by
  `.github/workflows/docs-api.yml`, which runs on push to `main` and opens its
  own PR with a commit signed through the GitHub API. The diff above is what
  that workflow will produce after this merges.

### The dead `""` key, fixed here

`@midnight-ntwrk/compact-js` mapped `"": "#"`. Per the resolver source that key
was dead — it can only match a symbol literally named `""` — so its ~318
references rendered as plain text. It is replaced by a `"*"` wildcard pointing
at the public source repo, so those references now resolve.

### Correction to an earlier draft of this description

The first version of this text said `compact-js` and `platform-js` would keep
`"#"` because their upstream is private, and that 7 dead anchors were an
accepted cost. That is no longer what this branch does — see above. Issue #1221
carries the same superseded wording in its acceptance criteria; a comment there
records the change.

## Test plan

- [x] `yarn build` — 16/16 tasks successful
- [x] `yarn lint ./packages` — clean
- [x] `yarn test` — 27/27 tasks successful
- [x] `yarn build:markdown-docs` — zero new warnings, zero new
      `Failed to resolve link`
- [x] Drift baseline measured separately, so the reported numbers are this
      change's effect and not pre-existing staleness
- [x] `prettier --check` clean on both files
- [x] Diff is exactly two files; nothing under `docs/` committed
- [x] `gitnexus detect_changes` — 2 files, 0 changed symbols, 0 affected
      processes, risk low

## Links

Closes #1221
