### PR TITLE
docs(midnight-js): move protocol architecture rationale into package documents

### DIFF
--- a/docs/adr/0007-cross-the-era-boundary-with-plain-data-only.md
+++ b/docs/adr/0007-cross-the-era-boundary-with-plain-data-only.md
@@ -1,0 +1,114 @@
+# 0007. Cross the era boundary with plain data only
+
+- Status: Accepted
+- Date: 2026-09-04
+- Deciders: Szymon Paluchowski
+
+## Context
+
+`@midnight-ntwrk/midnight-js-protocol` co-installs two ledger WASM toolchains —
+`@midnightntwrk/ledger-v9` for the current era and `@midnightntwrk/ledger-v8`
+for the retained pre-fork one — alongside the retained pre-fork execution
+toolchain (`compact-runtime@0.16` and `@midnight-ntwrk/onchain-runtime-v3`).
+The package exists to let a caller work with a record from either era without
+knowing which era it holds.
+
+A WASM handle is not a value. It is a pointer into one module instance's linear
+memory, valid only there. Three properties follow, and all three shape this
+decision:
+
+- A handle from one module is meaningless in another. Where a vendor checks
+  (`wasm-bindgen`'s `_assertClass` in an argument position) it throws; where it
+  does not check — the receiver position — nothing is validated and a plausible
+  wrong value comes back. ADR-0004 already commits this package to exactly one
+  runtime path per era so a second copy cannot appear through it; a handle
+  passed across a seam would reintroduce the same failure mode between the two
+  *eras*, which are two distinct modules by construction rather than by
+  accident.
+- A handle outlives nothing. A caller holding one also holds the module that
+  produced it, and cannot put the value in a `structuredClone`, send it to a
+  worker, or persist it.
+- Handles from different eras are not comparable. Two results describing the
+  same contract state are two unrelated objects if each is a handle from its
+  own module.
+
+Against that, handles are the natural currency *inside* one era: the retained
+pre-fork execution pipeline down-converts a state, runs a circuit against it,
+and binds the transcript, and encoding between each of those steps would be
+pure cost.
+
+## Decision
+
+We will let no live WASM handle pass between two ledger eras. At every
+era-crossing point the value is encoded to plain data — a `Uint8Array`, or a
+plain object or tagged union over `Uint8Array`, `Map`, array and primitive —
+and the receiving side deserializes it into its own era.
+
+Two consequences of that rule are worth stating explicitly, because they look
+inconsistent until the rule is in view:
+
+- **`LedgerEra` trades only plain data, in both directions.** Its caller may
+  hold either era, so every value on that surface is era-crossing by
+  construction: `extractState` returns an `EncodedStateValue`,
+  `decodeContractState` a `ContractStatePojo`, `composeCallTx` a `Uint8Array`,
+  `composeDeployTx` a `DeployResultPojo` of bytes and a string. Inward too —
+  `composeEraV8DeployTx` (`src/lib/v8/adapt.ts`) hands the contract state to
+  the v8-native deploy leg as BYTES, which that leg deserializes into its own
+  era rather than accepting a handle.
+- **`Ledger8Engine` may hand back pre-fork handles, because it is bound to the
+  pre-fork era and says so.** `DownConvertedState.data` is an
+  `onchain-runtime-v3` `ChargedState`; `TranscriptPojo` carries two of them;
+  `ConstructorResultPojo.contractState` is a pre-fork state handle. These
+  circulate within the retained pipeline and never leave it. The one method on
+  that surface which does cross, `wrapKeepStateCall`, encodes first —
+  `transcript.preContractState.data.state.encode()` (`src/lib/v9/wrap.ts`) —
+  so the pre-fork handle never reaches the ledger-v9 module, only the plain
+  value it encoded to.
+
+The `LedgerEra` half is mechanised rather than left to convention:
+`era-parity.test.ts` (`packages/protocol/src/test/`) calls `structuredClone`
+over the result of all four methods, on both eras. A live WASM handle in any of
+them makes that clone throw, so the gate fails instead of the handle shipping.
+
+This is a transport rule, not an immutability rule. `readonly` on a result's
+members freezes each reference, not the bytes behind it, so a value that
+survives a `structuredClone` is not thereby protected from a caller writing
+through the arrays it carries. Immutability, where this package needs it, is
+bought separately by freezing the object.
+
+## Consequences
+
+- **Positive:** a result outlives the module that produced it and can be
+  cloned, transferred to a worker or persisted; results from the two eras are
+  structurally comparable, which is what makes the era-agnostic facade
+  worth having; no object is ever passed between two WASM copies, so the
+  dual-instantiation failure mode cannot be reached through a result even if a
+  duplicate install exists; the rule is stated once, mechanised on the surface
+  where it matters most, and checkable on the other by reading its return
+  types.
+- **Negative:** every era crossing pays an encode plus a decode, including the
+  `wrapKeepStateCall` encode on a path that is otherwise handle-to-handle; the
+  seam cannot hand back a rich vendor object even when caller and seam
+  demonstrably share one module copy; a caller that wants to operate on a
+  result has to deserialize it again; and the two surfaces genuinely differ,
+  so `readonly` and "Pojo" in a type name are not on their own evidence that a
+  value is plain — `TranscriptPojo` is `readonly` throughout and still carries
+  handles.
+- **Follow-ups:** none. A new operation on `LedgerEra` must return plain data;
+  a new one on `Ledger8Engine` may return a pre-fork handle only if it stays
+  inside the retained pipeline, and must encode at the point it does not.
+
+## Alternatives considered
+
+- **Pass live handles across the era boundary** — rejected: it ties a result's
+  lifetime to its module, makes the two eras' results incomparable, and
+  reintroduces the cross-copy failure ADR-0004's single-path rule exists to
+  prevent, this time between modules that are distinct by design.
+- **Plain data everywhere, including inside `Ledger8Engine`** — rejected: the
+  retained pipeline is three steps in one era, and encoding between each would
+  buy nothing. The cost is real (`downConvertForExecution` already re-encodes
+  once for its integrity check) and there is no boundary there to protect.
+- **Deep-freeze every result instead** — rejected: it answers a different
+  question. Freezing stops a caller mutating a value; it does nothing about
+  module lifetime, cloneability or cross-era comparability, which are what this
+  rule is for.

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -65,6 +65,28 @@ The directory names say what a module is **about**, not what it links. Three con
 
 `compose-types.ts` and `era.ts` name their shared types through `@midnightntwrk/ledger-v9` because some vendor has to name them. `EncodedStateValue`, `Op`, `AlignedValue` and `Transcript` are pinned identical across `onchain-runtime-v3`, `ledger-v8` and `ledger-v9` by the compile-time assertions in `v8-down-convert.test.ts`; the import names one era, the type belongs to neither. Those assertions are evaluated by `yarn typecheck:tests` on the pre-push hook, not by CI — vitest transpiles test files without type-checking, so treat a failure there as the only signal you will get.
 
+## Architecture Documents
+
+The reasoning behind this package's shape lives in `docs/`, not in the source
+docstrings. Each file is registered with TypeDoc through `projectDocuments`, so
+it is a page in the generated API reference and `@see {@link Title}` in a
+docstring resolves to it.
+
+| Document | What it explains |
+|---|---|
+| [Era seam](./docs/era-seam.md) | Why only bytes and plain objects cross between the eras, how the eight operations are split between `LedgerEra` and `Ledger8Engine`, and the memoisation rules |
+| [Retained-era execution](./docs/retained-era-execution.md) | The down-conversion stages, the Merkle rehash requirement, the era pin, and what a `TranscriptPojo` carries |
+| [Dual-instantiation guard](./docs/dual-instantiation-guard.md) | What a duplicate WASM install does in the argument position versus the receiver position, and why the guard is a correctness requirement rather than a diagnostic |
+| [Fail-closed decoding](./docs/fail-closed-decoding.md) | Why the envelope is the only authority over the bytes, and the division of labour between the three decode failures |
+| [Compose refusal order](./docs/compose-refusal-order.md) | The order in which both era arms refuse compose options, and the one deliberate difference between them |
+| [Verifier keys](./docs/verifier-keys.md) | Registration rules, the refusals that stop a deploy landing at an address the caller's artifacts do not describe, and why the address cannot be recomputed |
+| [Module graph and lazy loading](./docs/module-graph-and-lazy-loading.md) | Build entries, the `./v8` and `./engine` chunks, the import cycle avoided by a leaf module, and derived versus structural vendor types |
+| [Shared table discipline](./docs/shared-table-discipline.md) | Why the shared tables are frozen and null-prototyped, and why exhaustiveness is enforced at compile time as well as at run time |
+
+Docstrings in `src/` carry the API contract: what a symbol does, its
+parameters, what it returns and what it throws. Anything that answers "why is
+it built this way" belongs in a document above, stated once.
+
 ## Accessing the v8 Ledger Era
 
 The `./v8` subpath re-exports the previous-era ledger (`@midnightntwrk/ledger-v8`), which carries its own WASM. To keep that WASM out of eagerly-loaded module graphs, runtime imports of `@midnight-ntwrk/midnight-js-protocol/v8` are blocked by ESLint everywhere outside this package. Use the lazy accessor instead:

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -80,7 +80,8 @@ docstring resolves to it.
 | [Fail-closed decoding](./docs/fail-closed-decoding.md) | Why the envelope is the only authority over the bytes, and the division of labour between the three decode failures |
 | [Compose refusal order](./docs/compose-refusal-order.md) | The order in which both era arms refuse compose options, and the one deliberate difference between them |
 | [Verifier keys](./docs/verifier-keys.md) | Registration rules, the refusals that stop a deploy landing at an address the caller's artifacts do not describe, and why the address cannot be recomputed |
-| [Module graph and lazy loading](./docs/module-graph-and-lazy-loading.md) | Build entries, the `./v8` and `./engine` chunks, the import cycle avoided by a leaf module, and derived versus structural vendor types |
+| [Module graph and lazy loading](./docs/module-graph-and-lazy-loading.md) | Build entries, the `./v8` and `./engine` chunks, the import cycle avoided by a leaf module, and why a vendor's types are named with `import type` |
+| [Injected vendor slices](./docs/injected-vendor-slices.md) | How a seam names the vendor class it takes by injection — derived from the vendor's own class, declared structurally, or narrowed — and what each choice buys |
 | [Shared table discipline](./docs/shared-table-discipline.md) | Why the shared tables are frozen and null-prototyped, and why exhaustiveness is enforced at compile time as well as at run time |
 
 Docstrings in `src/` carry the API contract: what a symbol does, its

--- a/packages/protocol/docs/compose-refusal-order.md
+++ b/packages/protocol/docs/compose-refusal-order.md
@@ -11,7 +11,7 @@ they refuse a caller's options, the one ordering difference that survives on
 purpose, what each arm accepts rather than refuses, and why every caller-caused
 failure leaves as a coded error rather than as a raw WASM failure. The
 verifier-key rules a deploy is validated against are a separate thread — see
-`VerifierKeys`.
+[VerifierKeys](./verifier-keys.md).
 
 The legs described here are `composeEraV8CallTx` / `composeEraV8DeployTx`
 (`packages/protocol/src/lib/v8/adapt.ts`), `composeV8CallTx`
@@ -258,8 +258,11 @@ produces state, never a proof.
 
 ## Injected era seams: narrowed, not derived
 
-The structural slices these legs are injected through are narrowed on purpose,
-and each narrowing is a different trade.
+The general rule these legs trade against is in [ModuleGraphAndLazyLoading](./module-graph-and-lazy-loading.md):
+derive an injected vendor slice from the vendor's own class where exactly one
+era can satisfy the shape, and declare it structurally where a seam serves both.
+Everything below is the compose legs' half of that — the slices here are
+narrowed on purpose, and each narrowing is a different trade.
 
 `CallAssemblyLedger` (`packages/protocol/src/lib/shared/assemble-call.ts`) is
 satisfied by both ledger modules with every type parameter inferred from the

--- a/packages/protocol/docs/compose-refusal-order.md
+++ b/packages/protocol/docs/compose-refusal-order.md
@@ -1,0 +1,318 @@
+---
+title: ComposeRefusalOrder
+---
+
+# The composition contract: refusal order
+
+Both era arms of this package compose the same two transaction kinds — a
+contract call and a contract deploy — from the same facade options. This
+document records the contract the two arms hold in common: the order in which
+they refuse a caller's options, the one ordering difference that survives on
+purpose, what each arm accepts rather than refuses, and why every caller-caused
+failure leaves as a coded error rather than as a raw WASM failure. The
+verifier-key rules a deploy is validated against are a separate thread — see
+`VerifierKeys`.
+
+The legs described here are `composeEraV8CallTx` / `composeEraV8DeployTx`
+(`packages/protocol/src/lib/v8/adapt.ts`), `composeV8CallTx`
+(`packages/protocol/src/lib/v8/compose.ts`), `composeV8DeployTx`
+(`packages/protocol/src/lib/v8/deploy.ts`), `composeV9CallTx` /
+`composeV9DeployTx` (`packages/protocol/src/lib/v9/compose.ts`), and the shared
+pieces under `packages/protocol/src/lib/shared/`.
+
+`composeV8CallTx` is the "same-era" leg: both the circuit's execution and the
+call it produces are bound entirely on the ledger-v8 axis, as opposed to
+`wrapKeepStateCall` (`packages/protocol/src/lib/v9/wrap.ts`), which binds a
+retained-execution transcript natively onto the current ledger-v9 axis instead.
+
+## Refusal order on both era arms
+
+Both arms refuse a caller's options in the SAME order: the envelope, then the
+call list, then the offers, then the era's own limits, then the state. A caller
+handing both an empty network id and unreadable offer bytes has one defect to
+fix per era, not a different one per era.
+
+Holding that order is why the v8 era arm checks the envelope and the call list
+itself rather than leaving either to the inner v8 leg it delegates to. The inner
+leg checks the envelope again; the check is idempotent, and leaving it there is
+what keeps `composeV8CallTx` and `composeV8DeployTx` safe to call directly.
+
+Both offers are read before anything is composed, so a caller handed bad offer
+bytes learns that instead of paying for a full assembly first. On the v9 call
+leg the transaction-wide options are all checked up front in the same way, while
+each call's own contract state is read as that call is assembled — so a bad
+state late in a call tree is reported after the earlier calls have already been
+built. Nothing is emitted either way: the throw discards the whole intent.
+
+## The one deliberate ordering difference
+
+Both deploy legs check the envelope first and the offer second, but the v9 leg
+reads the state before it looks at `verifierKeys`, and the v8 era arm cannot:
+the state is read by the leg it delegates to, and reading it in the arm as well
+would deserialize the same bytes twice.
+
+So a deploy that is BOTH unreadable and missing its key map reports
+`'contractState'` on v9 and `'verifierKeys'` on v8. Both name a real defect in
+the same call, and closing the gap costs a redundant deserialization of every
+deploy in order to reorder a diagnosis for a caller who has two things to fix
+either way.
+
+## Envelope options: well-formedness, never policy
+
+`assertComposeEnvelope` (`packages/protocol/src/lib/shared/compose-options.ts`)
+rejects the two envelope options the ledger accepts but should not: an empty
+`networkId`, and a `ttl` that is not a valid instant. Both are silently absorbed
+by the WASM — an empty network id is baked into the transaction, and an Invalid
+Date is recorded as the Unix epoch, yielding a transaction that has already
+expired the moment it is composed. Neither surfaces until submission, so both
+are refused here.
+
+This validates well-formedness only, never policy: which network a deployment
+targets and how long a transaction should live remain the caller's decisions.
+
+## Zswap offers are carried on both eras
+
+A Zswap offer is not refused on either era. The retained era executes
+coin-moving circuits and hands their post-call Zswap local state back on the
+transcript, which is what a caller turns into the offer it passes here
+(`zswapStateToSegmentedOffer`,
+`packages/contracts/src/utils/zswap-utils.ts`). Refusing the offer on the
+retained era would take away the only way to attach those coin movements to the
+transaction that carries the call.
+
+An absent offer is the normal shape of a call that moved no shielded coins, and
+stays absent. Bytes an era cannot decode are reported as `ComposeOptionError`
+with option `'zswapOffer'` — the same wrapping the other arm applies to the
+identical call. The same symmetry holds for the contract state: both arms wrap a
+rejected state as `ComposeOptionError` with option `'contractState'` rather than
+letting a raw decoder failure escape.
+
+That option error is deliberately not the class `extractEncodedStateValue`
+(`packages/protocol/src/lib/era/envelope.ts`) raises for its own decode: a state
+that cannot be READ is a different fault from an option that cannot be USED, and
+the two carry different remediations.
+
+Inside a v8-native leg the offers are v8-native offer HANDLES rather than bytes:
+that leg runs inside the retained era with the module already in hand, so the
+era arm that read the caller's offer bytes hands the decoded offer straight
+over — exactly as it already does for `contractState`.
+
+## One call per v8 transaction
+
+One shape the facade allows is not expressible on the retained era and is
+refused rather than silently narrowed: a call tree with more than one entry. A
+cross-contract call is a ledger-9-only feature that a pre-fork contract cannot
+emit at all, so this era has no call tree to compose, and composing only the
+first entry would drop the rest without a word.
+
+## Unshielded payouts fail closed
+
+`extractUserAddressedOutputs`
+(`packages/protocol/src/lib/shared/unshielded.ts`) reads the UTXO outputs a
+call's transcript claims on behalf of USERS.
+
+A contract-addressed claimed spend is skipped, and cross-contract calls make
+that a normal, expected case rather than an oddity. It is safe to skip because a
+cross-contract transfer is never materialized as a UTXO: the ledger settles it
+against the callee's own balance update, under the `real_unshielded_spends`
+superset check, and `UtxoOutput.owner` takes a user address in the first place.
+Emitting an output for one would add a payout the transaction cannot cover.
+
+A user-addressed spend this seam cannot pay out is REFUSED, not skipped. That is
+a different case from a contract-addressed spend, which is not a UTXO payout at
+all: this one is a payout the transaction has no way to make. Dropping it
+silently composes a transaction that tells the user they were paid and pays them
+nothing, so it leaves as a coded failure at composition time instead. Two token
+types reach that refusal — dust, which carries no raw token type to pay out in
+(`'call-dust-payout'`), and a shielded type, whose value moves through a Zswap
+offer rather than a UTXO (`'call-unsupported-payout'`).
+
+The check is on the ONE type this seam can pay out rather than on a list of the
+ones it cannot. `TokenType` is a vendor union, and a shielded type carries a
+`raw` field exactly as an unshielded one does, so an
+exclude-what-we-know-about test emits a plausible-looking `UtxoOutput` for
+everything it has not heard of. A fourth member added by a vendor bump has to
+fail closed here, not compose a payout nothing can settle.
+
+An absent transcript is the normal shape of a call with no fallible half, not an
+error, so it yields no outputs rather than throwing.
+
+`aggregateUnshieldedOffers` builds the one offer each segment carries from EVERY
+call in the tree. A user-addressed output can be produced by any call, not just
+the root, and a transaction has a single guaranteed and a single fallible offer.
+Assembling either from the root call alone would drop a cross-contract callee's
+payout and leave the transaction unbalanced — rejected on submission, with
+nothing having reported a problem at composition time. A segment with nothing to
+pay out gets no offer at all rather than an empty one: the ledger expects the
+field left unset, not a declared offer paying out nothing.
+
+Both era legs read the partitioned pairs back off the intent rather than
+re-deriving them: those are the exact transcripts the transaction now carries,
+so the offers cannot describe a different partition than the calls do. A
+user-addressed payout has to be attached on BOTH eras, or a call that pays one
+out composes into an unbalanced transaction the node rejects on submission, with
+nothing having reported a problem at composition time.
+
+## Resolving a call's transcript pair
+
+A partitioned source is passed through untouched — the whole point of the shape.
+Re-partitioning it would need a query context the caller no longer has, to redo
+work compact-js already did. Only the CALLER-supplied pair is checked for
+emptiness: an empty pair coming back from the module's own partitioner is that
+module's answer for the program it was handed, and this seam does not overrule
+it. A partitioned source carrying neither half is different — it is a caller
+with nothing to compose, and a prototype built from it would claim a circuit ran
+while recording no operations, the same silent no-op `'call-empty'` refuses one
+level up.
+
+An unpartitioned source is bridged into the module's own `QueryContext` and
+split there, in two steps: the state crosses as an envelope, then the context
+the call recorded is written onto it. Constructing a `QueryContext` restores the
+STATE and nothing else, so a context carrying only the state would partition the
+program against one the circuit never ran on. `bridgePartitionContext` performs
+the step compact-js's own v9 leg performs before it partitions
+(`ContractExecutable.js`: `asLedgerQueryContext` sets `block` and `effects`,
+`partitionAllTranscripts` folds the commitment indices), in that same order —
+set the two members, then fold. `insertCommitment` returns a new context
+carrying whatever was already set, so the fold's result is what everything
+downstream uses, never the context it started from.
+
+The state crossing is safe, not a lossy re-encode: the `EncodedStateValue`
+algebra is structurally identical between onchain-runtime-v3 and both ledger
+modules (compile-time drift gate in `v8-down-convert.test.ts`). Every member of
+the recorded context is caller data the runtime validates itself, from inside
+wasm, so the caller wraps the bridge in its own coded stage.
+
+## Coded failures, and the one that is not
+
+Every failure a caller can cause on this seam is coded. On the call path an
+empty call list is refused with `ComposeFailedError` at stage `'call-empty'`,
+and an unreadable contract state, Zswap offer, network id or ttl with
+`ComposeOptionError`; the shared assembler contributes `'call-operation'`,
+`'call-verifier-key'`, `'call-contract-state'`, `'call-transcript-empty'`,
+`'call-partition-context'`, `'call-partition'` and `'call-prototype'`, and a
+payout the transaction cannot settle surfaces as `'call-dust-payout'` or
+`'call-unsupported-payout'`.
+
+Three of those stages exist because the raw failure underneath them starts
+inside wasm. The public transcript is caller data in the ledger's own declared
+algebra, and nothing type-checks an op's operand into range, so the partitioner
+rejects a hand-built or re-encoded sequence with a raw runtime error; coding it
+means a caller catches the same shape it catches for every other caller fault
+here. The prototype construction is wrapped as ONE step rather than per
+argument: the constructor re-reads the transcript pair, the private outputs and
+the input/output values, all of which are caller data that nothing
+range-checks, and the failure a caller needs to act on is the same whichever
+field the runtime tripped over — the runtime's own message on `cause` names it.
+A partitioned pair is the sharpest case there, having never passed through this
+process's own partitioner.
+
+Which stage names a failed operation lookup is the CALLER's choice, passed in as
+`stage` and narrowed to `CallResolutionStage`: the assembler only ever resolves
+a call's operation, so a caller cannot ask it to report a deploy stage. Every
+other stage the assembler can raise it chooses itself. `'call-verifier-key'` in
+particular is not a caller choice, because the diagnosis does not differ by leg:
+an operation without a key is unusable on either ledger axis, and composing the
+call anyway would produce one no ledger could verify.
+
+The prototype carries the canonical, contract-qualified key location this
+framework's provers resolve artifacts by (see `encodeContractKeyLocation` and
+`ZKConfigRegistry`). A bare circuit id is ambiguous across contracts and
+`parseContractKeyLocation` rejects it, so a call carrying one cannot be proven
+through the registry or the DApp-connector path.
+
+There is exactly one deliberate exception to the coding rule:
+`partitionTranscripts` returning nothing for the single call submitted is an
+internal invariant of the ledger module, not a caller error, so that one throws
+a plain `Error` and deliberately carries no protocol error code.
+
+## One stage union across both eras
+
+`ComposeStage` (`packages/protocol/src/errors.ts`) is a single union covering
+both arms rather than one union per era, and the era a failure happened on is
+carried separately, on the error's `version` field. Every stage but
+`'wrap-call'` is reachable on both eras, so folding the era into the stage would
+nearly double the union without adding a distinction any caller wants to
+`switch` on. `'wrap-call'` is the exception because the operation it names is
+itself fork-crossing: it binds a pre-fork transcript onto a v9 state, so it is
+only ever raised for `'v9'`.
+
+## Segment ids: fixed for deploys, randomized for calls
+
+Both eras' call legs use `Transaction.fromPartsRandomized`, so the intent lands
+at a random segment id and stays mergeable with other calls — matching the v9
+call path in `packages/contracts/src/utils/ledger-utils.ts`. Both deploy legs
+use `Transaction.fromParts` instead, so the intent lands at a fixed segment id,
+matching `createUnprovenLedgerDeployTx` in the same file, which the v9 deploy
+path already does. Only calls randomize their segment, and only to stay
+mergeable.
+
+## Composition never proves
+
+No leg here proves the transaction it returns: the bytes are an UNPROVEN,
+tag-prefixed serialization, exactly what `Transaction.serialize()` produces
+before `.prove()` is ever called. Proving needs a proving provider and a running
+proof server, neither of which this seam has. That holds for the deploy legs
+too, including the constructor execution that feeds them — a constructor
+produces state, never a proof.
+
+## Injected era seams: narrowed, not derived
+
+The structural slices these legs are injected through are narrowed on purpose,
+and each narrowing is a different trade.
+
+`CallAssemblyLedger` (`packages/protocol/src/lib/shared/assemble-call.ts`) is
+satisfied by both ledger modules with every type parameter inferred from the
+module namespace itself, so callers pass the module and never spell out type
+arguments. Its `AlignedValue` / `Op` / `EncodedStateValue` / `Transcript`
+payload types are declared once against ledger-v9: they are structurally
+identical across onchain-runtime-v3, ledger-v8 and ledger-v9, pinned by the
+compile-time drift gate at the bottom of `v8-down-convert.test.ts`, which covers
+all three axes. `Transcript` is spelled out rather than left as a type parameter
+because a call can arrive with its transcript ALREADY partitioned, in which case
+the pair comes from the caller rather than from the module's own partitioner —
+so there is no module-bound type left to infer it from.
+`PartitionableQueryContext` is generic in `TSelf` because `insertCommitment`
+returns a NEW context rather than mutating, which keeps the fold typed as the
+module's own context instead of widening to the interface.
+
+The recorded query context a call carries travels the same way.
+`PartitionContext`'s `CallContext` and `Effects`
+(`packages/protocol/src/lib/shared/compose-types.ts`) are likewise declared once
+against ledger-v9 and are structurally identical on all three axes, pinned by
+the compile-time drift gate in `engine-down-convert.test.ts`.
+
+`CallOperationRegistry`'s `TOperation` is constrained to the one property the
+assembler inspects. Both eras' `ContractOperation` declare `verifierKey` as a
+required `Uint8Array`, but a slot that was never assigned one reads back
+`undefined` — pinned by the operation-resolution tests, so a vendor change fails
+a test rather than silently disabling the verifier-key check.
+
+`UnshieldedOfferLedger` stays a hand-written slice because the function above it
+genuinely runs on BOTH eras: the v9 arm passes ledger-v9, the v8 leg passes the
+module `loadLedger8` handed it, and deriving the shape from either era's class
+would pick a side. Its `inputs` and `signatures` are typed `never[]` rather than
+the ledger's own parameter types, because this seam only ever aggregates
+OUTPUTS, so `[]` is the only value that can be passed and the type says so
+instead of a comment.
+
+The v8 deploy seam goes the other way where it can.
+`Ledger8DeployableContractState` is a `Pick` of the vendor's own class rather
+than a restatement of its one member, so a change to `serialize` in
+onchain-runtime-v3 fails this build; but picking one member keeps it
+structurally loose enough that unrelated serializables satisfy it, which is what
+lets tests substitute a fake instead of invoking real WASM. The type therefore
+does not enforce that the bytes are a contract state at all — whichever deploy
+leg receives them is what turns that residual risk into a legible error rather
+than a raw decoder failure. `Ledger8ConstructorRuntime` is narrowed rather than
+derived from the retained glue's own `createConstructorContext`: that one is
+generic in the private state and returns a `ConstructorContext`, a shape this
+seam never inspects, since it only hands the value straight back to the
+contract's `initialState`. Typing it as the glue's would force every constructor
+test to build a real context to check plumbing it does not read, so the return
+stays `unknown` and `v8-deploy.test.ts` pins that the real glue satisfies the
+narrowing.
+
+The `version` every failure names is passed rather than inferred from the ledger
+module, for the same reason: the assembler is generic over the module, so it has
+no way to ask which axis it was handed.

--- a/packages/protocol/docs/compose-refusal-order.md
+++ b/packages/protocol/docs/compose-refusal-order.md
@@ -256,66 +256,10 @@ proof server, neither of which this seam has. That holds for the deploy legs
 too, including the constructor execution that feeds them — a constructor
 produces state, never a proof.
 
-## Injected era seams: narrowed, not derived
+## Injected era seams
 
-The general rule these legs trade against is in [ModuleGraphAndLazyLoading](./module-graph-and-lazy-loading.md):
-derive an injected vendor slice from the vendor's own class where exactly one
-era can satisfy the shape, and declare it structurally where a seam serves both.
-Everything below is the compose legs' half of that — the slices here are
-narrowed on purpose, and each narrowing is a different trade.
-
-`CallAssemblyLedger` (`packages/protocol/src/lib/shared/assemble-call.ts`) is
-satisfied by both ledger modules with every type parameter inferred from the
-module namespace itself, so callers pass the module and never spell out type
-arguments. Its `AlignedValue` / `Op` / `EncodedStateValue` / `Transcript`
-payload types are declared once against ledger-v9: they are structurally
-identical across onchain-runtime-v3, ledger-v8 and ledger-v9, pinned by the
-compile-time drift gate at the bottom of `v8-down-convert.test.ts`, which covers
-all three axes. `Transcript` is spelled out rather than left as a type parameter
-because a call can arrive with its transcript ALREADY partitioned, in which case
-the pair comes from the caller rather than from the module's own partitioner —
-so there is no module-bound type left to infer it from.
-`PartitionableQueryContext` is generic in `TSelf` because `insertCommitment`
-returns a NEW context rather than mutating, which keeps the fold typed as the
-module's own context instead of widening to the interface.
-
-The recorded query context a call carries travels the same way.
-`PartitionContext`'s `CallContext` and `Effects`
-(`packages/protocol/src/lib/shared/compose-types.ts`) are likewise declared once
-against ledger-v9 and are structurally identical on all three axes, pinned by
-the compile-time drift gate in `engine-down-convert.test.ts`.
-
-`CallOperationRegistry`'s `TOperation` is constrained to the one property the
-assembler inspects. Both eras' `ContractOperation` declare `verifierKey` as a
-required `Uint8Array`, but a slot that was never assigned one reads back
-`undefined` — pinned by the operation-resolution tests, so a vendor change fails
-a test rather than silently disabling the verifier-key check.
-
-`UnshieldedOfferLedger` stays a hand-written slice because the function above it
-genuinely runs on BOTH eras: the v9 arm passes ledger-v9, the v8 leg passes the
-module `loadLedger8` handed it, and deriving the shape from either era's class
-would pick a side. Its `inputs` and `signatures` are typed `never[]` rather than
-the ledger's own parameter types, because this seam only ever aggregates
-OUTPUTS, so `[]` is the only value that can be passed and the type says so
-instead of a comment.
-
-The v8 deploy seam goes the other way where it can.
-`Ledger8DeployableContractState` is a `Pick` of the vendor's own class rather
-than a restatement of its one member, so a change to `serialize` in
-onchain-runtime-v3 fails this build; but picking one member keeps it
-structurally loose enough that unrelated serializables satisfy it, which is what
-lets tests substitute a fake instead of invoking real WASM. The type therefore
-does not enforce that the bytes are a contract state at all — whichever deploy
-leg receives them is what turns that residual risk into a legible error rather
-than a raw decoder failure. `Ledger8ConstructorRuntime` is narrowed rather than
-derived from the retained glue's own `createConstructorContext`: that one is
-generic in the private state and returns a `ConstructorContext`, a shape this
-seam never inspects, since it only hands the value straight back to the
-contract's `initialState`. Typing it as the glue's would force every constructor
-test to build a real context to check plumbing it does not read, so the return
-stays `unknown` and `v8-deploy.test.ts` pins that the real glue satisfies the
-narrowing.
-
-The `version` every failure names is passed rather than inferred from the ledger
-module, for the same reason: the assembler is generic over the module, so it has
-no way to ask which axis it was handed.
+The slices these legs take by injection — `CallAssemblyLedger`,
+`PartitionableQueryContext`, `CallOperationRegistry`, `UnshieldedOfferLedger`
+and the v8 deploy seam's two — are narrowed, and each narrowing is a different
+trade. How they are typed, and what each trade buys, is in
+[InjectedVendorSlices](./injected-vendor-slices.md).

--- a/packages/protocol/docs/dual-instantiation-guard.md
+++ b/packages/protocol/docs/dual-instantiation-guard.md
@@ -1,0 +1,177 @@
+---
+title: DualInstantiationGuard
+---
+
+# The dual-instantiation guard
+
+`assertSharedLedger8Instance` (`packages/protocol/src/lib/v8/instance-guard.ts`)
+fails fast on a dual-instantiation of a WASM package the down-convert engine
+depends on, along one named `axis`. This document records what a
+dual-instantiation actually does to a running process, why the guard is a
+correctness requirement rather than a diagnostics improvement, and why each
+detail of its shape — reference equality, a shared binding, two acquisition
+paths, a nullish check ahead of the comparison, a validated axis — is the way it
+is.
+
+## What a duplicate install actually produces
+
+A duplicate install resolves to two physically distinct module instances — same
+shape, different WASM linear memory, different classes. What happens when they
+mix depends on which position the foreign object is in, and only one of the two
+is checked.
+
+## Argument position: wasm-bindgen throws
+
+As an **argument** to a wasm-bound function, wasm-bindgen emits `_assertClass`,
+which throws `expected instance of <Class>`. Loud, though deep inside a decode
+and naming neither the package nor the duplicate install.
+
+That is the whole reason `Ledger8InstanceMismatchError` exists. Mixing copies
+does not corrupt results silently in this direction: wasm-bindgen emits an
+`_assertClass` check on every object handed across a class boundary, so a
+cross-copy handoff throws `expected instance of <Class>`. That failure is loud
+but opaque — it names neither the package nor the duplicate install. The error
+replaces it with one that does, at the point the two copies are first observed
+rather than deep inside a down-convert.
+
+## Receiver position: nothing is checked
+
+As the **receiver** of a wasm-bound method, nothing is checked. The glue reads
+`this.__wbg_ptr` and calls into its own linear memory with a pointer that
+belongs to the other copy's heap. Measured on the pinned version, that returns a
+plausible, wrong value: a cell built in one copy read back through the other's
+`encode()` yields different bytes with no error, and `type()` still reports the
+correct variant. Whether it happens to come back right depends on how the two
+heaps line up, so it is not reliably reproducible — and a test that passes proves
+nothing about production.
+
+## Why the guard is a correctness requirement, not a diagnostics improvement
+
+So this guard is not only a diagnosis-improver. For the receiver direction it is
+the only thing standing between a duplicate install and silently wrong contract
+state, which is why it must run before any state crosses the bridge rather than
+being treated as optional belt-and-braces.
+
+## Reference equality is the probe
+
+Reference equality is the probe: two references to the *same* physical copy are
+always `===`; two sourced from different physical copies never are, even at the
+same package version.
+
+## Pass a shared binding, never a module namespace object
+
+Pass a **shared binding** — a class the package exports, such as `ChargedState`
+or `StateValue` — never a module namespace object. A namespace is per-module, so
+a re-export produces a different one even when there is exactly one physical
+copy behind it; comparing namespaces would report a mismatch on a healthy
+install and send the user hunting a duplicate that does not exist. A re-export
+preserves the identity of the binding itself, which is why the binding is the
+sound probe and the namespace is not.
+
+## Two acquisition paths, and why the caller owns that
+
+Both probes are compared symmetrically — there is no expected side — so the two
+arguments are interchangeable. What matters is that they are obtained from **two
+different acquisition paths** (two distinct import specifiers, or an import
+versus a caller-supplied module). Passing the same binding twice satisfies the
+check trivially and proves nothing; the caller owns that, because nothing in the
+signature can enforce it.
+
+## A nullish probe is rejected before the comparison
+
+A nullish probe (`null`/`undefined`) on either side is rejected before the `===`
+comparison runs, rather than compared directly: two nullish values are always
+`===` to each other, so a caller that optional-chained a missing export on both
+sides (or simply forgot to pass a probe) would otherwise pass this fail-fast
+safety net by accident instead of failing it.
+
+It is reported as `Ledger8RuntimeInvalidError`, not as a mismatch: a missing
+probe is a binding the caller did not hand over, which is the same fault the
+envelope seam reports under that code. Calling it a dual-instantiation would
+assert two physical copies exist and send the reader to `npm why` after a
+duplicate that is not there.
+
+## The axis is validated before either probe is looked at
+
+`axis` is validated against the closed union before either probe is looked at,
+for the same reason `extractEncodedStateValue` validates `version`: it is only
+type-checked for TypeScript callers, and it selects the package names the
+remediation hint tells the reader to trace.
+
+`UnknownLedger8AxisError` is the counterpart of `UnknownLedgerVersionError` on
+the other closed union this package validates at a boundary, and it exists for
+the same untyped JavaScript consumers. The axis is not only a label: it selects
+the package names `Ledger8InstanceMismatchError` tells the reader to trace, so
+an unvalidated string would put an `Object.prototype` member where a package
+name belongs, and would land in an `axis` field consumers are told they can
+`switch` on.
+
+`requestedAxis` carries the offending value; like `requestedVersion` it is kept
+out of the message, because caller-supplied text is the one thing these errors
+never render.
+
+## Why `onchain-runtime-v3` is the only asserted axis
+
+An axis earns an assertion only when the package genuinely reaches this process
+through two acquisition paths.
+
+`'onchain-runtime-v3'` is the only member of `Ledger8InstanceAxis` because it is
+the only retained pre-fork package this one both depends on directly and can
+receive from a consumer's own resolution — a `compact-runtime` build that
+re-exports it, a bundler that failed to dedupe it, or the same version installed
+under both npm scopes while the scope migration runs. A new axis joins only when
+it gains a comparable second acquisition path.
+
+No other WASM package the engine module acquires has a comparable second
+acquisition path, so no other axis is asserted.
+
+## What the mismatch error carries, and what it does not
+
+`Ledger8InstanceMismatchError` is thrown when the same-named WASM package
+resolved to two physically distinct copies in this process (a
+dual-instantiation).
+
+`axis` names the package the check ran on. This is a direct assertion failure (a
+reference-equality mismatch), not a wrapped lower-level exception, so unlike
+`DownConvertFailedError` there is no `cause` to carry.
+
+The remediation names every mainstream package manager rather than the one this
+repo happens to use, because this package is consumed by dApps installed with
+all of them.
+
+## Naming both published npm scopes in the remediation hint
+
+`PUBLISHED_SCOPES` in `packages/protocol/src/errors.ts` holds the npm scopes
+this package and its retained pre-fork runtimes are published under, while the
+scope migration runs. The scope is held apart from the `/` on purpose, and
+joined only at `axisPackageNames`. The dual-publish
+(`.github/scripts/publish-public-npm.mjs`) rewrites the old scope to the new one
+inside built `.js`/`.d.ts` files as well as in `package.json`, matching on the
+scope *with* its trailing slash. A scoped package name written as one literal
+would therefore ship rewritten, collapsing the two names into one and turning a
+hint that names both scopes into one that names a single scope twice. Splitting
+the scope from the slash leaves the rewrite nothing to match; `errors.test.ts`
+holds that line.
+
+`AXIS_BARE_PACKAGE_NAMES` carries the unscoped npm name of each axis. Both
+published copies of an axis carry this same name under a different scope, so
+naming only one scope would point every consumer installed from the other at a
+package not in their tree.
+
+## Where the guard runs, and the mixed runtime it makes sound
+
+`createLedger8Engine` (`packages/protocol/src/lib/v8/engine.ts`) runs
+`assertSharedLedger8Instance` exactly once, on the `onchain-runtime-v3` axis: it
+compares this package's own copy against the copy the 0.16 glue resolves for its
+own dependency (a genuine second acquisition path — a duplicate install would
+resolve these differently), so a dual-instantiation fails loudly before any
+contract execution can silently corrupt on a physical-instance mismatch. Any
+acquisition failure surfaces through the facade
+(`packages/protocol/src/lib/v8/load-engine.ts`) as
+`Ledger8RuntimeMissingError`.
+
+The runtime object assembled immediately after that assertion takes
+`ContractState` from ocrt3 while the other two members come from the glue. That
+is sound only because the assertion above has already established the two are
+one physical copy: had they been distinct, it would have thrown rather than let
+a mixed runtime be assembled there.

--- a/packages/protocol/docs/dual-instantiation-guard.md
+++ b/packages/protocol/docs/dual-instantiation-guard.md
@@ -22,17 +22,15 @@ is checked.
 
 ## Argument position: wasm-bindgen throws
 
-As an **argument** to a wasm-bound function, wasm-bindgen emits `_assertClass`,
-which throws `expected instance of <Class>`. Loud, though deep inside a decode
-and naming neither the package nor the duplicate install.
+As an **argument** to a wasm-bound function, wasm-bindgen emits `_assertClass`
+on every object handed across a class boundary, so a cross-copy handoff throws
+`expected instance of <Class>`. Results are not corrupted silently in this
+direction.
 
-That is the whole reason `Ledger8InstanceMismatchError` exists. Mixing copies
-does not corrupt results silently in this direction: wasm-bindgen emits an
-`_assertClass` check on every object handed across a class boundary, so a
-cross-copy handoff throws `expected instance of <Class>`. That failure is loud
-but opaque — it names neither the package nor the duplicate install. The error
-replaces it with one that does, at the point the two copies are first observed
-rather than deep inside a down-convert.
+The failure is loud but opaque: it names neither the package nor the duplicate
+install, and it surfaces deep inside a decode. That is what
+`Ledger8InstanceMismatchError` exists to replace — the same fault, reported at
+the point the two copies are first observed and naming what to go and fix.
 
 ## Receiver position: nothing is checked
 
@@ -47,10 +45,10 @@ nothing about production.
 
 ## Why the guard is a correctness requirement, not a diagnostics improvement
 
-So this guard is not only a diagnosis-improver. For the receiver direction it is
-the only thing standing between a duplicate install and silently wrong contract
-state, which is why it must run before any state crosses the bridge rather than
-being treated as optional belt-and-braces.
+Improving that diagnosis is the lesser half of what the guard does. For the
+receiver direction it is the only thing standing between a duplicate install and
+silently wrong contract state, which is why it must run before any state crosses
+the bridge rather than being treated as optional belt-and-braces.
 
 ## Reference equality is the probe
 
@@ -178,17 +176,7 @@ a mixed runtime be assembled there.
 
 ## The one crossing this cannot affect
 
-Not every era crossing in the engine is exposed to a dual-instantiation. A
-crossing that passes BYTES rather than a handle is immune by construction,
-because no object is handed between the two physical copies at all.
-
-`Ledger8DeployableContractState` (`lib/v8/deploy.ts`) is that case: it is a
-`Pick` of the pre-fork `ContractState` narrowed to `.serialize()`, which is how
-a caller turns the handle `executeConstructor` returned into the bytes every
-deploy leg takes. Picking one member also keeps it structurally satisfiable by
-a test double, so the deploy tests need no real WASM.
-
-This is why the guard's blast radius is the crossings that pass handles, and
-why widening it to cover the byte crossings would assert something already
-true. The general rule about deriving versus narrowing an injected vendor slice
-is in [ModuleGraphAndLazyLoading](./module-graph-and-lazy-loading.md).
+A crossing that passes BYTES rather than a handle is immune by construction, so
+the guard's blast radius is the crossings that pass handles.
+`Ledger8DeployableContractState` (`lib/v8/deploy.ts`) is the byte case, and how
+it is typed is in [InjectedVendorSlices](./injected-vendor-slices.md).

--- a/packages/protocol/docs/dual-instantiation-guard.md
+++ b/packages/protocol/docs/dual-instantiation-guard.md
@@ -175,3 +175,20 @@ The runtime object assembled immediately after that assertion takes
 is sound only because the assertion above has already established the two are
 one physical copy: had they been distinct, it would have thrown rather than let
 a mixed runtime be assembled there.
+
+## The one crossing this cannot affect
+
+Not every era crossing in the engine is exposed to a dual-instantiation. A
+crossing that passes BYTES rather than a handle is immune by construction,
+because no object is handed between the two physical copies at all.
+
+`Ledger8DeployableContractState` (`lib/v8/deploy.ts`) is that case: it is a
+`Pick` of the pre-fork `ContractState` narrowed to `.serialize()`, which is how
+a caller turns the handle `executeConstructor` returned into the bytes every
+deploy leg takes. Picking one member also keeps it structurally satisfiable by
+a test double, so the deploy tests need no real WASM.
+
+This is why the guard's blast radius is the crossings that pass handles, and
+why widening it to cover the byte crossings would assert something already
+true. The general rule about deriving versus narrowing an injected vendor slice
+is in [ModuleGraphAndLazyLoading](./module-graph-and-lazy-loading.md).

--- a/packages/protocol/docs/era-seam.md
+++ b/packages/protocol/docs/era-seam.md
@@ -8,29 +8,18 @@ title: EraSeam
 the two ledger eras it supports. On one side a caller holds a `LedgerEra`
 object, or — for the operations only the retained pre-fork era can perform — a
 `Ledger8Engine`. On the other side sit two WASM toolchains that must never be
-mixed. This document records why that boundary is shaped the way it is: what
-kind of value is allowed to cross it, how the surface is split between the two
-objects, and how each side is acquired.
+mixed. This document records why that boundary is shaped the way it is: how the
+surface is split between the two objects, and how each side is acquired.
 
-## Only bytes and plain objects cross the seam
+## What may cross the seam
 
-Every value crossing the era boundary is plain data: `Uint8Array`s and plain
-objects, never a live WASM handle. That is what lets a caller hold a result
-without also holding the module that produced it, keeps the two eras' results
-comparable, and makes a result safe to send through a `structuredClone` or a
-worker boundary.
-
-The same discipline is applied in the inward direction, not only on the way
-out. In `composeEraV8DeployTx` the contract state crosses into the v8-native
-deploy leg by BYTES, which is what that leg takes: it deserializes into its own
-era rather than accepting a handle, so no object is passed between two WASM
-copies.
-
-That is a transport guarantee, not an immutability one. `readonly` on a result's
-members freezes each reference, not the bytes behind it, so a result that
-survives a `structuredClone` is not thereby protected from a caller writing
-through the arrays it carries. Where this package does need immutability it
-freezes the object itself — see [SharedTableDiscipline](./shared-table-discipline.md).
+What is allowed across the era boundary — plain data only, encoded at the
+crossing point, with handles free to circulate inside a single era — is decided
+in `docs/adr/0007-cross-the-era-boundary-with-plain-data-only.md`. That ADR also
+records why the rule is a transport guarantee and not an immutability one; where
+this package does need immutability it freezes the object itself, see
+[SharedTableDiscipline](./shared-table-discipline.md). This document does not
+restate the rule; it records how the surface is split and acquired given it.
 
 ## One surface, the same on both eras
 

--- a/packages/protocol/docs/era-seam.md
+++ b/packages/protocol/docs/era-seam.md
@@ -30,7 +30,7 @@ That is a transport guarantee, not an immutability one. `readonly` on a result's
 members freezes each reference, not the bytes behind it, so a result that
 survives a `structuredClone` is not thereby protected from a caller writing
 through the arrays it carries. Where this package does need immutability it
-freezes the object itself — see `SharedTableDiscipline`.
+freezes the object itself — see [SharedTableDiscipline](./shared-table-discipline.md).
 
 ## One surface, the same on both eras
 

--- a/packages/protocol/docs/era-seam.md
+++ b/packages/protocol/docs/era-seam.md
@@ -1,0 +1,164 @@
+---
+title: EraSeam
+---
+
+# The era seam
+
+`@midnightntwrk/midnight-js-protocol` puts one boundary between a caller and
+the two ledger eras it supports. On one side a caller holds a `LedgerEra`
+object, or — for the operations only the retained pre-fork era can perform — a
+`Ledger8Engine`. On the other side sit two WASM toolchains that must never be
+mixed. This document records why that boundary is shaped the way it is: what
+kind of value is allowed to cross it, how the surface is split between the two
+objects, and how each side is acquired.
+
+## Only bytes and plain objects cross the seam
+
+Every value crossing the era boundary is plain data: `Uint8Array`s and plain
+objects, never a live WASM handle. That is what lets a caller hold a result
+without also holding the module that produced it, keeps the two eras' results
+comparable, and makes a result safe to send through a `structuredClone` or a
+worker boundary.
+
+The same discipline is applied in the inward direction, not only on the way
+out. In `composeEraV8DeployTx` the contract state crosses into the v8-native
+deploy leg by BYTES, which is what that leg takes: it deserializes into its own
+era rather than accepting a handle, so no object is passed between two WASM
+copies.
+
+That is a transport guarantee, not an immutability one. `readonly` on a result's
+members freezes each reference, not the bytes behind it, so a result that
+survives a `structuredClone` is not thereby protected from a caller writing
+through the arrays it carries. Where this package does need immutability it
+freezes the object itself — see `SharedTableDiscipline`.
+
+## One surface, the same on both eras
+
+Both eras expose the SAME methods with the same signatures. Which era a
+`LedgerEra` object is bound to is readable from `LedgerEra.version` and nowhere
+else — a caller that has resolved the era for a record (see
+`protocolVersionToLedger` in `packages/protocol/src/version.ts`) hands that
+value to `loadLedgerEra` once and then writes era-agnostic code.
+
+The four operations on `LedgerEra` are the era-symmetric ones:
+
+| Operation | Why it is era-symmetric |
+|---|---|
+| `extractState` | Both eras read a state envelope they wrote. |
+| `decodeContractState` | Both eras decode to the same plain-data shape. |
+| `composeCallTx` | Both eras compose a call, with the same inputs. |
+| `composeDeployTx` | Both eras compose a deploy, with the same result shape. |
+
+Reading a contract state and composing a call or a deploy are era-symmetric
+operations: both eras do them, with the same inputs and the same result shape,
+so they belong on the era facade (`packages/protocol/src/lib/era/era.ts`) where
+a caller can reach them without knowing which era it holds.
+
+## What sits on `Ledger8Engine` instead
+
+`Ledger8Engine` is scoped to what only the retained era can do. What is left
+there after the era-symmetric operations have moved to the facade is the
+fork-crossing work:
+
+| Operation | Why it cannot sit on the era facade |
+|---|---|
+| `downConvertForExecution` | Down-converts a post-fork state for pre-fork execution. |
+| `executeCircuit` | Runs a pre-fork circuit. |
+| `executeConstructor` | Runs a pre-fork constructor. |
+| `wrapKeepStateCall` | Binds a pre-fork transcript natively onto v9. |
+
+`Ledger8Engine` is the public surface `createLedger8Engine` builds: the
+retained pre-fork EXECUTION capabilities, with the 0.16 runtime instance
+already captured in closure — no method there takes a runtime or module
+parameter.
+
+## Why the engine does not acquire the v8 ledger module
+
+`createLedger8Engine` deliberately does NOT acquire the v8 ledger module.
+Nothing on its surface needs it — call and deploy composition live on the era
+facade (`packages/protocol/src/lib/era/era.ts`), which acquires the module
+itself when a caller asks for the v8 era.
+
+A consumer that only executes circuits and binds them onto v9 therefore never
+instantiates the multi-megabyte v8 WASM, and never hard-depends on ledger-v8
+resolving. That property is gated by `v8-load-engine-laziness.test.ts`.
+
+## One memo slot per era
+
+`loadLedgerEra` is memoised per era, so the retained pre-fork WASM is
+instantiated at most once per process. `loadLedger8` and `loadLedger8Engine`
+memoise their own imports for the same reason, one slot each.
+
+The memoisation is one slot per era, not one shared slot. A shared slot would
+hand the second caller whichever era happened to be asked for first, silently
+reading one era's bytes with the other era's runtime — the exact confusion this
+facade exists to remove.
+
+## A failed acquisition is deliberately not memoised
+
+A FAILED v8 acquisition is not memoised. In `loadLedgerEra` the rejection
+propagates unchanged — already a `Ledger8RuntimeMissingError` carrying the
+underlying cause — and the next call retries, so a repaired install does not
+stay broken for the life of the process.
+
+The same rule holds one level down, at each accessor:
+
+- In `loadLedger8`, a failed load is not memoised: the rejection propagates as
+  `Ledger8RuntimeMissingError` and the next call retries the import.
+- In `loadLedger8Engine`, a failed load is not memoised either: the next call
+  retries the import.
+
+The shared reason is that a module-resolution or instantiation failure is
+usually a property of the install, not of the call. Caching the rejection would
+convert a repairable environment problem into a process-lifetime one.
+
+## Acquisition is hoisted, so the era methods stay synchronous
+
+`createV8Era` acquires the retained pre-fork ledger through `loadLedger8` — the
+only sanctioned runtime path to it — and binds it into closure, so the era's
+own methods stay synchronous.
+
+Hoisting the acquisition there, rather than deferring it into each method, is
+what makes the two arms symmetrical. It costs a v9-only consumer nothing:
+asking for the v8 era IS the observation of v8, and nothing reaches that
+function until someone does.
+
+`Ledger8Engine` is built the same way. Every method on it is synchronous
+because the object is handed over only after the retained toolchain has been
+acquired, so there is nothing left to await — the acquisition happens once, in
+`createLedger8Engine`, and the runtime instance it obtained is captured in
+closure.
+
+The v9 arm needs no hoisting to reach the same shape. `createV9Era` is wholly
+synchronous: `@midnightntwrk/ledger-v9` is this package's current era and is
+already linked by the package root, so there is nothing to acquire and nothing
+that can fail there.
+
+The result is that both arms hand back an object whose methods are synchronous,
+for two eras whose acquisition costs are not remotely alike.
+
+## `loadLedgerEra` is the entry point
+
+`loadLedgerEra` is the only sanctioned way to reach either era's operations.
+Pass the version resolved from a record or from the network head (see
+`protocolVersionToLedger` in `packages/protocol/src/version.ts`) rather than a
+string chosen by hand.
+
+## The v8 arm composes exactly one call
+
+The two eras are not equivalent in `composeCallTx`, and the difference is
+deliberate rather than hidden: the retained pre-fork era composes exactly one
+call. One shape the facade allows is not expressible on that era and is refused
+rather than silently narrowed — a call tree with more than one entry.
+
+The limit is not a missing feature of this package. A cross-contract call is a
+ledger-9-only feature that a pre-fork contract cannot emit at all, so the
+retained era has no call tree to compose, and composing only the first entry
+would drop the rest without a word. The refusal is raised
+(`ComposeOptionError` on `'calls'`), never worked around.
+
+## Unproven output only
+
+`composeCallTx` returns the bytes `Transaction.serialize()` produces before
+`.prove()` is ever called. Proving needs a proving provider and a running proof
+server, neither of which this seam has.

--- a/packages/protocol/docs/fail-closed-decoding.md
+++ b/packages/protocol/docs/fail-closed-decoding.md
@@ -29,13 +29,10 @@ era with `protocolVersionToLedger` (`packages/protocol/src/version.ts`) rather
 than constructing the string by hand, and let the decoder have the final word.
 
 `extractEncodedStateValue` (`packages/protocol/src/lib/era/envelope.ts`)
-therefore validates `version` before it is used, rather than trusting it from
-the type signature. That guard is also what keeps `stage` inside its closed
-union: `stage` is built from `version`, so an unvalidated string would
-otherwise reach a field whose whole contract is that consumers can `switch` on
-it. No production caller passes anything but a literal today, and this function
-is not reachable from any subpath export — see the note on collapsing this
-dispatch in `packages/protocol/README.md`.
+therefore validates `version` at runtime before selecting a decoder with it;
+why that guard is not redundant with the type signature, and how much of the
+era dispatch is reachable today, belong with the package-wide table discipline
+— see [SharedTableDiscipline](./shared-table-discipline.md).
 
 ## A decode never returns a partial or empty state
 

--- a/packages/protocol/docs/fail-closed-decoding.md
+++ b/packages/protocol/docs/fail-closed-decoding.md
@@ -135,21 +135,27 @@ no gain.
 
 `extractEncodedStateValue` takes `ledger8ContractState` for every `version`,
 not just `'v8'`. Requiring it unconditionally costs nobody a runtime they would
-not otherwise hold. This seam is reached only from the ledger-8 engine's own
-factory, which has already awaited onchain-runtime-v3 to assemble the runtime
-it hands to `downConvertForExecution`; the `'v9'` decoder is here so that the
+not otherwise hold. This seam is reached only from `createV8Era`
+(`lib/era/load-era.ts`), which has already awaited `loadLedger8()` and hands
+that module's `ContractState` in; the `'v9'` decoder is here so that the
 *bridge* can read a post-fork envelope before down-converting it, not to serve
 a caller who has no pre-fork runtime at all. Such a caller reads ledger-v9
 directly and never reaches this function. Note this is a statement about the
 call graph, not about bundling — the separate reason the pre-fork types are
 imported with `import type` is unaffected either way.
 
+`Ledger8ContractState` is declared as a `Pick` of the onchain-runtime-v3 class,
+which reads as though the engine's assembled runtime were the argument. It is
+not: the only production caller passes ledger-v8's `ContractState`, and the
+`Pick` holds because the two agree on `deserialize`. The engine's own factory
+never calls this function at all.
+
 That is what makes the unconditional form the cheaper one: a single guard
 covering both eras, with no era-conditional branch to keep correct and no
 optional parameter weakening the one call that genuinely needs the argument. It
-stops being free the moment this function is surfaced beyond the engine — if a
-v9-only path ever calls it, move the check into the `'v8'` decoder and make the
-parameter optional there.
+stops being free the moment this function is surfaced beyond the v8 era facade —
+if a v9-only path ever calls it, move the check into the `'v8'` decoder and make
+the parameter optional there.
 
 The standalone `extractV9EncodedStateValue` is the release valve that keeps
 that requirement from spreading. It was split out of

--- a/packages/protocol/docs/fail-closed-decoding.md
+++ b/packages/protocol/docs/fail-closed-decoding.md
@@ -1,0 +1,219 @@
+---
+title: FailClosedDecoding
+---
+
+# Fail-closed decoding
+
+Reading a contract state is the one place in `@midnightntwrk/midnight-js-protocol`
+where bytes of unknown provenance meet a WASM codec that will happily answer a
+question it was never asked. This document records the discipline that keeps
+that seam honest: what the decoders treat as authoritative, why no read is
+allowed to return a plausible-looking empty answer, and why the three failures
+this seam can raise are three distinct classes rather than one.
+
+## The envelope is the only authority over the bytes
+
+There are two envelope shapes, and each era reads only its own:
+
+- `v9` — a post-fork `contract-state[v8]`-tagged envelope, read via
+  `@midnightntwrk/ledger-v9`.
+- `v8` — a pre-fork `contract-state[v6]`-tagged envelope, read via
+  onchain-runtime-v3, the same codec that produced it.
+
+A reported protocol version selects which of those decoders is used; it does
+not establish what the bytes are. The same bytes are a valid state on one axis
+and refuse to decode on the other, which is why the era whose decoder rejected
+an envelope is the first thing a reader of `StateDecodeFailedError` needs: an
+era-less message would send a caller to audit bytes that are fine. Derive the
+era with `protocolVersionToLedger` (`packages/protocol/src/version.ts`) rather
+than constructing the string by hand, and let the decoder have the final word.
+
+`extractEncodedStateValue` (`packages/protocol/src/lib/era/envelope.ts`)
+therefore validates `version` before it is used, rather than trusting it from
+the type signature. That guard is also what keeps `stage` inside its closed
+union: `stage` is built from `version`, so an unvalidated string would
+otherwise reach a field whose whole contract is that consumers can `switch` on
+it. No production caller passes anything but a literal today, and this function
+is not reachable from any subpath export — see the note on collapsing this
+dispatch in `packages/protocol/README.md`.
+
+## A decode never returns a partial or empty state
+
+`extractEncodedStateValue` never returns a silently empty or partial state: any
+deserialization failure (malformed bytes, a truncated or over-long payload, or
+an envelope tagged for the other ledger version) is wrapped in a
+`DownConvertFailedError` with `{ cause }`, so failures propagate loudly instead
+of producing a misleading result. The wrapped cause carries the runtime's own
+diagnosis, which distinguishes a tag mismatch from truncated, trailing, or
+empty bytes.
+
+`decodeContractStateWith`
+(`packages/protocol/src/lib/shared/contract-state.ts`) holds the same line one
+level up: the whole read is covered, not just the deserialization, so no raw
+runtime error escapes this seam uncoded.
+
+That is why the per-entry-point lookup inside it does not use `?.`. The entry
+point came from `operations()` on that same object, so a state that cannot
+resolve it is internally inconsistent, not a state with a blank slot. Optional
+chaining collapsed the two into the same answer, and `verifierKey: undefined`
+has a specific documented meaning — never deployed. A whole contract reading as
+never-deployed would send a caller comparing key hashes hunting a deployment
+bug that does not exist, so this leaves as `StateDecodeFailedError` like every
+other read failure here.
+
+The same refusal to repair quietly governs the Merkle assertion further down
+the pipeline. A bounded Merkle tree only has a readable root once every node
+hash has been computed; the vendor documents `root()` as returning `undefined`
+until then, and `rehash()` as necessary "because the onchain runtime does not
+automatically rehash trees". `downConvertForExecution` asserts this on every
+tree it decodes, failing fast with `MerkleNotRehashedError` instead of silently
+repairing.
+
+## Three failures, three remediations
+
+The seam raises three coded failures, and folding any two of them together
+would misdescribe the fix.
+
+| Error | Reports |
+|---|---|
+| `StateDecodeFailedError` | the envelope was never readable at all by the era it was requested for |
+| `DownConvertFailedError` | a raw envelope, or an already-extracted `EncodedStateValue`, could not be turned into an executable pre-fork state |
+| `Ledger8RuntimeInvalidError` | the injected pre-fork runtime cannot be used — nothing is wrong with the input |
+
+`StateDecodeFailedError` is distinct from `DownConvertFailedError`, which
+reports a failure to bridge an already-extracted state into the pre-fork
+execution algebra: the first reports the envelope never having been readable at
+all. `version` names the era whose decoder rejected it.
+
+`Ledger8RuntimeInvalidError` is separate from `DownConvertFailedError` because
+the remediation is unrelated: nothing is wrong with the caller's input. Folding
+this into a down-convert failure would name an extraction stage and tell the
+caller to read a cause describing tag mismatches and truncation, sending them
+to audit data that is perfectly good. It is also distinct from
+`Ledger8RuntimeMissingError`, which reports a *failed acquisition* of the v8
+chunk; this one reports a runtime that was acquired, or assembled by hand, and
+then handed over incomplete.
+
+Checking the injected runtime up front is what buys that distinction. It turns
+the omission into `Ledger8RuntimeInvalidError` instead of a `TypeError` wrapped
+as a `DownConvertFailedError` — which would name an extraction stage and point
+the caller at input bytes that are not the problem.
+
+Down-convert is version-agnostic — it consumes an already-extracted
+`EncodedStateValue` whichever era it came from — so its stage carries no
+version, unlike the two extraction stages (`'v8 envelope extraction'` and
+`'v9 envelope extraction'`, against `'state down-convert'`).
+
+## Why the facade's two read methods fail the same way
+
+`extractStateWith` (`packages/protocol/src/lib/shared/contract-state.ts`)
+exists so the facade's two read methods fail the SAME way. Underneath, the
+extractors raise `DownConvertFailedError` naming an extraction stage — a class
+with no `version` field, and a diagnosis phrased around down-converting a state
+for execution, which is not what a caller asking to read a state was doing. A
+caller handed one era's bytes on the other era's object should learn that from
+`extractState` and `decodeContractState` alike, not have to know which of the
+two it called. The extractor's own diagnosis stays on `cause`.
+
+## Wrapped exactly once, and the stage is checked
+
+`extractV9EncodedStateValue` owns the same wrapping the dispatching entry
+applies: a rejected envelope (malformed, truncated, over-long, or tagged for
+the other era) leaves as a `DownConvertFailedError` at stage
+`'v9 envelope extraction'`, carrying the runtime's own diagnosis on `cause`.
+The dispatching entry delegates here rather than decoding again, so a failure
+is wrapped exactly once. The `v9` slot of the decoder table is a reference to
+that standalone decoder, not a second copy of the same read: the two must not
+be able to drift apart, and the wrapping it already owns is why the dispatch
+re-wraps nothing it raises.
+
+Re-wrapping is skipped on an identity check over the *stage*, not just the
+class. A decoder is injectable, so one that wrapped its failure at a different
+stage would otherwise pass straight through and tell a caller who asked for one
+era that the other era's codec rejected their bytes. Re-wrapping an
+already-correct failure would bury the runtime's diagnosis one level deeper for
+no gain.
+
+## The pre-fork runtime is required for every era
+
+`extractEncodedStateValue` takes `ledger8ContractState` for every `version`,
+not just `'v8'`. Requiring it unconditionally costs nobody a runtime they would
+not otherwise hold. This seam is reached only from the ledger-8 engine's own
+factory, which has already awaited onchain-runtime-v3 to assemble the runtime
+it hands to `downConvertForExecution`; the `'v9'` decoder is here so that the
+*bridge* can read a post-fork envelope before down-converting it, not to serve
+a caller who has no pre-fork runtime at all. Such a caller reads ledger-v9
+directly and never reaches this function. Note this is a statement about the
+call graph, not about bundling — the separate reason the pre-fork types are
+imported with `import type` is unaffected either way.
+
+That is what makes the unconditional form the cheaper one: a single guard
+covering both eras, with no era-conditional branch to keep correct and no
+optional parameter weakening the one call that genuinely needs the argument. It
+stops being free the moment this function is surfaced beyond the engine — if a
+v9-only path ever calls it, move the check into the `'v8'` decoder and make the
+parameter optional there.
+
+The standalone `extractV9EncodedStateValue` is the release valve that keeps
+that requirement from spreading. It was split out of
+`extractEncodedStateValue`'s decoder table so the v9 read is reachable without
+a pre-fork runtime. The dispatching entry requires that runtime for every
+version on purpose — it is what stops a v9 caller drifting into a v8 read with
+nothing to decode it — but that requirement is not the v9 decode's own, and a
+v9-only consumer should not have to instantiate multi-megabyte pre-fork WASM to
+read a state its own era wrote.
+
+## These errors never render caller-supplied text
+
+`DownConvertStage` is a closed union rather than a free-form string for two
+reasons: a consumer can `switch` on `stage` exhaustively, and no call site can
+interpolate input-derived text into the error message, which is what keeps the
+"never renders state contents" guarantee a property of this class rather than
+of every caller's discipline.
+
+`DownConvertFailedError` therefore names which step failed and nothing more, so
+the message stays useful without ever including the input bytes themselves —
+this class never renders raw hex or decoded state contents, only the stage name
+and the wrapped `cause`. The underlying runtime distinguishes tag-mismatch,
+truncated, trailing-bytes and empty input in its own message; that detail is
+preserved on `cause`. `StateDecodeFailedError` likewise renders no hex and no
+byte dump of its own, and preserves the decoder's own diagnosis — which
+distinguishes a tag mismatch from truncated, trailing or empty input — on
+`cause`.
+
+The property has to hold on the two errors that carry an offending value, or it
+is not worth having:
+
+- `UnknownLedgerVersionError` carries the offending era string on
+  `requestedVersion` for programmatic use, deliberately kept out of the
+  message: this is the one input on the seam that comes straight from an
+  untrusted caller, and the down-convert errors' "never renders caller-supplied
+  text" property is only worth having if it holds here too. For the same reason
+  that class names no `version` field — there is no valid era to name.
+- `Ledger8RuntimeInvalidError` exposes `missingMember`. Like
+  `UnknownLedgerVersionError`, a TypeScript caller cannot produce this error —
+  it exists for the untyped JavaScript consumers this package also serves — and
+  `missingMember` names the absent binding from `errors.ts`'s own literals
+  rather than caller-supplied text, so exposing it leaks nothing.
+
+## The shape of a decoded state
+
+The decoded result is a `ContractStatePojo`, and three of its shape decisions
+are deliberate refusals rather than conveniences.
+
+**`verifierKey` and `verifierKeyHash` are absent, not empty.** Both are absent
+for a blank slot — the shape a constructor-built state has before a deploy
+fills it in. They are absent rather than zero-length or a hash of nothing on
+purpose: hashing an empty key yields a real-looking digest that a caller
+comparing hashes would match against a contract that was never deployed.
+
+**`entryPoints` is an ARRAY, not a map keyed by circuit id.** A contract state
+can declare two distinct byte entry points that decode to the same name (bytes
+that are not valid UTF-8 both resolve to the replacement character), and a
+name-keyed result would silently drop one of them. An array leaves both visible
+to a caller that has to reconcile them.
+
+**`maintenanceAuthority` and `balance` are deliberately absent** from
+`DecodableContractState`, the slice of a ledger `ContractState` this decoder
+reads: nothing in this framework reads them off a decoded state, and a field
+carried "in case" becomes a field a caller depends on.

--- a/packages/protocol/docs/injected-vendor-slices.md
+++ b/packages/protocol/docs/injected-vendor-slices.md
@@ -1,0 +1,209 @@
+---
+title: InjectedVendorSlices
+---
+
+# How an injected vendor slice is typed
+
+Several seams in this package take a vendor's class by injection rather than
+importing it: the era arms take the ledger module they compose against, and the
+retained-engine seams take the pre-fork runtime they execute through. A seam
+that takes a class by injection still has to name the shape it expects, and
+this document records how that shape is written down.
+
+There are three choices, and each one is made for a reason:
+
+- **Derived** from the vendor's own class, where exactly one era can satisfy
+  the shape.
+- **Structural** — a hand-written declaration — where the seam genuinely serves
+  both eras.
+- **Narrowed** to the members the seam actually calls, which every slice is,
+  and which sometimes buys something beyond a smaller surface.
+
+Injection itself is a separate rule from any of this, and belongs to
+[ModuleGraphAndLazyLoading](./module-graph-and-lazy-loading.md): a value import
+of either era's module would statically link that era's WASM into whatever
+bundle reaches the importing module, so a seam that needs a vendor's classes at
+runtime takes them by injection. Naming a type links nothing — the
+`import type * as` every declaration below reads through is erased with the rest
+of the type layer — so deriving a slice from the vendor's class leaves the lazy
+acquisition path the caller owns untouched. Derivation is orthogonal to the
+import rule, and injection stays required either way.
+
+## Derived from the vendor's own class
+
+Where exactly one era can satisfy the shape, the type is derived from the
+vendor's class rather than restated, so a vendor signature change fails this
+build instead of quietly leaving a hand-written mirror describing a shape the
+runtime no longer has.
+
+`Ledger8ContractState` (`lib/era/envelope.ts`) is
+`Pick<typeof OnchainRuntimeV3.ContractState, 'deserialize'>` — the pre-fork
+`ContractState` statics, so a signature change in onchain-runtime-v3 fails the
+build here. It is narrowed to `deserialize` because that is the only member its
+seam calls. That narrowing carries one further consequence: it pins the slice to
+the pre-fork era, which is what `Ledger8CompactRuntime` depends on. That
+consequence is recorded in
+[RetainedEraExecution](./retained-era-execution.md).
+
+`Ledger8CompactRuntimeStateValue` (`lib/v8/down-convert.ts`) is derived the same
+way from the pre-fork `StateValue` statics, by reading its one member's type
+straight off `typeof OnchainRuntimeV3.StateValue` rather than by a `Pick`: a
+`decode` whose signature moves fails this build instead of leaving a mirror
+describing a static the runtime no longer has. It is narrowed to `decode`
+because that is the only static its seam calls, and because the narrowing is
+what lets `v8-down-convert.test.ts` drive the decode safety net with a
+one-member double (`StateValue: { decode }`) instead of a whole WASM class.
+
+`Ledger8DeployableContractState` (`lib/v8/deploy.ts`) is a `Pick` of the
+vendor's own class rather than a restatement of its one member, so a change to
+`serialize` in onchain-runtime-v3 fails this build; but picking one member keeps
+it structurally loose enough that unrelated serializables satisfy it, which is
+what lets the constructor test in `v8-deploy.test.ts` hand `executeConstructor`
+a plain `{ serialize: () => … }` object instead of invoking real WASM. The type
+therefore does not enforce that the bytes are a contract state at all —
+whichever deploy leg receives them is what turns that residual risk into a
+legible error rather than a raw decoder failure.
+
+`CostModel` on `Ledger8ExecutionRuntime` (`lib/v8/execute.ts`) is a `Pick` of
+the vendor's class narrowed to `initialCostModel`, the only static this seam
+calls, and the narrowing is what lets `v8-execute.test.ts` inject a stub cost
+model. The cost model is not a caller choice: `executeCircuit` always builds the
+context with the glue's own `initialCostModel()` and passes no gas limit.
+
+## Structural where a seam serves both eras
+
+The counterpart to derivation is a hand-written structural declaration, and the
+contrast is the point: derived where there is one era, structural where there
+are two. Naming either era's type on a two-era seam would pick a side.
+
+`ContractStateDecoder` (`lib/shared/contract-state.ts`) is declared structurally
+rather than derived from one era's class, because that decoder genuinely serves
+BOTH axes — the v9 arm passes ledger-v9, the v8 leg passes the module
+`loadLedger8` handed it. `Ledger8ContractState` is the single-era counterpart,
+and IS derived from the vendor for that reason.
+
+`UnshieldedOfferLedger` (`lib/shared/unshielded.ts`) stays a hand-written slice
+for the same reason: the function above it runs on both eras, the v9 arm passing
+ledger-v9 and the v8 leg passing the module `loadLedger8` handed it, so
+deriving the shape from either era's class would pick a side. Its `inputs` and
+`signatures` are typed `never[]` rather than the ledger's own parameter types,
+because this seam only ever aggregates OUTPUTS, so `[]` is the only value that
+can be passed and the type says so instead of a comment.
+
+## Narrowed instead of derived
+
+Two slices could have been derived and deliberately are not, because the
+vendor's own shape drags in a value no test can build.
+
+`createCircuitContext` on `Ledger8ExecutionRuntime` is the sharper case. The
+glue's own version is generic in the private state and returns a
+`CircuitContext` carrying a real `QueryContext`, a WASM class no test double can
+satisfy. Deriving it would make every execution test stand up real WASM just to
+check plumbing, so the seam narrows it to return `Ledger8CircuitContext`
+instead — whose own `currentQueryContext` is a `Pick` of the vendor's
+`QueryContext`, so the narrowing cannot drift away from the class it stands for.
+
+`Ledger8ConstructorRuntime` (`lib/v8/deploy.ts`) is narrowed rather than derived
+from the retained glue's own `createConstructorContext`: that one is generic in
+the private state and returns a `ConstructorContext`, a shape this seam never
+inspects, since it only hands the value straight back to the contract's
+`initialState`. Typing it as the glue's would force every constructor test to
+build a real context to check plumbing it does not read, so the return stays
+`unknown`.
+
+## The three injected runtime slices of the retained engine
+
+Three slices of the retained toolchain reach the engine's seams by injection
+rather than by import: `Ledger8CompactRuntime` (down-convert),
+`Ledger8ExecutionRuntime` (circuit execution) and `Ledger8ConstructorRuntime`
+(constructor execution). Injection is what lets a caller target a specific
+WASM-backed instance, and what lets a test substitute a controlled fake instead
+of standing up real WASM. `createLedger8Engine` (`lib/v8/engine.ts`) assembles
+all three out of one acquisition and captures them in closure, so nothing on
+the engine's public surface takes a runtime parameter.
+
+`Ledger8CompactRuntime` names `ContractState`, `StateValue` and `ChargedState`,
+each typed off onchain-runtime-v3; why `ContractState` is there at all is the
+era pin, in [RetainedEraExecution](./retained-era-execution.md).
+`Ledger8ExecutionRuntime` carries exactly what building and running a circuit
+context needs: `decodeZswapLocalState`, `createCircuitContext` and `CostModel`.
+
+## Type parameters callers never spell out
+
+`CallAssemblyLedger` (`lib/shared/assemble-call.ts`) is satisfied by both ledger
+modules with every type parameter inferred from the module namespace itself, so
+callers pass the module and never spell out type arguments.
+
+`Transcript` is spelled out rather than left as a type parameter because a call
+can arrive with its transcript ALREADY partitioned, in which case the pair comes
+from the caller rather than from the module's own partitioner — so there is no
+module-bound type left to infer it from.
+
+`PartitionableQueryContext` is generic in `TSelf` because `insertCommitment`
+returns a NEW context rather than mutating, which keeps the fold typed as the
+module's own context instead of widening to the interface.
+
+`CallOperationRegistry` leaves `TOperation` open; `assembleCallPrototype`
+constrains it to `VerifiableOperation`, the one property the assembler inspects.
+Both eras' `ContractOperation` declare `verifierKey` as a required
+`Uint8Array`, but a slot that was never assigned one reads back `undefined` —
+pinned by the blank-operation refusals in `v9-wrap.test.ts` and
+`v8-compose.test.ts`, so a vendor change fails a test rather than silently
+disabling the verifier-key check.
+
+The `version` every failure names is passed rather than inferred from the ledger
+module, for the same reason the type parameters are inferred: the assembler is
+generic over the module, so it has no way to ask which axis it was handed.
+
+## Payload types declared once against ledger-v9
+
+`CallAssemblyLedger`'s `AlignedValue` / `Op` / `EncodedStateValue` /
+`Transcript` payload types are declared once against ledger-v9: they are
+structurally identical across onchain-runtime-v3, ledger-v8 and ledger-v9,
+pinned by the compile-time drift gate at the bottom of
+`v8-down-convert.test.ts`, which covers all three axes.
+
+The recorded query context a call carries travels the same way.
+`PartitionContext`'s `CallContext` and `Effects`
+(`lib/shared/compose-types.ts`) are likewise declared once against ledger-v9
+and are structurally identical on all three axes, pinned by the same gate —
+`_CallContextUnchanged`, `_EffectsUnchanged`, `_V8CallContextUnchanged` and
+`_V8EffectsUnchanged`.
+
+## The byte crossing a dual-instantiation cannot affect
+
+Not every era crossing in the engine is exposed to a dual-instantiation. A
+crossing that passes BYTES rather than a handle is immune by construction,
+because no object is handed between the two physical copies at all.
+
+`Ledger8DeployableContractState` is that case: `.serialize()` is how a caller
+turns the handle `executeConstructor` returned into the bytes every deploy leg
+takes. This is why the guard's blast radius is the crossings that pass handles,
+and why widening it to cover the byte crossings would assert something already
+true. The guard itself is in
+[DualInstantiationGuard](./dual-instantiation-guard.md).
+
+## What holds each slice to its vendor
+
+A narrowing is only worth having while it still describes the runtime it stands
+for, so each one is held to its vendor by something that fails rather than by
+prose:
+
+- `createLedger8Engine` (`lib/v8/engine.ts`) annotates all three engine slices
+  against the real glue and the real onchain-runtime-v3, so a member the vendor
+  moved fails to type-check there. `v8-load-engine.test.ts` then exercises that
+  assembled engine end-to-end against the real glue.
+- `v8-deploy.test.ts` annotates the real glue's `createConstructorContext` as a
+  `Ledger8ConstructorRuntime` directly, pinning that the glue still satisfies
+  the narrowing.
+- The compile-time drift gate at the bottom of `v8-down-convert.test.ts` pins
+  the payload types across all three axes. The negative assertion in the same
+  file that keeps a post-fork runtime out of `Ledger8CompactRuntime` belongs to
+  the era pin, in [RetainedEraExecution](./retained-era-execution.md).
+- The blank-operation refusals in `v9-wrap.test.ts` and `v8-compose.test.ts`
+  pin the `verifierKey`-reads-back-`undefined` behaviour the operation
+  constraint is written for.
+
+Those compile-time assertions are evaluated by `yarn typecheck:tests` on the
+pre-push hook rather than by CI, so a failure there is the only signal a drifted
+slice will give.

--- a/packages/protocol/docs/module-graph-and-lazy-loading.md
+++ b/packages/protocol/docs/module-graph-and-lazy-loading.md
@@ -81,7 +81,7 @@ A consumer that only executes circuits and binds them onto v9 therefore never
 instantiates the v8 ledger WASM at all: `createLedger8Engine` deliberately
 does not acquire the v8 ledger module, so such a consumer never hard-depends
 on ledger-v8 resolving either. The reason that surface does not need it is
-recorded in `docs/era-seam.md`.
+recorded in [EraSeam](./era-seam.md).
 
 ## The only sanctioned runtime access
 
@@ -180,6 +180,13 @@ importing a value — so deriving the type leaves the lazy acquisition path the
 caller owns untouched.
 
 Each derived slice is also narrowed to the members the seam actually calls.
+
+Where a narrowing buys something beyond that — a shape a test double can
+satisfy, or a type parameter callers never have to spell out — the trade is
+recorded with the seam it belongs to: [ComposeRefusalOrder](./compose-refusal-order.md) for the compose
+legs, [RetainedEraExecution](./retained-era-execution.md) for the execution runtime, and
+[DualInstantiationGuard](./dual-instantiation-guard.md) for the byte crossing a dual-instantiation cannot
+affect.
 `Ledger8ContractState` is narrowed to `deserialize` because that is the only
 member its seam calls. `Ledger8CompactRuntimeStateValue` is narrowed to
 `decode` because that is the only static its seam calls, and because the
@@ -189,7 +196,7 @@ with a one-member double instead of a whole WASM class.
 The narrowing on `Ledger8ContractState` carries one further consequence — it
 pins the slice to the pre-fork era, which is what `Ledger8CompactRuntime`
 depends on. That consequence is recorded in
-`docs/retained-era-execution.md`.
+[RetainedEraExecution](./retained-era-execution.md).
 
 ## Structural where a seam serves both eras
 

--- a/packages/protocol/docs/module-graph-and-lazy-loading.md
+++ b/packages/protocol/docs/module-graph-and-lazy-loading.md
@@ -1,0 +1,209 @@
+---
+title: ModuleGraphAndLazyLoading
+---
+
+# The module graph and lazy loading
+
+`@midnight-ntwrk/midnight-js-protocol` co-installs two ledger runtimes and a
+retained pre-fork toolchain, each carrying its own WASM artifact. Which of
+them a consumer actually pays for is decided by the shape of the module graph:
+which modules are build entries, which direction the imports run, and which
+dependencies are reachable only through a dynamic import. This document
+records those decisions, the tests that hold them in place, and the rule that
+follows from them for how a seam names a vendor's classes without importing
+them.
+
+The mechanism that exposes the v8 era — the `./v8` subpath, the relative
+dynamic import, and the three ways the single sanctioned path is enforced — is
+decided in `docs/adr/0004-lazy-v8-era-access-via-protocol-subpath.md`. This
+document does not restate it; it records the parts of the graph that grew
+around it.
+
+## Every module directly under `src/` is a build entry
+
+Every module directly under `src/` is a build entry paired with an `exports`
+subpath. `export-surface.test.ts` is the gate: it reads the `exports` map out
+of `package.json` and requires one subpath per top-level module under `src/`.
+
+That is why the accessors do not sit at the top of `src/`. `loadLedger8` lives
+in `lib/v8/load.ts` and `loadLedger8Engine` in `lib/v8/load-engine.ts`: both
+are published through the root barrel instead of through a subpath of their
+own, so neither may be a top-level module. It is also why the dynamic
+specifiers read `../../v8.js` and `../../engine.js` rather than `./v8.js` and
+`./engine.js`.
+
+The same split applies to the engine. The implementation lives in
+`lib/v8/engine.ts`, so it is not an entry of its own; `src/engine.ts`
+re-exports it and is what rollup emits as `dist/engine.js`, the chunk
+`loadLedger8Engine` reaches by dynamic import. Keeping it a separate entry is
+what holds the retained `compact-runtime@0.16` glue and the
+`@midnight-ntwrk/onchain-runtime-v3` WASM out of the package root.
+
+## Where `LEDGER_VERSIONS` lives, and the cycle it avoids
+
+`LEDGER_VERSIONS` is declared in `lib/shared/ledger-version.ts`, a leaf module
+that imports nothing, and is re-exported unchanged by `version.ts`, so the
+public surface is the one it always was. Consumers keep importing both
+`LEDGER_VERSIONS` and `LedgerVersion` from `version.ts` — and from the root
+barrel — exactly as before.
+
+Two modules need that set, and the dependency between them runs one way:
+`version.ts` imports `errors.ts` for the error it throws, while `errors.ts`
+imports nothing but this file. `errors.ts` needs `LedgerVersion` to type the
+era its composition failures name. Declaring the constant in `version.ts`
+would therefore close a cycle.
+
+Declaring it in `errors.ts` would not close a cycle, but it would put the era
+vocabulary in the error module and make every reader of that vocabulary an
+importer of errors. A leaf both modules can reach keeps the direction and the
+ownership straight.
+
+## `./v8` and `./engine` are separate chunks
+
+Two heavy dependency sets are reachable only through a dynamic import, and
+each has its own entry chunk, because each pulls a different set of
+retained-era dependencies:
+
+- `./v8` — the multi-megabyte v8 ledger WASM (`@midnightntwrk/ledger-v8`,
+  re-exported by `src/v8.ts`). The relative specifier in `lib/v8/load.ts`
+  names this build entry, which rollup emits as its own chunk and links only
+  through that dynamic import, so the v8 WASM loads on the first call to
+  `loadLedger8` and not before.
+- `./engine` — the retained `compact-runtime@0.16` glue (installed under the
+  `compact-runtime-ledger8` alias) and the
+  `@midnight-ntwrk/onchain-runtime-v3` WASM. The relative specifier in
+  `lib/v8/load-engine.ts` names the `./engine` build entry the same way, so
+  those two load only on the first call to `loadLedger8Engine` — never as a
+  side effect of importing the package root. Evaluating `lib/v8/engine.ts` is
+  what pulls them in, and that happens only on that import.
+
+A consumer that only executes circuits and binds them onto v9 therefore never
+instantiates the v8 ledger WASM at all: `createLedger8Engine` deliberately
+does not acquire the v8 ledger module, so such a consumer never hard-depends
+on ledger-v8 resolving either. The reason that surface does not need it is
+recorded in `docs/era-seam.md`.
+
+## The only sanctioned runtime access
+
+`loadLedger8()` is the only sanctioned runtime path to the v8 ledger era, and
+`loadLedger8Engine()` is the only sanctioned runtime path to the engine's
+public surface. Every other module in the package reaches the retained era
+through one of those two accessors, which is what keeps the number of physical
+WASM copies at one and keeps the laziness a property of a single call site
+rather than of a convention spread across files.
+
+`lib/v8/load-engine.ts` re-exports the engine's option and result types
+type-only — `DownConvertedState`, `EncodedStateValue`, `ExecuteCircuitOptions`,
+`Ledger8Engine`, `TranscriptPojo` and `WrapKeepStateCallOptions` — so the root
+barrel can name every type a caller needs without linking the engine chunk.
+Without them a consumer holding a `Ledger8Engine` cannot annotate a variable
+or write a helper without a second, subpath-gated import.
+
+## The tests that enforce each property
+
+Each property above is pinned by a named suite rather than by convention:
+
+- `export-surface.test.ts` — every top-level module under `src/` has an
+  `exports` subpath, which is what makes "not an entry" the reason the
+  accessors live under `lib/`.
+- `v8-surface.test.ts` — no module under `src/` other than `lib/v8/load.ts`
+  may import the v8 module at runtime. It reads past comments and type-only
+  imports and re-exports, and resolves each relative specifier against the
+  file naming it, so the `./engine` build entry is never confused with the
+  `lib/v8/engine.ts` sibling that shares its name.
+- `dist-laziness.test.ts` — the index bundle must never link the v8 entry
+  statically, and must never link the `./engine` subpath,
+  `@midnight-ntwrk/onchain-runtime-v3`, or the `compact-runtime-ledger8` glue
+  alias statically either. It inspects the built rollup output, so it is the
+  suite that proves erasure and chunking rather than assuming them, and the
+  eager closure it scans is the set of modules a consumer pays for on
+  `import`.
+- `v8-load-engine-laziness.test.ts` — constructing the engine, and calling any
+  of its methods, never acquires the v8 ledger module.
+
+## Vendor types are imported with `import type`
+
+Where a module names a vendor's types but must not link the vendor's module,
+the import is type-only. `import type * as` is erased with the rest of the
+type layer and links nothing; that is the same idiom `ProtocolV8` uses in
+`lib/v8/load.ts`.
+
+The rule is about values, not names. A value import of either era's module
+would statically link that era's WASM into whatever bundle reaches the
+importing module — which for ledger-v8 is exactly what
+`dist-laziness.test.ts` forbids, and which for the other era would make a
+consumer pay for a runtime it never calls. Naming a type does not: type-only
+imports are erased. This is why the seams that need a vendor's classes at
+runtime take them by injection instead of importing them, and why a seam that
+cannot name a single vendor type — `lib/shared/unshielded.ts`, which runs on
+both eras — declares a structural slice rather than reaching for a value
+import.
+
+`lib/v8/down-convert.ts` reads the three pre-fork instance types it names off
+one type-only namespace import rather than adding a second named import of the
+same module. Those aliases are not mirrors: they are the vendor's types.
+
+## Naming a type versus importing a value at the envelope seam
+
+`Ledger8ContractState` in `lib/era/envelope.ts` is the clearest case of the
+distinction, because the module it names is one the package must not link
+eagerly. Injection is still what gets the runtime into that seam — that is
+about not importing a value. The `import type * as` the declaration reads
+through is erased and links nothing, which leaves the lazy acquisition path
+the caller owns untouched. `lib/era/envelope.ts` sits inside the eager closure
+`dist-laziness.test.ts` scans, and that suite is what proves the erasure.
+
+The same distinction is stated again where the seam is used: whether
+`ledger8ContractState` is required for every era is a statement about the call
+graph, not about bundling, and the reason the pre-fork types are imported with
+`import type` is unaffected either way.
+
+## Injected runtime slices are derived from the vendor, not restated
+
+A seam that takes a vendor class by injection still has to name the shape it
+expects. Where exactly one era can satisfy that shape, the type is DERIVED
+from the vendor's own class rather than restated, so a vendor signature change
+fails this build instead of quietly leaving a hand-written mirror describing a
+shape the runtime no longer has:
+
+- `Ledger8ContractState` (`lib/era/envelope.ts`) is derived from the pre-fork
+  `ContractState` statics, so a signature change in onchain-runtime-v3 fails
+  the build here.
+- `Ledger8CompactRuntimeStateValue` (`lib/v8/down-convert.ts`) is derived the
+  same way from the pre-fork `StateValue` statics: a `decode` whose signature
+  moves fails this build instead of leaving a hand-written mirror describing a
+  static the runtime no longer has.
+
+Derivation is orthogonal to the import rule above. The `import type * as` each
+declaration reads through is erased and links nothing — injection is about not
+importing a value — so deriving the type leaves the lazy acquisition path the
+caller owns untouched.
+
+Each derived slice is also narrowed to the members the seam actually calls.
+`Ledger8ContractState` is narrowed to `deserialize` because that is the only
+member its seam calls. `Ledger8CompactRuntimeStateValue` is narrowed to
+`decode` because that is the only static its seam calls, and because the
+narrowing is what lets `v8-down-convert.test.ts` drive the decode safety net
+with a one-member double instead of a whole WASM class.
+
+The narrowing on `Ledger8ContractState` carries one further consequence — it
+pins the slice to the pre-fork era, which is what `Ledger8CompactRuntime`
+depends on. That consequence is recorded in
+`docs/retained-era-execution.md`.
+
+## Structural where a seam serves both eras
+
+The counterpart to derivation is a structural declaration, and the contrast is
+the point: derived where there is one era, structural where there are two.
+
+`ContractStateDecoder` (`lib/shared/contract-state.ts`) is declared
+structurally rather than derived from one era's class, because that decoder
+genuinely serves BOTH axes — the v9 arm passes ledger-v9, the v8 leg passes
+the module `loadLedger8` handed it — and naming either era's type there would
+pick a side. `Ledger8ContractState` is the single-era counterpart, and IS
+derived from the vendor for that reason.
+
+Injection remains required in both cases, and for the reason already given:
+naming a type links nothing, but importing either era's module as a value
+would statically link its WASM into whatever bundle reaches the importing
+module.

--- a/packages/protocol/docs/module-graph-and-lazy-loading.md
+++ b/packages/protocol/docs/module-graph-and-lazy-loading.md
@@ -92,12 +92,21 @@ through one of those two accessors, which is what keeps the number of physical
 WASM copies at one and keeps the laziness a property of a single call site
 rather than of a convention spread across files.
 
-`lib/v8/load-engine.ts` re-exports the engine's option and result types
-type-only — `DownConvertedState`, `EncodedStateValue`, `ExecuteCircuitOptions`,
-`Ledger8Engine`, `TranscriptPojo` and `WrapKeepStateCallOptions` — so the root
-barrel can name every type a caller needs without linking the engine chunk.
-Without them a consumer holding a `Ledger8Engine` cannot annotate a variable
-or write a helper without a second, subpath-gated import.
+`lib/v8/load-engine.ts` re-exports engine option and result types type-only —
+`DownConvertedState`, `EncodedStateValue`, `ExecuteCircuitOptions`,
+`Ledger8Engine`, `TranscriptPojo` and `WrapKeepStateCallOptions` — so a consumer
+holding a `Ledger8Engine` can annotate a variable or write a helper without a
+second, subpath-gated import, and without linking the engine chunk.
+
+The list is INCOMPLETE, and knowingly so as of this writing. `Ledger8Engine`
+has a fourth method, `executeConstructor(options: ExecuteConstructorOptions):
+ConstructorResultPojo` (`lib/v8/engine.ts`), and neither of those two types is
+re-exported — so neither reaches the root barrel, and `executeConstructor` is
+the one method on the seam whose argument and result a caller cannot annotate
+without the gated import. TypeDoc reports both as referenced-but-not-included.
+Closing it is a one-line change to the re-export list; it is left out of the
+documentation change that recorded this so that a docs-only commit does not
+alter the package's export surface.
 
 ## The tests that enforce each property
 
@@ -158,59 +167,10 @@ The same distinction is stated again where the seam is used: whether
 graph, not about bundling, and the reason the pre-fork types are imported with
 `import type` is unaffected either way.
 
-## Injected runtime slices are derived from the vendor, not restated
+## Injected vendor slices
 
 A seam that takes a vendor class by injection still has to name the shape it
-expects. Where exactly one era can satisfy that shape, the type is DERIVED
-from the vendor's own class rather than restated, so a vendor signature change
-fails this build instead of quietly leaving a hand-written mirror describing a
-shape the runtime no longer has:
-
-- `Ledger8ContractState` (`lib/era/envelope.ts`) is derived from the pre-fork
-  `ContractState` statics, so a signature change in onchain-runtime-v3 fails
-  the build here.
-- `Ledger8CompactRuntimeStateValue` (`lib/v8/down-convert.ts`) is derived the
-  same way from the pre-fork `StateValue` statics: a `decode` whose signature
-  moves fails this build instead of leaving a hand-written mirror describing a
-  static the runtime no longer has.
-
-Derivation is orthogonal to the import rule above. The `import type * as` each
-declaration reads through is erased and links nothing — injection is about not
-importing a value — so deriving the type leaves the lazy acquisition path the
-caller owns untouched.
-
-Each derived slice is also narrowed to the members the seam actually calls.
-
-Where a narrowing buys something beyond that — a shape a test double can
-satisfy, or a type parameter callers never have to spell out — the trade is
-recorded with the seam it belongs to: [ComposeRefusalOrder](./compose-refusal-order.md) for the compose
-legs, [RetainedEraExecution](./retained-era-execution.md) for the execution runtime, and
-[DualInstantiationGuard](./dual-instantiation-guard.md) for the byte crossing a dual-instantiation cannot
-affect.
-`Ledger8ContractState` is narrowed to `deserialize` because that is the only
-member its seam calls. `Ledger8CompactRuntimeStateValue` is narrowed to
-`decode` because that is the only static its seam calls, and because the
-narrowing is what lets `v8-down-convert.test.ts` drive the decode safety net
-with a one-member double instead of a whole WASM class.
-
-The narrowing on `Ledger8ContractState` carries one further consequence — it
-pins the slice to the pre-fork era, which is what `Ledger8CompactRuntime`
-depends on. That consequence is recorded in
-[RetainedEraExecution](./retained-era-execution.md).
-
-## Structural where a seam serves both eras
-
-The counterpart to derivation is a structural declaration, and the contrast is
-the point: derived where there is one era, structural where there are two.
-
-`ContractStateDecoder` (`lib/shared/contract-state.ts`) is declared
-structurally rather than derived from one era's class, because that decoder
-genuinely serves BOTH axes — the v9 arm passes ledger-v9, the v8 leg passes
-the module `loadLedger8` handed it — and naming either era's type there would
-pick a side. `Ledger8ContractState` is the single-era counterpart, and IS
-derived from the vendor for that reason.
-
-Injection remains required in both cases, and for the reason already given:
-naming a type links nothing, but importing either era's module as a value
-would statically link its WASM into whatever bundle reaches the importing
-module.
+expects, and this package makes that choice three ways — derived from the
+vendor's own class, declared structurally, or narrowed. That whole topic,
+including what each choice buys and how each slice is held to its vendor, is in
+[InjectedVendorSlices](./injected-vendor-slices.md).

--- a/packages/protocol/docs/retained-era-execution.md
+++ b/packages/protocol/docs/retained-era-execution.md
@@ -16,10 +16,10 @@ down-conversion stage is for, why a tree that was not rehashed is refused
 rather than repaired, what pins the bridge to the pre-fork era, what the
 execution result has to carry, and why the runtime the seams call is injected.
 
-The error classes named here are described in `FailClosedDecoding`, which owns
+The error classes named here are described in [FailClosedDecoding](./fail-closed-decoding.md), which owns
 the division of labour between `DownConvertFailedError`,
 `StateDecodeFailedError` and `Ledger8RuntimeInvalidError`; the refusal ordering
-on the composition legs is in `ComposeRefusalOrder`.
+on the composition legs is in [ComposeRefusalOrder](./compose-refusal-order.md).
 
 ## The down-conversion stages
 
@@ -85,7 +85,7 @@ a `boundedMerkleTree` leaf tuple (`[Uint8Array, undefined]`), which arrives
 through the array branch and never reaches this comparison. So the check guards
 against a record gaining one rather than fixing a live defect. That it is a
 partial guard rather than a total one, and what `Object.hasOwn` would close, is
-part of the package-wide discipline in `SharedTableDiscipline`.
+part of the package-wide discipline in [SharedTableDiscipline](./shared-table-discipline.md).
 
 ## The Merkle walk, and why a rootless tree is refused
 
@@ -129,7 +129,7 @@ pinned by tests over a multi-entry map rather than by prose alone.
 
 The walk's `default` arm carries both a compile-time exhaustiveness assertion
 and a runtime throw; why neither is redundant with the other is in
-`SharedTableDiscipline`, alongside the same form in `version.ts` and
+[SharedTableDiscipline](./shared-table-discipline.md), alongside the same form in `version.ts` and
 `loadLedgerEra`.
 
 ## What the down-convert does not cover
@@ -180,7 +180,7 @@ two shapes would otherwise silently reopen the hole.
 
 Why the assembled object may take `ContractState` from onchain-runtime-v3 while
 the other two members come from the 0.16 glue is a dual-instantiation question,
-and belongs to `DualInstantiationGuard`.
+and belongs to [DualInstantiationGuard](./dual-instantiation-guard.md).
 
 ## Circuit dispatch
 
@@ -201,7 +201,7 @@ An unknown `circuitId` throws a plain `Error`, not a
 runtime-instance failure modes this engine wraps elsewhere; it mirrors the plain
 `Error` the spike itself throws for the analogous "operation missing on contract
 state" case. Why the lookup is an own-property one is in
-`SharedTableDiscipline`.
+[SharedTableDiscipline](./shared-table-discipline.md).
 
 A circuit that moved coins runs like any other: its post-call Zswap local state
 leaves on the result for the caller to turn into the transaction's Zswap offer.
@@ -261,8 +261,8 @@ initial ledger state.
 into a deploy: both `composeV8DeployTx` and the era facade's `composeDeployTx`
 take the state as bytes, which is what `.serialize()` on that handle produces.
 The deploy-side consequences — the blank verifier-key slots a constructor-built
-state carries, and why the address cannot be recomputed — are in `VerifierKeys`
-and `ComposeRefusalOrder`.
+state carries, and why the address cannot be recomputed — are in [VerifierKeys](./verifier-keys.md)
+and [ComposeRefusalOrder](./compose-refusal-order.md).
 
 ## Binding the result back onto v9
 
@@ -279,7 +279,7 @@ submits its transcript as `kind: 'unpartitioned'` and lets the ledger module do
 the split. The counterpart shape, a transcript already partitioned by
 compact-js, and the refusal of a partitioned transcript that carries neither
 half (`ComposeFailedError`, stage `'call-transcript-empty'`) rather than
-composing a call that records nothing, belong to `ComposeRefusalOrder`.
+composing a call that records nothing, belong to [ComposeRefusalOrder](./compose-refusal-order.md).
 
 A keep-state call never registers a new verifier key, unlike a deploy: it reuses
 whichever key was already registered on-chain by the contract's original
@@ -316,5 +316,18 @@ narrowing cannot drift away from the runtime it stands for.
 
 Why each slice is DERIVED from the vendor's own class where it can be, rather
 than restated as a hand-written mirror, and why each is narrowed to the members
-its seam actually calls, is in `ModuleGraphAndLazyLoading`; the trade the
-constructor slice makes is in `ComposeRefusalOrder`.
+its seam actually calls, is in [ModuleGraphAndLazyLoading](./module-graph-and-lazy-loading.md); the trade the
+constructor slice makes is in [ComposeRefusalOrder](./compose-refusal-order.md).
+
+Two of those slices are narrowed rather than derived, and each narrowing buys
+something specific. `createCircuitContext` is the sharper case: the glue's own
+version is generic in the private state and returns a `CircuitContext` carrying
+a real `QueryContext`, a WASM class no test double can satisfy. Deriving it
+would make every execution test stand up real WASM just to check plumbing, so
+the seam narrows it to return `Ledger8CircuitContext` instead. `CostModel` is
+narrowed to `initialCostModel` for the same reason: it is the only static this
+seam calls, and the narrowing lets a test inject a stub cost model.
+
+The general rule this trades against — derive from the vendor where exactly one
+era can satisfy the shape, declare structurally where a seam serves both — is
+in [ModuleGraphAndLazyLoading](./module-graph-and-lazy-loading.md).

--- a/packages/protocol/docs/retained-era-execution.md
+++ b/packages/protocol/docs/retained-era-execution.md
@@ -221,14 +221,16 @@ reach `.operations`, `.maintenanceAuthority` or `.balance` through them.
 `partitionContext` is the query-context state the call ran with, which the
 carried state bytes do not hold. Composing a call without it partitions the
 transcript against a context the circuit never ran on; a call that received a
-coin in-contract cannot be partitioned at all. Of the four members the pre-fork
-query context exposes, `block` and `effects` are read off the PRE-call context,
-because the partitioner recomputes both from the program it replays — post-call
-values would be counted twice; `comIndices` is read off the POST-call one,
-because the runtime registers a received coin's commitment as the circuit
-produces it (`createZswapOutput` in the retained 0.16 glue). All four are
-declared on one type because the runtime exposes them on the same object; which
-one each is read from is `executeCircuit`'s choice, not the type's.
+coin in-contract cannot be partitioned at all. `PartitionContext` carries three
+members. `block` and `effects` are read off the PRE-call context, because the
+partitioner recomputes both from the program it replays — post-call values would
+be counted twice; `comIndices` is read off the POST-call one, because the
+runtime registers a received coin's commitment as the circuit produces it
+(`createZswapOutput` in the retained 0.16 glue). All three sit on one type
+because the runtime exposes them on the same object; which context each is read
+from is `executeCircuit`'s choice, not the type's. (The fourth member
+`Ledger8QueryContext` picks off the vendor's `QueryContext` is `state`, which
+this seam returns as `postContractState` rather than on this type.)
 
 `zswapLocalState` is the post-call Zswap local state, DECODED into the
 runtime's public shape: the coins the circuit spent and produced. A caller turns
@@ -293,41 +295,8 @@ when no operation is registered for the circuit at all, and
 
 ## The injected runtime slices
 
-Three structural slices of the retained toolchain reach these seams by
-injection rather than by import: `Ledger8CompactRuntime` (down-convert),
-`Ledger8ExecutionRuntime` (circuit execution) and `Ledger8ConstructorRuntime`
-(constructor execution). Injection is what lets a caller target a specific
-WASM-backed instance, and what lets a test substitute a controlled fake instead
-of standing up real WASM. `createLedger8Engine`
-(`packages/protocol/src/lib/v8/engine.ts`) assembles all three out of one
-acquisition and captures them in closure, so nothing on the engine's public
-surface takes a runtime parameter.
-
-`Ledger8ExecutionRuntime` carries exactly what building and running a circuit
-context needs: `decodeZswapLocalState`, `createCircuitContext`, and `CostModel`
-narrowed to `initialCostModel` — the only static this seam calls, and the
-narrowing is what lets a test inject a stub cost model. The cost model is not a
-caller choice: `executeCircuit` always builds the context with the glue's own
-`initialCostModel()` and passes no gas limit.
-
-`v8-load-engine.test.ts` pins that the real glue still satisfies the execution
-slice, and `v8-deploy.test.ts` does the same for the constructor slice, so a
-narrowing cannot drift away from the runtime it stands for.
-
-Why each slice is DERIVED from the vendor's own class where it can be, rather
-than restated as a hand-written mirror, and why each is narrowed to the members
-its seam actually calls, is in [ModuleGraphAndLazyLoading](./module-graph-and-lazy-loading.md); the trade the
-constructor slice makes is in [ComposeRefusalOrder](./compose-refusal-order.md).
-
-Two of those slices are narrowed rather than derived, and each narrowing buys
-something specific. `createCircuitContext` is the sharper case: the glue's own
-version is generic in the private state and returns a `CircuitContext` carrying
-a real `QueryContext`, a WASM class no test double can satisfy. Deriving it
-would make every execution test stand up real WASM just to check plumbing, so
-the seam narrows it to return `Ledger8CircuitContext` instead. `CostModel` is
-narrowed to `initialCostModel` for the same reason: it is the only static this
-seam calls, and the narrowing lets a test inject a stub cost model.
-
-The general rule this trades against — derive from the vendor where exactly one
-era can satisfy the shape, declare structurally where a seam serves both — is
-in [ModuleGraphAndLazyLoading](./module-graph-and-lazy-loading.md).
+`Ledger8CompactRuntime`, `Ledger8ExecutionRuntime` and
+`Ledger8ConstructorRuntime` reach these seams by injection rather than by
+import, and each is narrowed to the members its seam calls. How the three are
+typed, what each narrowing buys, and where `createLedger8Engine` assembles them
+is in [InjectedVendorSlices](./injected-vendor-slices.md).

--- a/packages/protocol/docs/retained-era-execution.md
+++ b/packages/protocol/docs/retained-era-execution.md
@@ -1,0 +1,320 @@
+---
+title: RetainedEraExecution
+---
+
+# Running a contract on the retained pre-fork era
+
+A contract compiled before the fork keeps running on the retained pre-fork
+execution engine (`compact-runtime@0.16` and `@midnight-ntwrk/onchain-runtime-v3`)
+after the fork. The post-fork state it must execute against is down-converted
+into the pre-fork algebra, the circuit or constructor is run there, and the
+resulting call is bound NATIVELY against the current ledger-v9 axis from the
+start — no v8-tx carrier, no later re-bind.
+
+This document collects the rationale behind that path: what each
+down-conversion stage is for, why a tree that was not rehashed is refused
+rather than repaired, what pins the bridge to the pre-fork era, what the
+execution result has to carry, and why the runtime the seams call is injected.
+
+The error classes named here are described in `FailClosedDecoding`, which owns
+the division of labour between `DownConvertFailedError`,
+`StateDecodeFailedError` and `Ledger8RuntimeInvalidError`; the refusal ordering
+on the composition legs is in `ComposeRefusalOrder`.
+
+## The down-conversion stages
+
+`downConvertForExecution` (`packages/protocol/src/lib/v8/down-convert.ts`)
+takes an already-extracted post-fork `EncodedStateValue` and produces the
+pre-fork state a v8-era circuit executes against. It runs in stages, and each
+stage exists to make one class of failure legible:
+
+1. **The injected runtime is checked first**, before anything is decoded, for
+   the same reason `extractEncodedStateValue` checks the runtime it is handed:
+   a runtime missing a binding this function dereferences would otherwise raise
+   a bare `TypeError` that the catch below relabels
+   `DownConvertFailedError` — an error whose message sends the caller to audit
+   input bytes that are not the problem. Only the two members the function
+   actually calls are checked; `ContractState` is on `Ledger8CompactRuntime` to
+   pin the era, and is never dereferenced here.
+2. **Decode through the injected pre-fork `StateValue.decode`.**
+3. **Structural integrity**, by re-encoding the decoded value and comparing it
+   to the input. This catches loss at every depth — a shortened array, a
+   dropped map entry, a changed cell, a substituted subtree — rather than only
+   a wholesale collapse to `null`. It costs one extra encode plus a deep
+   comparison per call, and that is deliberate: the alternative is a bridge
+   that can hand a circuit silently wrong data.
+4. **The Merkle rehash walk**, described below.
+5. **`ChargedState` construction.**
+
+Never returns a silently empty or partial state. Every failure leaves as a
+`DownConvertFailedError` carrying `{ cause }`, or a `MerkleNotRehashedError` —
+including failures from the Merkle walk and from `ChargedState` construction,
+so no uncoded error escapes a seam whose whole contract is code-based
+discrimination.
+
+`DownConvertedState` is deliberately not a full pre-fork `ContractState`: this
+bridge produces only the `ChargedState`, so it does not fabricate blank
+defaults for `.operations`, `.maintenanceAuthority`, or `.balance`. Those
+remain the caller's to carry — execution receives balances via
+`CallContext.balance`, not via this state.
+
+## Structural equality over the encoded algebra
+
+`structurallyEqual` compares values in the `EncodedStateValue` algebra — plain
+objects, arrays, `Map`s, `Uint8Array`s and primitives.
+
+It is hand-rolled rather than `node:util`'s `isDeepStrictEqual`, which does not
+resolve in a browser bundle.
+
+`Map`s are compared pairwise in iteration order, deliberately: both runtimes
+emit map entries in a deterministic, insertion-order-independent order that the
+two of them agree on, so a value and its re-encoding iterate identically
+whatever order the entries were inserted in. That order is not ascending by key
+— it is a canonical hash order, so do not reason about it as sorted. The
+agreement is a cross-runtime property, not a single-codec one — the source
+encoding comes from ledger-v9 and the re-encoding from onchain-runtime-v3 — so
+it is pinned by tests that build the two sides with the two different codecs,
+not only by the same-codec round trip.
+
+The record branch tests `key in bRecord` rather than only matching key counts.
+Without it, two objects that share no key at all compare equal whenever the
+diverging key's value in `a` is `undefined`, because both lookups then read
+`undefined` and short-circuit. No *record* in today's algebra holds an
+undefined-valued field — the one `undefined` it contains is the second slot of
+a `boundedMerkleTree` leaf tuple (`[Uint8Array, undefined]`), which arrives
+through the array branch and never reaches this comparison. So the check guards
+against a record gaining one rather than fixing a live defect. That it is a
+partial guard rather than a total one, and what `Object.hasOwn` would close, is
+part of the package-wide discipline in `SharedTableDiscipline`.
+
+## The Merkle walk, and why a rootless tree is refused
+
+`assertMerkleTreesRehashed` asserts that every bounded Merkle tree in a
+`StateValue` tree already has its node hashes computed, recursing through the
+only two container variants in the algebra (`array` and `map`) and ignoring the
+leaf variants (`cell`, `null`, and `boundedMerkleTree`'s own contents).
+
+`checkRoot` treats three shapes of "no root" alike, because all three mean the
+same thing to a caller and only one is in the vendor's type: `undefined` (what
+the typings document), `null` (what a `None` can serialize to), and a throw —
+the wasm-bindgen shim for `root()` rethrows a Rust `Err` rather than always
+resolving to a value. Letting that throw escape would demote it to a generic
+down-convert failure and tell the caller to check its envelope bytes when the
+actual remediation is to rehash the tree.
+
+The walk is fail-fast by design rather than reparative. An `encode()`/`decode()`
+round trip materializes a tree's hashes on the pinned
+onchain-runtime-v3/ledger-v9 versions, and every state reaching
+`downConvertForExecution` has crossed one — so a rootless tree here can only
+mean an upstream programming error, which this surfaces loudly instead of
+silently repairing. That round-trip behaviour is a vendor property rather than
+a guarantee, so it is pinned by a test (`materializes the hashes of a tree that
+was never rehashed`) that fails if a vendor bump changes it.
+
+Accepting one instead — or repairing it in passing — would hand a circuit a
+state whose hashes this bridge quietly supplied, which is the
+silent-wrong-data outcome the module exists to prevent.
+
+The walk does not mutate or rebuild the state. It is not allocation-free: each
+`asArray()`/`asMap()` step marshals fresh wrapper objects out of WASM.
+
+Its non-null assertions are guarded by the preceding `type()` call: the `as*`
+accessors return `undefined` only on a variant mismatch, which the switch has
+already excluded. `map.get(key)` is likewise asserted because a key marshalled
+out by `keys()` resolves back through `get()`. Both are observed behaviour of
+onchain-runtime-v3 rather than vendor-documented invariants — the vendor's own
+types are not authoritative about definedness here (`asCell()` is declared
+non-optional yet returns `undefined` for a `null` state value) — so they are
+pinned by tests over a multi-entry map rather than by prose alone.
+
+The walk's `default` arm carries both a compile-time exhaustiveness assertion
+and a runtime throw; why neither is redundant with the other is in
+`SharedTableDiscipline`, alongside the same form in `version.ts` and
+`loadLedgerEra`.
+
+## What the down-convert does not cover
+
+Anything the pre-fork encoder re-derives rather than carries. A bounded Merkle
+tree encodes as its height and leaves, never its node hashes, so a tree whose
+internal hashes were re-materialized differently across the fork boundary still
+re-encodes byte-identically here. `assertMerkleTreesRehashed` establishes only
+that each tree has a readable root, not that the root matches the source's.
+Comparing roots across the boundary needs the source-side tree, which
+`downConvertForExecution` never sees — it belongs at the envelope seam.
+
+## The era pin
+
+`Ledger8CompactRuntime` names three members:
+
+```
+ContractState   StateValue   ChargedState
+```
+
+`ContractState` is there to pin the *era*, not because
+`packages/protocol/src/lib/v8/down-convert.ts` calls it.
+
+`StateValue.decode` and `new ChargedState(...)` are structurally identical
+across the fork — that identity is what makes the bridge possible at all, and
+it is asserted directly by the wire-shape drift detectors in
+`v8-down-convert.test.ts`. So neither member can tell a pre-fork runtime from a
+post-fork one. Without a third member the interface is satisfied by
+onchain-runtime-v4 and by `compact-runtime` (which re-exports it) — both public
+barrel exports of this very package. A caller reaching for the wrong one gets
+no error: decode and re-encode then use the same post-fork codec, so the
+structural comparison passes, the Merkle walk passes, and a v4 `ChargedState`
+is returned typed as a v3 one, to surface later as an opaque wasm-bindgen
+rejection deep inside execution.
+
+`ContractState` closes that hole, and the closing happens in
+`Ledger8ContractState` (`packages/protocol/src/lib/era/envelope.ts`). The
+narrowing there carries the era pin `Ledger8CompactRuntime` depends on: the
+static's RETURN type is the v3 instance, whose `query()` returns a
+`GatherResult` whose `log` variant gained fields after the fork, so a post-fork
+module fails to satisfy the type.
+
+That divergence is incidental to this bridge, so it is pinned by a compile-time
+negative assertion rather than trusted:
+`_PostForkOnchainRuntimeIsRejected` in `v8-down-convert.test.ts` pins exactly
+that a post-fork runtime is not assignable. A vendor bump that realigned the
+two shapes would otherwise silently reopen the hole.
+
+Why the assembled object may take `ContractState` from onchain-runtime-v3 while
+the other two members come from the 0.16 glue is a dual-instantiation question,
+and belongs to `DualInstantiationGuard`.
+
+## Circuit dispatch
+
+`executeCircuit` (`packages/protocol/src/lib/v8/execute.ts`) runs one impure
+circuit, following the exact `createCircuitContext` /
+`impureCircuits[id](ctx, ...args)` sequence the retained toolchain expects (the
+spike's `runCircuit`).
+
+`Ledger8ContractLike` names only `impureCircuits`, the map every generated
+contract exposes its callable entry points under. The other own properties a
+real compiled contract carries (`witnesses`, `circuits`, `provableCircuits`,
+`initialState`) are never read here — execution only ever dispatches through
+`impureCircuits`.
+
+An unknown `circuitId` throws a plain `Error`, not a
+`PROTOCOL_ERROR_CODES`-carrying class. This is a caller-programming-error case
+(an unknown circuit name passed by the caller), not one of the decode/
+runtime-instance failure modes this engine wraps elsewhere; it mirrors the plain
+`Error` the spike itself throws for the analogous "operation missing on contract
+state" case. Why the lookup is an own-property one is in
+`SharedTableDiscipline`.
+
+A circuit that moved coins runs like any other: its post-call Zswap local state
+leaves on the result for the caller to turn into the transaction's Zswap offer.
+
+## What a `TranscriptPojo` carries, and why
+
+`TranscriptPojo` is the result of one impure circuit's invocation: the primary
+result plus every artifact `wrapKeepStateCall`
+(`packages/protocol/src/lib/v9/wrap.ts`) needs to assemble a v9-native
+`ContractCallPrototype`.
+
+`preContractState`/`postContractState` are `DownConvertedState`s — the same
+execution-only state shape `downConvertForExecution` already produces — not
+full pre-fork `ContractState`s: they carry only `.data`, so a consumer cannot
+reach `.operations`, `.maintenanceAuthority` or `.balance` through them.
+
+`partitionContext` is the query-context state the call ran with, which the
+carried state bytes do not hold. Composing a call without it partitions the
+transcript against a context the circuit never ran on; a call that received a
+coin in-contract cannot be partitioned at all. Of the four members the pre-fork
+query context exposes, `block` and `effects` are read off the PRE-call context,
+because the partitioner recomputes both from the program it replays — post-call
+values would be counted twice; `comIndices` is read off the POST-call one,
+because the runtime registers a received coin's commitment as the circuit
+produces it (`createZswapOutput` in the retained 0.16 glue). All four are
+declared on one type because the runtime exposes them on the same object; which
+one each is read from is `executeCircuit`'s choice, not the type's.
+
+`zswapLocalState` is the post-call Zswap local state, DECODED into the
+runtime's public shape: the coins the circuit spent and produced. A caller turns
+it into the transaction's segmented Zswap offer (`zswapStateToSegmentedOffer`,
+`packages/contracts/src/utils/zswap-utils.ts`) and hands that offer to whichever
+composition leg it targets. Carrying it is what makes a coin-moving circuit
+composable on the retained era at all — omitting it would leave the caller
+composing a transaction that is missing the coin movements the circuit recorded,
+and the node rejects that as unbalanced on submission.
+
+The decoding happens through the injected 0.16 glue rather than in the caller,
+so a caller never has to acquire the retained glue itself just to read which
+coins a call moved. `currentZswapLocalState` as the glue really puts it on a
+`CircuitContext` is the runtime's own BYTE-encoded shape, and is declared as the
+vendor type rather than an opaque one, because `executeCircuit` hands it on to a
+caller instead of only testing it for emptiness.
+
+`gasCost` is absent from the result shape because nothing here reads it.
+
+## Constructor execution
+
+`executeConstructor` (`packages/protocol/src/lib/v8/deploy.ts`) runs a pre-fork
+contract's constructor (`initialState`), following the
+`createConstructorContext` / `contract.initialState(cc, ...args)` sequence the
+retained toolchain expects. `Ledger8ConstructorContractLike` names only
+`initialState`, the constructor every generated contract exposes to build its
+initial ledger state.
+
+`contractState` on the result is a pre-fork HANDLE, so it does not go straight
+into a deploy: both `composeV8DeployTx` and the era facade's `composeDeployTx`
+take the state as bytes, which is what `.serialize()` on that handle produces.
+The deploy-side consequences — the blank verifier-key slots a constructor-built
+state carries, and why the address cannot be recomputed — are in `VerifierKeys`
+and `ComposeRefusalOrder`.
+
+## Binding the result back onto v9
+
+`wrapKeepStateCall` wraps a `TranscriptPojo` into a v9-native
+`ContractCallPrototype`, ready for `Intent.new(ttl).addCall(...)`, via
+`assembleCallPrototype` against the ledger-v9 module. This is the "keep-state"
+leg: execution stays on the retained pre-fork engine, but the call it produces
+is bound natively against the current ledger-v9 axis from the start.
+
+The retained execution leg partitions nothing. It hands over the raw op
+sequence the circuit emitted, against the state it ran on, plus the context it
+recorded while running which the state bytes do not carry — so it always
+submits its transcript as `kind: 'unpartitioned'` and lets the ledger module do
+the split. The counterpart shape, a transcript already partitioned by
+compact-js, and the refusal of a partitioned transcript that carries neither
+half (`ComposeFailedError`, stage `'call-transcript-empty'`) rather than
+composing a call that records nothing, belong to `ComposeRefusalOrder`.
+
+A keep-state call never registers a new verifier key, unlike a deploy: it reuses
+whichever key was already registered on-chain by the contract's original
+(pre-fork) deploy and carried through the migration. So `options.contractState`
+— the migrated, post-fork v9 `ContractState`, read from chain or otherwise
+carrying the contract's real registered operations — must already carry the
+operation for the circuit, or this throws `ComposeFailedError` rather than
+silently falling back to a blank, unverifiable operation: stage `'wrap-call'`
+when no operation is registered for the circuit at all, and
+`'call-verifier-key'` when the one registered carries no verifier key.
+
+## The injected runtime slices
+
+Three structural slices of the retained toolchain reach these seams by
+injection rather than by import: `Ledger8CompactRuntime` (down-convert),
+`Ledger8ExecutionRuntime` (circuit execution) and `Ledger8ConstructorRuntime`
+(constructor execution). Injection is what lets a caller target a specific
+WASM-backed instance, and what lets a test substitute a controlled fake instead
+of standing up real WASM. `createLedger8Engine`
+(`packages/protocol/src/lib/v8/engine.ts`) assembles all three out of one
+acquisition and captures them in closure, so nothing on the engine's public
+surface takes a runtime parameter.
+
+`Ledger8ExecutionRuntime` carries exactly what building and running a circuit
+context needs: `decodeZswapLocalState`, `createCircuitContext`, and `CostModel`
+narrowed to `initialCostModel` — the only static this seam calls, and the
+narrowing is what lets a test inject a stub cost model. The cost model is not a
+caller choice: `executeCircuit` always builds the context with the glue's own
+`initialCostModel()` and passes no gas limit.
+
+`v8-load-engine.test.ts` pins that the real glue still satisfies the execution
+slice, and `v8-deploy.test.ts` does the same for the constructor slice, so a
+narrowing cannot drift away from the runtime it stands for.
+
+Why each slice is DERIVED from the vendor's own class where it can be, rather
+than restated as a hand-written mirror, and why each is narrowed to the members
+its seam actually calls, is in `ModuleGraphAndLazyLoading`; the trade the
+constructor slice makes is in `ComposeRefusalOrder`.

--- a/packages/protocol/docs/shared-table-discipline.md
+++ b/packages/protocol/docs/shared-table-discipline.md
@@ -1,0 +1,221 @@
+---
+title: SharedTableDiscipline
+---
+
+# Shared table discipline
+
+Almost every era-keyed decision in `@midnight-ntwrk/midnight-js-protocol` is a
+table rather than a chain of comparisons, and every one of those tables is built
+the same way: a null prototype where it is indexed by a value, frozen, typed so
+that a missing entry is a build failure, and guarded at runtime anyway. This
+document holds the reasoning behind that shape, so the tables themselves and the
+symbols above them do not have to repeat it.
+
+## Frozen shared constants and tables
+
+The rule is that anything this package hands out — or memoises and hands to
+every caller in the process — is frozen.
+
+`LEDGER_VERSIONS` (`packages/protocol/src/lib/shared/ledger-version.ts`) is
+frozen, not merely `as const`: it is a public exported constant, and an unfrozen
+array is one a downstream package can mutate for every other consumer in the
+process. Nothing reads the value at runtime to dispatch on — the era tables are
+typed by `LedgerVersion` and built independently — so the freeze guards the
+export, not the dispatch.
+
+`PROTOCOL_ERROR_CODES` (`packages/protocol/src/errors.ts`) applies the same
+discipline to its own registry: frozen so a downstream package cannot mutate the
+shared registry object at runtime.
+
+`ENVELOPE_DECODERS` (`packages/protocol/src/lib/era/envelope.ts`) is the one
+table whose mutation would reroute contract-state bytes to the wrong era's
+codec, and it should not be the one left writable.
+
+Both era arms handed out by `loadLedgerEra`
+(`packages/protocol/src/lib/era/load-era.ts`) are frozen for the matching
+reason: a memoised era is one object shared by every caller in the process, so
+an unfrozen one lets any consumer reassign `composeCallTx` for all the others.
+
+The same construction — `Object.freeze` over an `Object.assign` onto
+`Object.create(null)` — is used for `KNOWN_AXES`
+(`packages/protocol/src/lib/v8/instance-guard.ts`) and for
+`AXIS_BARE_PACKAGE_NAMES` in `packages/protocol/src/errors.ts`, and
+`PUBLISHED_SCOPES` in the same module is frozen as a plain array for the reason
+`LEDGER_VERSIONS` is.
+
+## Null-prototype lookup tables
+
+A table that is *indexed by a value* gets a null prototype as well as a freeze.
+Both matter, for different reasons, and the null prototype is the one that
+prevents a wrong answer rather than a mutation.
+
+`ENVELOPE_DECODERS` is indexed by a value that is only type-checked for
+TypeScript callers, and a plain object literal resolves an unexpected key
+through `Object.prototype`. Two inherited members are directly reachable, and
+neither of them fails:
+
+- `'constructor'` would hand the caller's own raw bytes straight back.
+- `'toString'` would return `'[object Undefined]'`. The inherited method is read
+  into a local and called bare, so its `this` is `undefined` under ESM strict
+  mode, not the table.
+
+Both are typed as an `EncodedStateValue`, and neither throws. That is the whole
+argument: the failure mode of a plain object literal here is not an exception,
+it is a plausible-looking value flowing on as if a decode had happened.
+
+`KNOWN_AXES` in `packages/protocol/src/lib/v8/instance-guard.ts` is
+null-prototype and frozen for the reason `ENVELOPE_DECODERS` is: the value
+indexing it is only type-checked for TypeScript callers, and a plain object
+literal answers `true` for every `Object.prototype` member.
+
+The same exposure is why `UnknownLedgerVersionError`
+(`packages/protocol/src/errors.ts`) exists at all. TypeScript callers cannot
+produce it, because `version` is typed as `LedgerVersion`; it exists for the
+untyped JavaScript consumers this package also serves, where an unvalidated era
+string threaded from an indexer response would otherwise reach an era-keyed
+decision — and, where that decision is a lookup table rather than a `switch`,
+could resolve an inherited `Object.prototype` member and yield a
+plausible-looking non-era.
+
+There is a second closed union this package validates at a boundary for the same
+reason, the ledger-8 instance axis. Its own argument — why the axis is not only
+a label — belongs with the guard that uses it; see `DualInstantiationGuard`.
+
+## Own-property lookups where a null prototype is not available
+
+Two places index an object this package did not build, so they cannot give it a
+null prototype and use an own-property lookup instead.
+
+`executeCircuit` (`packages/protocol/src/lib/v8/execute.ts`) resolves a circuit
+by own property: `impureCircuits` is a plain object literal on every compiled
+contract, so a bare index would resolve `toString` or `constructor` off the
+prototype chain and dispatch into it.
+
+The structural comparison in
+`packages/protocol/src/lib/v8/down-convert.ts` is explicitly a partial guard,
+not a total one: the object it tests with `in` is a plain object, so `in` also
+succeeds for every `Object.prototype` member. Keys in the pinned algebra are
+only `tag`/`content`/`value`/`alignment`/`length`, none of them inherited, so
+the hole is unreachable today — but `Object.hasOwn` would close it outright and
+is the right move the moment that helper is used on anything wider.
+
+## Compile-time exhaustiveness
+
+Every era-keyed table in the package is total by construction, and the
+totality is checked by the type system rather than by review.
+
+`_allLedgerVersionsAreMapped` in `packages/protocol/src/version.ts` is the
+canonical form and the one the other sites name. It is a compile-time-only
+guard: if `LEDGER_VERSIONS` ever grows without a matching entry being added to
+`NODE_MAJOR_TO_LEDGER`, the assignment stops type-checking, because the
+conditional type resolves to `never`.
+
+`loadLedgerEra` (`packages/protocol/src/lib/era/load-era.ts`) does the same in a
+`switch`, in the style of `version.ts`'s `_allLedgerVersionsAreMapped` and the
+Merkle walk in `packages/protocol/src/lib/v8/down-convert.ts`: a new member of
+`LEDGER_VERSIONS` stops the `const unhandled: never = version` assignment
+type-checking, so the omission is a build failure rather than a review miss.
+
+The Merkle rehash walk in `packages/protocol/src/lib/v8/down-convert.ts` uses
+the same `const unhandled: never` form against the vendor's `StateValue`
+variants, in the style of `version.ts`'s `_allLedgerVersionsAreMapped`: a vendor
+bump that adds a variant stops the assignment type-checking, so the omission is
+a build failure rather than a review miss.
+
+`KNOWN_AXES` and `AXIS_BARE_PACKAGE_NAMES` reach the same property through
+`satisfies` rather than an assignment: the duplication of the one axis literal
+is checked, not trusted — `satisfies` fails to compile if `Ledger8InstanceAxis`
+gains a member the table does not name.
+
+## Why the runtime guard is not redundant with it
+
+The compile-time guard and the runtime guard answer different threats, so
+neither replaces the other.
+
+In `loadLedgerEra`, the runtime rejection is not redundant with the
+`never` assignment, because `version` reaches the function from untyped callers
+too. A TypeScript caller cannot produce an `UnknownLedgerVersionError` there; it
+exists for the untyped JavaScript consumers this package also serves, where an
+era string threaded from an indexer response would otherwise fall through to a
+plausible-looking non-era. The shape of the dispatch decides how much the
+runtime guard has to do: `packages/protocol/src/lib/era/envelope.ts` defends the
+same input against resolving an inherited `Object.prototype` member, because its
+dispatch is a lookup table, while `loadLedgerEra` is a closed `switch`, where no
+string can resolve to anything but a case or the default.
+
+`extractEncodedStateValue` (`packages/protocol/src/lib/era/envelope.ts`)
+validates `version` before it is used, rather than trusting it from the type
+signature. That guard is what keeps `stage` inside its closed union: `stage` is
+built from `version`, so an unvalidated string would otherwise reach a field
+whose whole contract is that consumers can `switch` on it.
+
+In the Merkle rehash walk, the runtime throw is not redundant with the
+`never` assignment either. The `StateValue` reaching that walk comes from a
+caller-injected runtime, whose WASM can emit a tag the pinned `.d.ts` does not
+declare — and those declarations are known to be unfaithful. Returning `void` on
+an unrecognised variant would skip every Merkle tree nested inside it without a
+word, which is the exact silent-wrong-data outcome that module exists to
+prevent.
+
+## A Record rather than a ternary or an if-chain
+
+`ENVELOPE_DECODERS` holds one decoder per `LedgerVersion` as a `Record` rather
+than a ternary, so that adding a member to `LEDGER_VERSIONS` fails to compile
+there instead of silently routing the new era's bytes to the pre-fork decoder —
+the same discipline `packages/protocol/src/version.ts` applies to its own
+mapping tables.
+
+`ComposeFailedError.MESSAGES` (`packages/protocol/src/errors.ts`) is a total
+`Record` rather than an if-chain, for the same reason `ENVELOPE_DECODERS` is
+one: adding a stage without its message fails to compile there, instead of
+silently shipping whichever message the fallthrough happened to reach. Every
+entry takes the era rather than naming one, so the same table serves both axes;
+an entry that hardcoded an era would report a v9 failure as a v8 one, which is
+worse than saying nothing, because the two eras' remediations differ.
+
+`ComposeOptionError.MESSAGES` (`packages/protocol/src/errors.ts`) is a total
+`Record` for exactly the reason `ComposeFailedError.MESSAGES` is one: adding an
+option without its message fails to compile there. This one was measured rather
+than assumed. As an if-chain it fell through to the `'ttl'` text, so a seventh
+option would have told a caller their time-to-live was invalid while `option`
+named something else — an error contradicting its own field.
+
+## The node-major mapping table
+
+The `protocolVersion` integer encodes the *node* version as
+`major * 1_000_000 + minor * 1_000 + patch`, so a whole node major occupies a
+`1_000_000`-wide range. That encoding is the one used by
+midnightntwrk/midnight-indexer
+(`indexer-common/src/domain/protocol_version.rs`).
+
+`NODE_MAJOR_TO_LEDGER` in `packages/protocol/src/version.ts` is deliberately
+narrower than the indexer's table: only majors `1` and `2` are mapped.
+midnight-js ships against node 1.x and 2.x, so a 0.x `protocolVersion` — which
+the indexer does map — is treated here as an unknown version rather than a
+supported era. This is a fail-closed choice, not a mirror.
+
+`lookupLedger` in the same module is kept as a small typed function, rather than
+indexing the `as const` table directly, because a `number`-typed key cannot
+index an object type with only numeric literal properties. The
+`Partial<Record<number, LedgerVersion>>` parameter type is what makes the
+`=== undefined` guard in `protocolVersionToLedger` type-driven instead of
+relying on a cast.
+
+## How much of the envelope dispatch is reachable
+
+The era dispatch in `packages/protocol/src/lib/era/envelope.ts` is more general
+than its current callers need, and that is a known state rather than an
+oversight. No production caller passes anything but a literal today, and
+`extractEncodedStateValue` is not reachable from any subpath export. See the
+note on collapsing this dispatch in `packages/protocol/README.md` for what that
+would cost.
+
+## Related documents
+
+- `DualInstantiationGuard` — the ledger-8 instance axis, and why
+  `onchain-runtime-v3` is the only one asserted.
+- `FailClosedDecoding` — what the decode guarantees once a decoder has been
+  selected, and how the failure classes divide the work between them.
+- `ModuleGraphAndLazyLoading` — why `LEDGER_VERSIONS` lives in a leaf module,
+  and which modules are build entries.
+- `EraSeam` — why the era arms are memoised per era and what crosses the seam.

--- a/packages/protocol/docs/shared-table-discipline.md
+++ b/packages/protocol/docs/shared-table-discipline.md
@@ -79,7 +79,7 @@ plausible-looking non-era.
 
 There is a second closed union this package validates at a boundary for the same
 reason, the ledger-8 instance axis. Its own argument — why the axis is not only
-a label — belongs with the guard that uses it; see `DualInstantiationGuard`.
+a label — belongs with the guard that uses it; see [DualInstantiationGuard](./dual-instantiation-guard.md).
 
 ## Own-property lookups where a null prototype is not available
 
@@ -212,10 +212,10 @@ would cost.
 
 ## Related documents
 
-- `DualInstantiationGuard` — the ledger-8 instance axis, and why
+- [DualInstantiationGuard](./dual-instantiation-guard.md) — the ledger-8 instance axis, and why
   `onchain-runtime-v3` is the only one asserted.
-- `FailClosedDecoding` — what the decode guarantees once a decoder has been
+- [FailClosedDecoding](./fail-closed-decoding.md) — what the decode guarantees once a decoder has been
   selected, and how the failure classes divide the work between them.
-- `ModuleGraphAndLazyLoading` — why `LEDGER_VERSIONS` lives in a leaf module,
+- [ModuleGraphAndLazyLoading](./module-graph-and-lazy-loading.md) — why `LEDGER_VERSIONS` lives in a leaf module,
   and which modules are build entries.
-- `EraSeam` — why the era arms are memoised per era and what crosses the seam.
+- [EraSeam](./era-seam.md) — why the era arms are memoised per era and what crosses the seam.

--- a/packages/protocol/docs/verifier-keys.md
+++ b/packages/protocol/docs/verifier-keys.md
@@ -16,7 +16,7 @@ both deploy legs, and the rules
 `resolveVerifierKeyRegistrations`
 (`packages/protocol/src/lib/shared/verifier-keys.ts`) enforces before any key is
 registered. The order in which the other compose options are refused is a
-separate thread — see `ComposeRefusalOrder`.
+separate thread — see [ComposeRefusalOrder](./compose-refusal-order.md).
 
 ## Optional on the facade, demanded by both deploy legs
 

--- a/packages/protocol/docs/verifier-keys.md
+++ b/packages/protocol/docs/verifier-keys.md
@@ -83,7 +83,7 @@ point rather than its resolved name: `setOperation` handed the name would leave
 a byte-declared slot blank and create a second, undeclared one beside it.
 Resolving each key inside the loop is also what removes the non-null assertion
 the set arithmetic would otherwise need at the end — the `undefined` branch IS
-the `'deploy-verifier-key'` check, not an unreachable case to assert away.
+the `'deploy-unknown-circuit'` check, not an unreachable case to assert away.
 
 The resolver is shared by both eras' deploy legs, so the two cannot drift on
 which checks run or in what order, and each leg's own docs point at it rather

--- a/packages/protocol/docs/verifier-keys.md
+++ b/packages/protocol/docs/verifier-keys.md
@@ -1,0 +1,123 @@
+---
+title: VerifierKeys
+---
+
+# Verifier keys on a deploy
+
+A compiled contract's constructor declares one operation slot per circuit but
+leaves each slot's verifier key blank. A deploy therefore has to carry real keys,
+and the address it lands at is derived from the state AFTER those keys are
+registered. That makes the verifier-key map the one deploy option whose
+validation is not merely hygiene: getting it wrong deploys a contract at an
+address the caller's own artifacts do not describe.
+
+This document records why the map is optional on the era facade but demanded by
+both deploy legs, and the rules
+`resolveVerifierKeyRegistrations`
+(`packages/protocol/src/lib/shared/verifier-keys.ts`) enforces before any key is
+registered. The order in which the other compose options are refused is a
+separate thread — see `ComposeRefusalOrder`.
+
+## Optional on the facade, demanded by both deploy legs
+
+`verifierKeys` is optional on the facade so that a state which ALREADY carries
+its keys can be deployed as-is. It is required by the v8 deploy leg
+(`packages/protocol/src/lib/v8/deploy.ts`, reached through
+`packages/protocol/src/lib/v8/adapt.ts`): that leg registers the compiled
+contract's keys onto the initial state itself, and a constructor-built state
+declares every entry point with a blank key. A deploy composed without the map
+would carry unregistered entry points and be refused by the ledger's own
+well-formedness check, so the omission is reported as `ComposeOptionError` with
+option `'verifierKeys'` instead.
+
+Omitting the map for a constructor-built state is a different thing entirely
+from the case the optionality exists for: every entry point is declared blank,
+the deploy derives its address from that blank state, and the contract lands on
+chain unable to verify any call against it. Nothing fails until the first call,
+which reports `'call-verifier-key'` a long way from the cause. That is why the
+v9 leg's `assertStateCarriesKeys` (`packages/protocol/src/lib/v9/compose.ts`)
+refuses a state still declaring a blank key when no map was supplied — it makes
+the two arms agree without taking away the one case the optionality exists for.
+
+Two details of that v9 check are deliberate. It uses `?.`, which collapses "no
+operation resolves" into "operation has a blank key" — something
+`packages/protocol/src/lib/shared/contract-state.ts` deliberately refuses to do
+for the same call. It is safe here because both answers have the one remediation
+this check exists to demand, supply the map, whereas a decoded state hands its
+caller a `verifierKey` field whose absence means "never deployed". And it is
+raised as the OPTION error, not as `ComposeFailedError`'s
+`'deploy-verifier-key'` stage, even though that stage means exactly this
+condition and would name the offending entry point: the v8 arm refuses the same
+omission as `ComposeOptionError('v8', 'verifierKeys')`, and a caller writing one
+handler across both eras matters more than naming which of a contract's slots
+was blank. Naming it as well needs a `circuitId` on `ComposeOptionError`, which
+is a wider change than this seam should make.
+
+## Registration rules
+
+`resolveVerifierKeyRegistrations` validates the supplied map against the state's
+declared entry points in BOTH directions, before anything is registered:
+
+- a key naming an entry point the state does not declare throws
+  `ComposeFailedError` at stage `'deploy-unknown-circuit'`. This direction
+  matters as much as the other: `setOperation` CREATES a slot rather than
+  requiring one, so an unchecked stray key (a stale `keys/*.verifier` from an
+  earlier compiler run) would give the deployed contract an entry point its
+  source never had and — since the deploy derives its address from the initial
+  state — silently deploy it at a different address than the caller's artifacts
+  describe;
+- a declared entry point with no key in the map throws stage
+  `'deploy-verifier-key'`, because a ledger rejects a deploy carrying an
+  unregistered entry point.
+
+Together the two make the map and the declared entry points equal sets. They run
+on resolved NAMES, because that is how the map is keyed, so two declared entry
+points resolving to one name would make them agree while leaving a slot blank;
+that case throws stage `'deploy-ambiguous-circuit'` before either check runs.
+The order is itself part of the contract for that reason: ambiguity is refused
+before either set-comparison runs, because an ambiguous pair makes both
+comparisons agree while leaving one slot blank.
+
+Registrations come back in the map's own order, each carrying the DECLARED entry
+point rather than its resolved name: `setOperation` handed the name would leave
+a byte-declared slot blank and create a second, undeclared one beside it.
+Resolving each key inside the loop is also what removes the non-null assertion
+the set arithmetic would otherwise need at the end — the `undefined` branch IS
+the `'deploy-verifier-key'` check, not an unreachable case to assert away.
+
+The resolver is shared by both eras' deploy legs, so the two cannot drift on
+which checks run or in what order, and each leg's own docs point at it rather
+than restating the three refusals. Restating them would be a second copy of the
+one contract the resolver exists to remove.
+
+## Why the deployed address cannot be recomputed
+
+The address is derived from the initial state AFTER the verifier keys are
+registered AND a fresh nonce is minted, so a caller cannot recompute it at all:
+repeating the registration would not reproduce it. That is why a composed deploy
+hands back a record rather than a bare `Uint8Array` — the transaction alone is
+not enough to use the deployment. The `initialState` beside it is the state that
+address was derived from, which is what a caller stores and later hands to a
+call.
+
+## Key bytes the ledger itself rejects
+
+Registering a key the ledger refuses is a separate failure, raised by each leg
+as `ComposeFailedError` at stage `'deploy-verifier-key-blob'` with the ledger's
+own failure on `cause`, so the failure names the entry point it belongs to. The
+setter validates a tagged `midnight:verifier-key[...]` blob, so a truncated,
+empty or wrong-era key fails at composition rather than at submission.
+
+## Resolving an entry point to a name
+
+`entryPointName` resolves a ledger entry-point key to its name.
+`ContractState.operations()` is declared `Array<string | Uint8Array>`, so a key
+is not statically a string. In practice ledger-v8 decodes even a byte-set entry
+point back to a string (pinned by the `entryPointName` suite in
+`v8-deploy.test.ts`; the v9 side of that behaviour is not pinned against the
+real vendor), but the declared union has to be resolved somewhere, and decoding
+is the only resolution that keeps an error message naming the entry point rather
+than dumping its bytes — which is what `ComposeFailedError` promises.
+
+It lives in a leaf module both eras can reach, so neither arm has to import the
+other's era-named module for a `TextDecoder` call.

--- a/packages/protocol/src/engine.ts
+++ b/packages/protocol/src/engine.ts
@@ -14,12 +14,9 @@
  */
 
 /**
- * Build entry for the `./engine` subpath.
+ * Build entry for the `./engine` subpath, re-exporting the engine
+ * implementation that lives under `lib/`.
  *
- * The engine implementation lives under `lib/` so it is not an entry of its
- * own; this module is what rollup emits as `dist/engine.js`, the chunk that
- * {@link loadLedger8Engine} reaches by dynamic import. Keeping it a separate
- * entry is what holds the retained `compact-runtime@0.16` glue and the
- * `@midnight-ntwrk/onchain-runtime-v3` WASM out of the package root.
+ * @see {@link ModuleGraphAndLazyLoading}
  */
 export * from './lib/v8/engine';

--- a/packages/protocol/src/errors.ts
+++ b/packages/protocol/src/errors.ts
@@ -639,11 +639,11 @@ export class StateDecodeFailedError extends Error {
  * `assertSharedLedger8Instance` (`lib/v8/instance-guard.ts`), the latter for a
  * nullish instance probe.
  *
- * Nothing is wrong with the caller's input here, so the remediation is
- * unrelated to {@link DownConvertFailedError}'s. Distinct too from
- * {@link Ledger8RuntimeMissingError}, which reports a *failed acquisition* of
- * the v8 chunk; this one reports a runtime that was acquired, or assembled by
- * hand, and then handed over incomplete.
+ * Nothing is wrong with the caller's input here. Distinct from
+ * {@link Ledger8RuntimeMissingError}, which reports the v8 chunk failing to
+ * load at all, and from {@link DownConvertFailedError}, which reports an
+ * envelope or state that could not be turned into an executable pre-fork
+ * state.
  *
  * @param missingMember Which binding was absent. One of this module's own
  *   literals, never caller-supplied text, so it is safe to log.

--- a/packages/protocol/src/errors.ts
+++ b/packages/protocol/src/errors.ts
@@ -15,7 +15,13 @@
 
 import type { LedgerVersion } from './lib/shared/ledger-version';
 
-/** Stable error-code strings for this package. Frozen so a downstream package cannot mutate the shared registry object at runtime. */
+/**
+ * Stable error-code strings for this package. Every error class in this module
+ * carries one of these on its `code` field, which is the field a consumer
+ * switches on to tell one failure from another.
+ *
+ * @see {@link SharedTableDiscipline}
+ */
 export const PROTOCOL_ERROR_CODES = Object.freeze({
   UNKNOWN_PROTOCOL_VERSION_READ: 'MIDNIGHT_JS_P_UNKNOWN_PROTOCOL_VERSION_READ',
   UNKNOWN_PROTOCOL_VERSION_CONSTRUCT: 'MIDNIGHT_JS_P_UNKNOWN_PROTOCOL_VERSION_CONSTRUCT',
@@ -30,8 +36,15 @@ export const PROTOCOL_ERROR_CODES = Object.freeze({
   LEDGER8_RUNTIME_INVALID: 'MIDNIGHT_JS_P_LEDGER8_RUNTIME_INVALID',
   UNKNOWN_LEDGER8_AXIS: 'MIDNIGHT_JS_P_UNKNOWN_LEDGER8_AXIS'
 } as const);
+/** The union of every value in {@link PROTOCOL_ERROR_CODES}; the type of every error class's `code` field. */
 export type ProtocolErrorCode = (typeof PROTOCOL_ERROR_CODES)[keyof typeof PROTOCOL_ERROR_CODES];
 
+/**
+ * Which call path asked for a ledger version:
+ * - `'read'` — the version was taken off an existing record.
+ * - `'construct'` — the version was chosen to build something new against the
+ *   network's current head.
+ */
 export type VersionResolutionPath = 'read' | 'construct';
 
 /**
@@ -50,12 +63,17 @@ export type ProtocolVersionUnknownReason = 'unknown' | 'malformed';
  * module -- the dependency stays one-way, so they are named here rather than
  * linked.
  *
- * `reason` distinguishes a malformed input (wrong shape/type, not a
- * protocol-version problem at all) from a well-formed but genuinely unknown
- * version (a real protocol version this framework build does not support
- * yet). `code` further splits each case by which call path produced it —
- * `read` for a version taken off an existing record, `construct` for a version
- * chosen to build something new against the network's current head.
+ * `code` is the field to switch on to tell all four cases apart: it splits
+ * `reason` by the `path` that produced it.
+ *
+ * @param protocolVersion The raw `protocolVersion` value that could not be
+ *   resolved. Carried for programmatic use, and rendered in the message.
+ * @param path Which call path asked for the version — see
+ *   {@link VersionResolutionPath}.
+ * @param reason A malformed input (wrong shape or type, not a
+ *   protocol-version problem at all) or a well-formed but genuinely unknown
+ *   version (a real protocol version this framework build does not support
+ *   yet) — see {@link ProtocolVersionUnknownReason}.
  */
 export class UnknownProtocolVersionError extends Error {
   readonly code:
@@ -90,9 +108,27 @@ export class UnknownProtocolVersionError extends Error {
  * Which lazily-loaded subpath export {@link Ledger8RuntimeMissingError} failed
  * to acquire. Each chunk pulls a different set of retained-era dependencies, so
  * naming the wrong one sends an operator to an entry point that loaded fine.
+ *
+ * @see {@link ModuleGraphAndLazyLoading}
  */
 export type RetainedEraSubpath = '/v8' | '/engine';
 
+/**
+ * Thrown when a lazily-loaded subpath export carrying the retained pre-fork
+ * runtime could not be acquired at all. Raised by `loadLedger8`
+ * (`lib/v8/load.ts`) and `loadLedger8Engine` (`lib/v8/load-engine.ts`), and
+ * surfaced through `createLedger8Engine` and `loadLedgerEra('v8')`.
+ *
+ * A failed acquisition is not memoised: the next call retries the import.
+ * Distinct from {@link Ledger8RuntimeInvalidError}, which reports a runtime
+ * that WAS acquired and then handed over incomplete.
+ *
+ * @param subpath Which chunk failed to load — see {@link RetainedEraSubpath}.
+ * @param cause The underlying module-resolution or initialisation failure,
+ *   preserved unchanged. Read it for which module actually failed.
+ * @see {@link ModuleGraphAndLazyLoading}
+ * @see {@link EraSeam}
+ */
 export class Ledger8RuntimeMissingError extends Error {
   readonly code = PROTOCOL_ERROR_CODES.LEDGER8_RUNTIME_MISSING;
 
@@ -114,12 +150,9 @@ export class Ledger8RuntimeMissingError extends Error {
  * Which physical-copy axis `assertSharedLedger8Instance`
  * (`lib/v8/instance-guard.ts`) detected two distinct instances on.
  *
- * `'onchain-runtime-v3'` is the only member because it is the only retained
- * pre-fork package this one both depends on directly and can receive from a
- * consumer's own resolution — a `compact-runtime` build that re-exports it, a
- * bundler that failed to dedupe it, or the same version installed under both
- * npm scopes while the scope migration runs. A new axis joins only when it
- * gains a comparable second acquisition path.
+ * `'onchain-runtime-v3'` is the only member this framework version checks.
+ *
+ * @see {@link DualInstantiationGuard}
  */
 export type Ledger8InstanceAxis = 'onchain-runtime-v3';
 
@@ -127,22 +160,14 @@ export type Ledger8InstanceAxis = 'onchain-runtime-v3';
  * The npm scopes this package and its retained pre-fork runtimes are published
  * under, while the scope migration runs.
  *
- * Held apart from the `/` on purpose, and joined only at
- * {@link axisPackageNames}. The dual-publish
- * (`.github/scripts/publish-public-npm.mjs`) rewrites the old scope to the new
- * one inside built `.js`/`.d.ts` files as well as in `package.json`, matching
- * on the scope *with* its trailing slash. A scoped package name written as one
- * literal would therefore ship rewritten, collapsing the two names below into
- * one and turning a hint that names both scopes into one that names a single
- * scope twice. Splitting the scope from the slash leaves the rewrite nothing
- * to match; `errors.test.ts` holds that line.
+ * Do not join a scope to the `/` in one literal -- the dual-publish rewrite
+ * would collapse both names into one. See DualInstantiationGuard.
  */
 const PUBLISHED_SCOPES = Object.freeze(['@midnight-ntwrk', '@midnightntwrk'] as const);
 
 /**
- * The unscoped npm name of each axis. Both published copies of an axis carry
- * this same name under a different scope, so naming only one scope would point
- * every consumer installed from the other at a package not in their tree.
+ * The unscoped npm name of each axis; `axisPackageNames` joins every published
+ * scope onto it. See DualInstantiationGuard.
  */
 const AXIS_BARE_PACKAGE_NAMES: Readonly<Record<Ledger8InstanceAxis, string>> = Object.freeze(
   Object.assign(Object.create(null) as Record<Ledger8InstanceAxis, string>, {
@@ -158,21 +183,13 @@ const axisPackageNames = (axis: Ledger8InstanceAxis): readonly string[] =>
  * when the same-named WASM package resolved to two physically distinct copies
  * in this process (a dual-instantiation).
  *
- * Mixing copies does not corrupt results silently: wasm-bindgen emits an
- * `_assertClass` check on every object handed across a class boundary, so a
- * cross-copy handoff throws `expected instance of <Class>`. That failure is
- * loud but opaque — it names neither the package nor the duplicate install.
- * This error exists to replace it with one that does, at the point the two
- * copies are first observed rather than deep inside a down-convert.
+ * Carries no `cause`: this is a direct reference-equality assertion failure,
+ * not a wrapped lower-level exception.
  *
- * `axis` names the package the check ran on. This is a direct assertion
- * failure (a reference-equality mismatch), not a wrapped lower-level
- * exception, so unlike {@link DownConvertFailedError} there is no `cause` to
- * carry.
- *
- * The remediation names every mainstream package manager rather than the one
- * this repo happens to use, because this package is consumed by dApps
- * installed with all of them.
+ * @param axis Which physical-copy axis the check ran on — see
+ *   {@link Ledger8InstanceAxis}. It also selects the package names the
+ *   message tells the reader to trace.
+ * @see {@link DualInstantiationGuard}
  */
 export class Ledger8InstanceMismatchError extends Error {
   readonly code = PROTOCOL_ERROR_CODES.LEDGER8_INSTANCE_MISMATCH;
@@ -193,15 +210,10 @@ export class Ledger8InstanceMismatchError extends Error {
 
 /**
  * Which step of the down-convert pipeline a {@link DownConvertFailedError}
- * came from. A closed union rather than a free-form string for two reasons:
- * a consumer can `switch` on `stage` exhaustively, and no call site can
- * interpolate input-derived text into the error message, which is what keeps
- * the "never renders state contents" guarantee a property of this class
- * rather than of every caller's discipline.
+ * came from. A closed union, so a consumer can `switch` on `stage`
+ * exhaustively.
  *
- * Down-convert is version-agnostic — it consumes an already-extracted
- * `EncodedStateValue` whichever era it came from — so its stage carries no
- * version, unlike the two extraction stages.
+ * @see {@link FailClosedDecoding}
  */
 export type DownConvertStage = 'v8 envelope extraction' | 'v9 envelope extraction' | 'state down-convert';
 
@@ -209,13 +221,16 @@ export type DownConvertStage = 'v8 envelope extraction' | 'v9 envelope extractio
  * Thrown by the down-convert engine (`lib/era/envelope.ts`,
  * `lib/v8/down-convert.ts`) when it cannot turn a raw contract-state
  * envelope, or an already-extracted `EncodedStateValue`, into an executable
- * pre-fork state.
+ * pre-fork state. Raised by `extractV9EncodedStateValue` (`lib/era/envelope.ts`)
+ * and `downConvertForExecution` (`lib/v8/down-convert.ts`).
  *
- * `stage` names which step failed, so the message stays useful without ever
- * including the input bytes themselves — this class never renders raw hex or
- * decoded state contents, only the stage name and the wrapped `cause`. The
- * underlying runtime distinguishes tag-mismatch, truncated, trailing-bytes
- * and empty input in its own message; that detail is preserved on `cause`.
+ * Renders no raw hex and no decoded state contents — only the stage name and
+ * the wrapped `cause`.
+ *
+ * @param stage Which step failed — see {@link DownConvertStage}.
+ * @param cause The runtime's own failure, preserved unchanged. It is what
+ *   distinguishes a tag mismatch from truncated, trailing, or empty input.
+ * @see {@link FailClosedDecoding}
  */
 export class DownConvertFailedError extends Error {
   readonly code = PROTOCOL_ERROR_CODES.DOWN_CONVERT_FAILED;
@@ -236,13 +251,17 @@ export class DownConvertFailedError extends Error {
 
 /**
  * Thrown by `checkRoot` (`lib/v8/down-convert.ts`) when a bounded Merkle
- * tree's root is read before the tree has been rehashed.
+ * tree's root is read before the tree has been rehashed. Reaches a caller
+ * through `assertMerkleTreesRehashed` and `downConvertForExecution`, which
+ * assert it on every tree they decode.
  *
- * A bounded Merkle tree only has a readable root once every node hash has
- * been computed; the vendor documents `root()` as returning `undefined` until
- * then, and `rehash()` as necessary "because the onchain runtime does not
- * automatically rehash trees". `downConvertForExecution` asserts this on
- * every tree it decodes, failing fast instead of silently repairing.
+ * The remediation is always the caller's: call `rehash()` on the tree before
+ * executing against it. Nothing here repairs the tree.
+ *
+ * @param cause The runtime's own failure, when reading the root threw. Absent
+ *   when `root()` returned nothing instead of throwing.
+ * @see {@link FailClosedDecoding}
+ * @see {@link RetainedEraExecution}
  */
 export class MerkleNotRehashedError extends Error {
   readonly code = PROTOCOL_ERROR_CODES.MERKLE_NOT_REHASHED;
@@ -266,6 +285,8 @@ export class MerkleNotRehashedError extends Error {
  * reading `circuitId` off a caught error can compare against it instead of
  * matching a string this package could change, and so it can never be mistaken
  * for a real entry point a caller might try to resolve.
+ *
+ * @see {@link ComposeRefusalOrder}
  */
 export const NO_CIRCUIT = '(none)';
 
@@ -323,11 +344,10 @@ export const NO_CIRCUIT = '(none)';
  *
  * Which ledger era the failure happened on is carried separately, on the
  * error's `version` field. Every stage but `'wrap-call'` is reachable on both
- * eras, so folding the era into the stage would nearly double this union
- * without adding a distinction any caller wants to `switch` on. `'wrap-call'`
- * is the exception because the operation it names is itself fork-crossing: it
- * binds a pre-fork transcript onto a v9 state, so it is only ever raised for
- * `'v9'`.
+ * eras; `'wrap-call'` is only ever raised for `'v9'`.
+ *
+ * @see {@link ComposeRefusalOrder}
+ * @see {@link VerifierKeys}
  */
 export type ComposeStage =
   | 'wrap-call'
@@ -355,17 +375,26 @@ export type ComposeStage =
  *
  * Most stages are direct assertion failures (a missing lookup, not a wrapped
  * lower-level exception) and carry no `cause`, like
- * {@link Ledger8InstanceMismatchError}. The exceptions are
- * `'call-contract-state'` and `'deploy-verifier-key-blob'`, where the ledger
- * itself rejected caller-supplied bytes: that failure is preserved on `cause`,
- * the same way {@link DownConvertFailedError} preserves its runtime's own
- * message.
+ * {@link Ledger8InstanceMismatchError}. The exceptions are the stages where
+ * the ledger itself rejected caller-supplied bytes — enumerated under `cause`
+ * below: that failure is preserved on `cause`, the same way
+ * {@link DownConvertFailedError} preserves its runtime's own message.
  *
  * `circuitId` names the entry point, never its raw contents: this class
- * renders no hex and no byte-array dump, and callers pass entry-point names
- * that have already been decoded (see `entryPointName` in
- * `lib/shared/verifier-keys.ts`). `'call-empty'` is the one stage with no circuit
- * to name, and its message names none.
+ * renders no hex and no byte-array dump. `'call-empty'` is the one stage with
+ * no circuit to name, and its message names none.
+ *
+ * @param version The ledger era the composition was running against.
+ * @param stage Which composition step failed — see {@link ComposeStage}. A
+ *   closed union, so a consumer can `switch` on it exhaustively.
+ * @param circuitId The entry-point name, already decoded. {@link NO_CIRCUIT}
+ *   for `'call-empty'`, the one stage raised before any circuit is looked up.
+ * @param cause The runtime's own failure, present only for the stages where
+ *   the ledger itself rejected caller-supplied bytes: `'call-contract-state'`,
+ *   `'call-partition-context'`, `'call-partition'`, `'call-prototype'` and
+ *   `'deploy-verifier-key-blob'`.
+ * @see {@link ComposeRefusalOrder}
+ * @see {@link VerifierKeys}
  */
 export class ComposeFailedError extends Error {
   readonly code: ProtocolErrorCode = PROTOCOL_ERROR_CODES.COMPOSE_FAILED;
@@ -380,15 +409,8 @@ export class ComposeFailedError extends Error {
     this.name = 'ComposeFailedError';
   }
 
-  // A total Record rather than an if-chain, for the same reason
-  // ENVELOPE_DECODERS in lib/era/envelope.ts is one: adding a stage without
-  // its message fails to compile here, instead of silently shipping whichever
-  // message the fallthrough happened to reach.
-  //
-  // Every entry takes the era rather than naming one, so the same table serves
-  // both axes. An entry that hardcoded an era would report a v9 failure as a
-  // v8 one, which is worse than saying nothing: the two eras' remediations
-  // differ.
+  // A total Record, and every entry takes the era rather than naming one --
+  // see SharedTableDiscipline. Keep both properties when adding a stage.
   private static readonly MESSAGES: Readonly<
     Record<ComposeStage, (version: LedgerVersion, circuitId: string) => string>
   > = {
@@ -507,6 +529,9 @@ export class ComposeFailedError extends Error {
  * - `'zswapOffer'` — the supplied offer bytes were rejected by the target era's
  *   decoder. Raised on BOTH eras, for the same reason and with the same
  *   remediation: pass the bytes that era's own offer serialization produced.
+ *
+ * @see {@link ComposeRefusalOrder}
+ * @see {@link VerifierKeys}
  */
 export type ComposeOption = 'calls' | 'contractState' | 'networkId' | 'ttl' | 'verifierKeys' | 'zswapOffer';
 
@@ -515,16 +540,18 @@ export type ComposeOption = 'calls' | 'contractState' | 'networkId' | 'ttl' | 'v
  * all, as opposed to {@link ComposeFailedError}, which reports a circuit whose
  * operation is missing or under-registered.
  *
- * These are the well-formedness checks the ledger itself does not make. Which
- * network a deployment targets and what TTL policy it uses are the caller's
- * decisions, but an empty network id and an Invalid Date are not decisions —
- * they are defects that the WASM accepts silently, so they are rejected here
- * instead of surfacing as an unexplained rejection at submission time.
+ * These are the well-formedness checks the ledger itself does not make.
  *
- * `option` names the offending field and `version` the ledger era the option
- * was being used against. Like {@link DownConvertFailedError}, this class
- * renders no input contents of its own: a wrapped decoder failure is preserved
- * on `cause`.
+ * Like {@link DownConvertFailedError}, this class renders no input contents of
+ * its own.
+ *
+ * @param version The ledger era the option was being used against.
+ * @param option Which option was unusable — see {@link ComposeOption}. A
+ *   closed union, so a consumer can `switch` on it exhaustively.
+ * @param cause The decoder's own failure, present only for `'contractState'`
+ *   and `'zswapOffer'`, where caller-supplied bytes were rejected.
+ * @see {@link ComposeRefusalOrder}
+ * @see {@link VerifierKeys}
  */
 export class ComposeOptionError extends Error {
   readonly code: ProtocolErrorCode = PROTOCOL_ERROR_CODES.COMPOSE_OPTION_INVALID;
@@ -538,12 +565,8 @@ export class ComposeOptionError extends Error {
     this.name = 'ComposeOptionError';
   }
 
-  // A total Record rather than an if-chain, for exactly the reason
-  // `ComposeFailedError.MESSAGES` above is one: adding an option without its
-  // message fails to compile here. As an if-chain this fell through to the
-  // `'ttl'` text, so a seventh option would have told a caller their
-  // time-to-live was invalid while `option` named something else — an error
-  // contradicting its own field.
+  // A total Record, for exactly the reason `ComposeFailedError.MESSAGES` above
+  // is one -- see SharedTableDiscipline. Never make this an if-chain.
   private static readonly MESSAGES: Readonly<Record<ComposeOption, (version: LedgerVersion) => string>> = {
     contractState: (version) =>
       `Failed to compose a ${version} transaction: the given contract state could not be bridged into the ` +
@@ -579,19 +602,16 @@ export class ComposeOptionError extends Error {
 
 /**
  * Thrown when a raw, serialized contract-state envelope could not be read by
- * the ledger era it was requested for.
+ * the ledger era it was requested for. Raised by both of the facade's read
+ * paths, `extractState` and `decodeContractState`
+ * (`lib/shared/contract-state.ts`), so a caller writes one handler for both.
  *
- * Distinct from {@link DownConvertFailedError}, which reports a failure to
- * bridge an already-extracted state into the pre-fork execution algebra: this
- * one reports the envelope never having been readable at all. `version` names
- * the era whose decoder rejected it, which is the first thing a reader needs —
- * the same bytes are a valid state on one axis and refuse to decode on the
- * other, so an era-less message would send a caller to audit bytes that are
- * fine.
+ * Renders no hex and no byte dump of its own.
  *
- * Renders no hex and no byte dump of its own. The decoder's own diagnosis —
- * which distinguishes a tag mismatch from truncated, trailing or empty input —
- * is preserved on `cause`.
+ * @param version The era whose decoder rejected the envelope.
+ * @param cause The decoder's own diagnosis, preserved unchanged. It is what
+ *   distinguishes a tag mismatch from truncated, trailing or empty input.
+ * @see {@link FailClosedDecoding}
  */
 export class StateDecodeFailedError extends Error {
   readonly code: ProtocolErrorCode = PROTOCOL_ERROR_CODES.STATE_DECODE_FAILED;
@@ -614,21 +634,21 @@ export class StateDecodeFailedError extends Error {
 /**
  * Thrown by `extractEncodedStateValue` (`lib/era/envelope.ts`) when the
  * injected pre-fork runtime cannot be used — it was not passed at all, or the
- * binding the decoder needs is absent from it.
+ * binding the decoder needs is absent from it. Also raised by
+ * `downConvertForExecution` (`lib/v8/down-convert.ts`) and
+ * `assertSharedLedger8Instance` (`lib/v8/instance-guard.ts`), the latter for a
+ * nullish instance probe.
  *
- * Separate from {@link DownConvertFailedError} because the remediation is
- * unrelated: nothing is wrong with the caller's input. Folding this into a
- * down-convert failure would name an extraction stage and tell the caller to
- * read a cause describing tag mismatches and truncation, sending them to audit
- * data that is perfectly good. It is also distinct from
+ * Nothing is wrong with the caller's input here, so the remediation is
+ * unrelated to {@link DownConvertFailedError}'s. Distinct too from
  * {@link Ledger8RuntimeMissingError}, which reports a *failed acquisition* of
  * the v8 chunk; this one reports a runtime that was acquired, or assembled by
  * hand, and then handed over incomplete.
  *
- * Like {@link UnknownLedgerVersionError}, a TypeScript caller cannot produce
- * this — it exists for the untyped JavaScript consumers this package also
- * serves. `missingMember` names the absent binding; it is one of this module's
- * own literals rather than caller-supplied text, so exposing it leaks nothing.
+ * @param missingMember Which binding was absent. One of this module's own
+ *   literals, never caller-supplied text, so it is safe to log.
+ * @see {@link FailClosedDecoding}
+ * @see {@link DualInstantiationGuard}
  */
 export class Ledger8RuntimeInvalidError extends Error {
   readonly code = PROTOCOL_ERROR_CODES.LEDGER8_RUNTIME_INVALID;
@@ -649,17 +669,13 @@ export class Ledger8RuntimeInvalidError extends Error {
  * Thrown by `assertSharedLedger8Instance` (`lib/v8/instance-guard.ts`)
  * when the `axis` it was handed is not a member of {@link Ledger8InstanceAxis}.
  *
- * The counterpart of {@link UnknownLedgerVersionError} on the other closed
- * union this package validates at a boundary, and it exists for the same
- * untyped JavaScript consumers. The axis is not only a label: it selects the
- * package names {@link Ledger8InstanceMismatchError} tells the reader to trace,
- * so an unvalidated string would put an `Object.prototype` member where a
- * package name belongs, and would land in an `axis` field consumers are told
- * they can `switch` on.
+ * A TypeScript caller cannot produce this — `axis` is typed as
+ * {@link Ledger8InstanceAxis}. It exists for the untyped JavaScript consumers
+ * this package also serves.
  *
- * `requestedAxis` carries the offending value; like `requestedVersion` it is
- * kept out of the message, because caller-supplied text is the one thing these
- * errors never render.
+ * @param requestedAxis The offending value that was passed. Carried for
+ *   programmatic use only; it is deliberately kept out of the message.
+ * @see {@link DualInstantiationGuard}
  */
 export class UnknownLedger8AxisError extends Error {
   readonly code = PROTOCOL_ERROR_CODES.UNKNOWN_LEDGER8_AXIS;
@@ -678,19 +694,17 @@ export class UnknownLedger8AxisError extends Error {
  * `LEDGER_VERSIONS`. Raised by `loadLedgerEra` (`lib/era/load-era.ts`) and by
  * `extractEncodedStateValue` (`lib/era/envelope.ts`).
  *
- * TypeScript callers cannot produce this: `version` is typed as
+ * A TypeScript caller cannot produce this: `version` is typed as
  * `LedgerVersion`. It exists for the untyped JavaScript consumers this package
- * also serves, where an unvalidated era string threaded from an indexer
- * response would otherwise reach an era-keyed decision — and, where that
- * decision is a lookup table rather than a `switch`, could resolve an inherited
- * `Object.prototype` member and yield a plausible-looking non-era.
+ * also serves.
  *
- * `requestedVersion` carries the offending value for programmatic use. It is
- * deliberately kept out of the message: this is the one input on the seam that
- * comes straight from an untrusted caller, and the down-convert errors'
- * "never renders caller-supplied text" property is only worth having if it
- * holds here too. For the same reason this class names no `version` field —
- * there is no valid era to name.
+ * Carries no `version` field, unlike every other era-aware error here — there
+ * is no valid era to name.
+ *
+ * @param requestedVersion The offending value that was passed. Carried for
+ *   programmatic use only; it is deliberately kept out of the message.
+ * @see {@link SharedTableDiscipline}
+ * @see {@link FailClosedDecoding}
  */
 export class UnknownLedgerVersionError extends Error {
   readonly code = PROTOCOL_ERROR_CODES.UNKNOWN_LEDGER_VERSION;

--- a/packages/protocol/src/lib/era/envelope.ts
+++ b/packages/protocol/src/lib/era/envelope.ts
@@ -30,21 +30,10 @@ export type { EncodedStateValue };
  * The pre-fork `ContractState` statics {@link extractEncodedStateValue} needs
  * to read a `contract-state[v6]` envelope.
  *
- * DERIVED from the vendor's own class rather than restated, so a signature
- * change in onchain-runtime-v3 fails this build instead of quietly leaving a
- * hand-written mirror describing a shape the runtime no longer has. Injection
- * is still what gets the module here — that is about not importing a VALUE.
- * The `import type * as` above is erased with the rest of the type layer and
- * links nothing, which is the same idiom `ProtocolV8` uses in `../v8/load.ts`;
- * this file sits inside the eager closure `dist-laziness.test.ts` scans, and
- * that suite is what proves the erasure.
- *
- * Narrowed to `deserialize` because that is the only member this seam calls.
- * The narrowing also carries the era pin `Ledger8CompactRuntime`
- * (`../v8/down-convert.ts`) depends on: the static's RETURN type is the v3
- * instance, whose `query()` result diverged from v4's after the fork, so a
- * post-fork module fails to satisfy this type. `_PostForkOnchainRuntimeIsRejected`
- * in `v8-down-convert.test.ts` pins exactly that.
+ * @see {@link ModuleGraphAndLazyLoading} for why this slice is derived from the
+ * vendor's own class, narrowed to `deserialize`, and reached by injection
+ * rather than by a value import.
+ * @see {@link RetainedEraExecution} for the era pin the narrowing carries.
  */
 export type Ledger8ContractState = Pick<typeof OnchainRuntimeV3.ContractState, 'deserialize'>;
 
@@ -54,18 +43,15 @@ type EnvelopeDecoder = (raw: Uint8Array, ledger8ContractState: Ledger8ContractSt
  * Reads the primary {@link EncodedStateValue} out of a raw, serialized
  * post-fork `contract-state[v8]` envelope.
  *
- * Split out of {@link extractEncodedStateValue}'s decoder table so the v9 read
- * is reachable without a pre-fork runtime. The dispatching entry requires that
- * runtime for every version on purpose — it is what stops a v9 caller drifting
- * into a v8 read with nothing to decode it — but that requirement is not the
- * v9 decode's own, and a v9-only consumer should not have to instantiate
- * multi-megabyte pre-fork WASM to read a state its own era wrote.
+ * Reachable without a pre-fork runtime, unlike {@link extractEncodedStateValue},
+ * which requires one for every era.
  *
- * Owns the same wrapping the dispatching entry applies: a rejected envelope
- * (malformed, truncated, over-long, or tagged for the other era) leaves as a
- * {@link DownConvertFailedError} at stage `'v9 envelope extraction'`, carrying
- * the runtime's own diagnosis on `cause`. The dispatching entry delegates here
- * rather than decoding again, so a failure is wrapped exactly once.
+ * @param raw The serialized `contract-state[v8]` envelope.
+ * @returns The primary state read out of the envelope.
+ * @throws DownConvertFailedError at stage `'v9 envelope extraction'` if the
+ * envelope is malformed, truncated, over-long, or tagged for the other era,
+ * carrying the runtime's own diagnosis on `cause`.
+ * @see {@link FailClosedDecoding}
  */
 export const extractV9EncodedStateValue = (raw: Uint8Array): EncodedStateValue => {
   try {
@@ -76,35 +62,22 @@ export const extractV9EncodedStateValue = (raw: Uint8Array): EncodedStateValue =
 };
 
 /**
- * One decoder per {@link LedgerVersion}. A `Record` rather than a ternary so
- * that adding a member to `LEDGER_VERSIONS` fails to compile here instead of
- * silently routing the new era's bytes to the pre-fork decoder — the same
- * discipline `version.ts` applies to its own mapping tables.
+ * One decoder per {@link LedgerVersion}:
  *
  * - `v9` — a post-fork `contract-state[v8]`-tagged envelope, read via
  *   `@midnightntwrk/ledger-v9`.
  * - `v8` — a pre-fork `contract-state[v6]`-tagged envelope, read via
  *   onchain-runtime-v3, the same codec that produced it.
  *
- * Built on a null prototype, and frozen. Both matter: this table is indexed by
- * a value that is only type-checked for TypeScript callers, and a plain object
- * literal resolves an unexpected key through `Object.prototype` — `'constructor'`
- * would hand the caller's own raw bytes straight back, and `'toString'` would
- * return `'[object Undefined]'` (the inherited method is read into a local and
- * called bare, so its `this` is `undefined` under ESM strict mode, not the
- * table). Both are typed as an `EncodedStateValue` and neither throws. The
- * freeze matches the discipline
- * `errors.ts` applies to its own tables: the one table whose mutation would
- * reroute contract-state bytes to the wrong era's codec should not be the one
- * left writable.
+ * A total `Record`, built on a null prototype and frozen -- see the
+ * SharedTableDiscipline document.
  */
 const ENVELOPE_DECODERS: Readonly<Record<LedgerVersion, EnvelopeDecoder>> = Object.freeze(
   Object.assign(Object.create(null) as Record<LedgerVersion, EnvelopeDecoder>, {
     v8: (raw: Uint8Array, ledger8ContractState: Ledger8ContractState): EncodedStateValue =>
       ledger8ContractState.deserialize(raw).data.state.encode(),
     // A reference to the standalone decoder, not a second copy of the same
-    // read: the two must not be able to drift apart, and the wrapping it
-    // already owns is why the dispatch below re-wraps nothing it raises.
+    // read -- see FailClosedDecoding.
     v9: extractV9EncodedStateValue
   } satisfies Record<LedgerVersion, EnvelopeDecoder>)
 );
@@ -113,48 +86,23 @@ const ENVELOPE_DECODERS: Readonly<Record<LedgerVersion, EnvelopeDecoder>> = Obje
  * Extracts the primary {@link EncodedStateValue} out of a raw, serialized
  * `ContractState` envelope, using the decoder that matches `version`.
  *
- * Never returns a silently empty or partial state: any deserialization
- * failure (malformed bytes, a truncated or over-long payload, or an envelope
- * tagged for the other ledger version) is wrapped in a
- * {@link DownConvertFailedError} with `{ cause }`, so failures propagate
- * loudly instead of producing a misleading result. The wrapped cause carries
- * the runtime's own diagnosis, which distinguishes a tag mismatch from
- * truncated, trailing, or empty bytes.
- *
- * `ledger8ContractState` is required for every `version`, not just `'v8'`,
- * and is checked before any decoding happens.
- *
- * Requiring it unconditionally costs nobody a runtime they would not otherwise
- * hold. This seam is reached only from the ledger-8 engine's own factory, which
- * has already awaited onchain-runtime-v3 to assemble the runtime it hands to
- * `downConvertForExecution`; the `'v9'` decoder is here so that the
- * *bridge* can read a post-fork envelope before down-converting it, not to
- * serve a caller who has no pre-fork runtime at all. Such a caller reads
- * ledger-v9 directly and never reaches this function. Note this is a statement
- * about the call graph, not about bundling — the separate reason the pre-fork
- * types are imported with `import type` (see {@link Ledger8ContractState}) is
- * unaffected either way.
- *
- * That is what makes the unconditional form the cheaper one: a single guard
- * covering both eras, with no era-conditional branch to keep correct and no
- * optional parameter weakening the one call that genuinely needs the argument.
- * It stops being free the moment this function is surfaced beyond the engine —
- * if a v9-only path ever calls it, move the check into the `'v8'` decoder and
- * make the parameter optional there.
- *
- * Checking it turns the omission into {@link Ledger8RuntimeInvalidError}
- * instead of a `TypeError` wrapped as a {@link DownConvertFailedError} — which
- * would name an extraction stage and point the caller at input bytes that are
- * not the problem.
- *
- * `version` is validated before it is used, rather than trusted from the type
- * signature. That guard is what keeps `stage` inside its closed union: it is
- * built from `version`, so an unvalidated string would otherwise reach a field
- * whose whole contract is that consumers can `switch` on it.
- *
- * No production caller passes anything but a literal today, and this function
- * is not reachable from any subpath export — see the note on collapsing this
- * dispatch in `packages/protocol/README.md`.
+ * @param raw The serialized envelope.
+ * @param version The era whose decoder reads `raw`. Validated at runtime, not
+ * merely type-checked.
+ * @param ledger8ContractState The pre-fork `ContractState` statics. Required
+ * for every `version`, not just `'v8'`, and checked before any decoding
+ * happens.
+ * @returns The primary state read out of the envelope — never a silently
+ * empty or partial one.
+ * @throws UnknownLedgerVersionError if `version` is not a member of
+ * `LEDGER_VERSIONS`.
+ * @throws Ledger8RuntimeInvalidError if `ledger8ContractState` does not carry
+ * `deserialize`.
+ * @throws DownConvertFailedError at stage `'v8 envelope extraction'` or
+ * `'v9 envelope extraction'` if the envelope cannot be read, carrying the
+ * runtime's own diagnosis on `cause`.
+ * @see {@link FailClosedDecoding}
+ * @see {@link SharedTableDiscipline}
  */
 export const extractEncodedStateValue = (
   raw: Uint8Array,
@@ -172,13 +120,9 @@ export const extractEncodedStateValue = (
   try {
     return decoder(raw, ledger8ContractState);
   } catch (cause) {
-    // Already coded, and already naming this exact stage: the v9 decoder wraps
-    // its own failure. THE STAGE IS CHECKED, not just the class — a decoder is
-    // injectable, so one that wrapped its failure at a different stage would
-    // otherwise pass straight through and tell a caller who asked for one era
-    // that the other era's codec rejected their bytes. Re-wrapping an
-    // already-correct failure would bury the runtime's diagnosis one level
-    // deeper for no gain.
+    // THE STAGE IS CHECKED, not just the class: a decoder is injectable, so one
+    // that wrapped at a different stage must not pass through -- see
+    // FailClosedDecoding.
     const stage: DownConvertStage = `${version} envelope extraction`;
     throw cause instanceof DownConvertFailedError && cause.stage === stage
       ? cause

--- a/packages/protocol/src/lib/era/envelope.ts
+++ b/packages/protocol/src/lib/era/envelope.ts
@@ -30,8 +30,9 @@ export type { EncodedStateValue };
  * The pre-fork `ContractState` statics {@link extractEncodedStateValue} needs
  * to read a `contract-state[v6]` envelope.
  *
- * @see {@link ModuleGraphAndLazyLoading} for why this slice is derived from the
- * vendor's own class, narrowed to `deserialize`, and reached by injection
+ * @see {@link InjectedVendorSlices} for why this slice is derived from the
+ * vendor's own class and narrowed to `deserialize`.
+ * @see {@link ModuleGraphAndLazyLoading} for why it is reached by injection
  * rather than by a value import.
  * @see {@link RetainedEraExecution} for the era pin the narrowing carries.
  */

--- a/packages/protocol/src/lib/era/era.ts
+++ b/packages/protocol/src/lib/era/era.ts
@@ -29,10 +29,8 @@ import type { LedgerVersion } from '../shared/ledger-version';
  * `loadLedgerEra` once and then writes era-agnostic code.
  *
  * Every value crossing this boundary is plain data: `Uint8Array`s and plain
- * objects, never a live WASM handle. That is what lets a caller hold a result
- * without also holding the module that produced it, keeps the two eras'
- * results comparable, and makes a result safe to send through a
- * `structuredClone` or a worker boundary.
+ * objects, never a live WASM handle, so a result outlives the module that
+ * produced it and survives a `structuredClone` or a worker boundary.
  *
  * The methods are synchronous. Asking for an era is the point at which its
  * runtime is acquired, so by the time a caller holds one of these there is

--- a/packages/protocol/src/lib/era/era.ts
+++ b/packages/protocol/src/lib/era/era.ts
@@ -37,6 +37,8 @@ import type { LedgerVersion } from '../shared/ledger-version';
  * The methods are synchronous. Asking for an era is the point at which its
  * runtime is acquired, so by the time a caller holds one of these there is
  * nothing left to await.
+ *
+ * @see {@link EraSeam}
  */
 export interface LedgerEra {
   /** The era this object is bound to — the value that was passed to `loadLedgerEra`. */
@@ -51,6 +53,11 @@ export interface LedgerEra {
    * failure is a `StateDecodeFailedError` naming this era, the same class
    * {@link LedgerEra.decodeContractState} raises, with the decoder's own
    * diagnosis on `cause`.
+   *
+   * @param raw The serialized contract-state envelope.
+   * @returns The primary state read out of the envelope.
+   * @throws StateDecodeFailedError if this era's decoder rejects `raw`.
+   * @see {@link FailClosedDecoding}
    */
   extractState(raw: Uint8Array): EncodedStateValue;
 
@@ -58,6 +65,13 @@ export interface LedgerEra {
    * Reads a raw, serialized contract-state envelope written by this era into
    * plain data: its primary state, and the entry points it declares with the
    * verifier key registered against each.
+   *
+   * @param raw The serialized contract-state envelope.
+   * @returns The decoded state. A `verifierKey` absent on an entry point means
+   * that slot was never deployed, not that the key is empty.
+   * @throws StateDecodeFailedError if this era's decoder rejects `raw`, or if
+   * the state cannot resolve an entry point it declares itself.
+   * @see {@link FailClosedDecoding}
    */
   decodeContractState(raw: Uint8Array): ContractStatePojo;
 
@@ -69,10 +83,20 @@ export interface LedgerEra {
    * proof server, neither of which this seam has.
    *
    * The two eras are not equivalent here, and the difference is deliberate
-   * rather than hidden: the retained pre-fork era composes exactly one call and
-   * refuses a Zswap offer outright, because its execution leg does not carry
-   * the coin movements such a call would make. Both refusals are raised, never
-   * worked around.
+   * rather than hidden: the retained pre-fork era composes exactly one call,
+   * because a cross-contract call is a ledger-9-only feature a pre-fork
+   * contract cannot emit. The refusal is raised, never worked around. A Zswap
+   * offer is NOT refused on either era.
+   *
+   * @param options The calls to compose and the transaction-wide envelope.
+   * @returns The serialized UNPROVEN transaction.
+   * @throws ComposeOptionError if an option is unusable on this era — an
+   * empty `networkId`, an invalid `ttl`, undecodable offer or state bytes, or
+   * a call tree with more than one entry on the retained pre-fork era.
+   * @throws ComposeFailedError if a call cannot be assembled; `stage` names
+   * which step refused it.
+   * @see {@link ComposeRefusalOrder}
+   * @see {@link EraSeam}
    */
   composeCallTx(options: ComposeCallOptions): Uint8Array;
 
@@ -84,6 +108,19 @@ export interface LedgerEra {
    * The address cannot be recomputed from the state a caller passed in — a
    * deploy mints a fresh nonce — which is why it is returned rather than left
    * to the caller to derive.
+   *
+   * @param options The initial state, its verifier keys, and the
+   * transaction-wide envelope.
+   * @returns The serialized UNPROVEN transaction, the address the deployment
+   * will have, and the initial state that address was derived from.
+   * @throws ComposeOptionError if an option is unusable on this era — an
+   * empty `networkId`, an invalid `ttl`, undecodable state bytes, or an
+   * omitted `verifierKeys` for a state that still declares a blank key.
+   * @throws ComposeFailedError if the supplied keys do not match the state's
+   * declared entry points, or if the ledger rejects a key blob; `stage` names
+   * which check refused it.
+   * @see {@link VerifierKeys}
+   * @see {@link ComposeRefusalOrder}
    */
   composeDeployTx(options: ComposeDeployOptions): DeployResultPojo;
 }

--- a/packages/protocol/src/lib/era/load-era.ts
+++ b/packages/protocol/src/lib/era/load-era.ts
@@ -35,23 +35,12 @@ export type {
 export type { ContractEntryPointPojo, ContractStatePojo } from '../shared/contract-state';
 export type { LedgerEra } from './era';
 
-// Both arms are frozen: a memoised era is one object shared by every caller in
-// the process, so an unfrozen one lets any consumer reassign `composeCallTx`
-// for all the others. The same discipline LEDGER_VERSIONS, PROTOCOL_ERROR_CODES
-// and ENVELOPE_DECODERS already apply to their own shared tables.
-//
-// One memo slot per era, not one shared slot. A shared slot would hand the
-// second caller whichever era happened to be asked for first, silently reading
-// one era's bytes with the other era's runtime — the exact confusion this
-// facade exists to remove.
+// One memo slot per era, never one shared slot, and both arms are frozen --
+// see SharedTableDiscipline and EraSeam.
 let v8EraPromise: Promise<LedgerEra> | undefined;
 let v9EraPromise: Promise<LedgerEra> | undefined;
 
-/**
- * The v9 arm. Wholly synchronous: `@midnightntwrk/ledger-v9` is this package's
- * current era and is already linked by the package root, so there is nothing
- * to acquire and nothing that can fail here.
- */
+/** The v9 arm. Wholly synchronous -- see the EraSeam document. */
 const createV9Era = (): LedgerEra => {
   const era: LedgerEra = {
     version: 'v9',
@@ -65,14 +54,9 @@ const createV9Era = (): LedgerEra => {
 };
 
 /**
- * The v8 arm. Acquires the retained pre-fork ledger through {@link loadLedger8}
- * — the only sanctioned runtime path to it — and binds it into closure, so the
- * era's own methods stay synchronous.
- *
- * Hoisting the acquisition here, rather than deferring it into each method, is
- * what makes the two arms symmetrical. It costs a v9-only consumer nothing:
- * asking for the v8 era IS the observation of v8, and nothing reaches this
- * function until someone does.
+ * The v8 arm. Acquires the retained pre-fork ledger and binds it into closure,
+ * so the era's own methods stay synchronous -- see the EraSeam document for why
+ * the acquisition is hoisted here.
  */
 const createV8Era = async (): Promise<LedgerEra> => {
   const v8 = await loadLedger8();
@@ -97,19 +81,18 @@ const createV8Era = async (): Promise<LedgerEra> => {
  * by hand.
  *
  * Memoised per era, so the retained pre-fork WASM is instantiated at most once
- * per process. A FAILED v8 acquisition is not memoised: the rejection
- * propagates unchanged — already a `Ledger8RuntimeMissingError` carrying the
- * underlying cause — and the next call retries, so a repaired install does not
- * stay broken for the life of the process.
+ * per process. A FAILED v8 acquisition is not memoised: the next call retries.
  *
- * Rejects with {@link UnknownLedgerVersionError} when `version` is not a member
- * of `LEDGER_VERSIONS`. A TypeScript caller cannot produce that; it exists for
- * the untyped JavaScript consumers this package also serves, where an era
- * string threaded from an indexer response would otherwise fall through to a
- * plausible-looking non-era. (`./envelope.ts` defends the same input
- * against resolving an inherited `Object.prototype` member, because its
- * dispatch is a lookup table; this one is a closed `switch`, where no string
- * can resolve to anything but a case or the default.)
+ * @param version The era to resolve.
+ * @returns The era facade bound to `version`. The same object on every call
+ * for that era, and frozen.
+ * @throws UnknownLedgerVersionError — as a rejection — if `version` is not a
+ * member of `LEDGER_VERSIONS`.
+ * @throws Ledger8RuntimeMissingError — as a rejection — if the retained
+ * pre-fork runtime cannot be acquired. It propagates unchanged, carrying the
+ * underlying cause.
+ * @see {@link EraSeam}
+ * @see {@link SharedTableDiscipline}
  */
 export const loadLedgerEra = (version: LedgerVersion): Promise<LedgerEra> => {
   switch (version) {
@@ -121,12 +104,8 @@ export const loadLedgerEra = (version: LedgerVersion): Promise<LedgerEra> => {
         throw error;
       }));
     default: {
-      // Compile-time exhaustiveness, in the style of version.ts's
-      // `_allLedgerVersionsAreMapped` and the Merkle walk in
-      // `../v8/down-convert.ts`: a new member of LEDGER_VERSIONS stops
-      // this assignment type-checking, so the omission is a build failure
-      // rather than a review miss. The runtime rejection is not redundant
-      // with it — `version` reaches here from untyped callers too.
+      // `const unhandled: never` is a compile-time exhaustiveness gate, and the
+      // runtime rejection is not redundant with it -- see SharedTableDiscipline.
       const unhandled: never = version;
       return Promise.reject(new UnknownLedgerVersionError(String(unhandled)));
     }

--- a/packages/protocol/src/lib/shared/assemble-call.ts
+++ b/packages/protocol/src/lib/shared/assemble-call.ts
@@ -31,10 +31,11 @@ import type { LedgerVersion } from './ledger-version';
 /**
  * The `QueryContext` capability {@link assembleCallPrototype} needs beyond
  * construction: the two settable members and the one method the pre-partition
- * bridge writes a {@link PartitionContext} through. Both eras' `QueryContext`
- * declare all three identically, and `insertCommitment` returns a NEW context
- * rather than mutating — hence `TSelf`, so the fold stays typed as the
- * module's own context rather than widening to this interface.
+ * bridge writes a {@link PartitionContext} through.
+ *
+ * @typeParam TSelf The module's own `QueryContext` type, which
+ * `insertCommitment` returns rather than mutating in place.
+ * @see {@link ComposeRefusalOrder}
  */
 export interface PartitionableQueryContext<TSelf> {
   block: CallContext;
@@ -44,19 +45,13 @@ export interface PartitionableQueryContext<TSelf> {
 
 /**
  * The structural surface a ledger module (ledger-v8 or ledger-v9) exposes for
- * assembling a call prototype. Both modules satisfy it with every type
- * parameter inferred from the module namespace itself, so callers pass the
- * module and never spell out type arguments. The
- * `AlignedValue`/`Op`/`EncodedStateValue`/`Transcript` payload types are
- * declared once against ledger-v9: they are structurally identical across
- * onchain-runtime-v3, ledger-v8 and ledger-v9 (compile-time drift gate at the
- * bottom of v8-down-convert.test.ts, which pins all three axes).
+ * assembling a call prototype. Every type parameter is inferred from the
+ * module namespace itself, so callers pass the module and never spell out type
+ * arguments.
  *
- * `Transcript` is spelled out rather than left as a type parameter because a
- * call can arrive with its transcript ALREADY partitioned (see
- * {@link CallTranscriptSource}), in which case the pair comes from the caller
- * rather than from this module's own partitioner — so there is no module-bound
- * type left to infer it from.
+ * @see {@link ComposeRefusalOrder} for why the payload types are declared once
+ * against ledger-v9, and why `Transcript` is spelled out rather than left as a
+ * type parameter.
  */
 export interface CallAssemblyLedger<
   TStateValue,
@@ -94,12 +89,10 @@ export interface CallAssemblyLedger<
 /**
  * The slice of a ledger `ContractState` {@link assembleCallPrototype} reads.
  *
- * `TOperation` is constrained to the one property this module inspects: a
- * registered operation must carry a verifier key for a call against it to be
- * verifiable. Both eras' `ContractOperation` declare `verifierKey` as a
- * required `Uint8Array`, but a slot that was never assigned one reads back
- * `undefined` — pinned by the operation-resolution tests, so a vendor change
- * fails a test rather than silently disabling the check below.
+ * @typeParam TOperation The resolved operation, constrained to the one
+ * property this module inspects: a registered operation must carry a verifier
+ * key for a call against it to be verifiable.
+ * @see {@link ComposeRefusalOrder}
  */
 export interface CallOperationRegistry<TOperation> {
   readonly operation: (circuitId: string) => TOperation | undefined;
@@ -112,11 +105,10 @@ export interface VerifiableOperation {
 
 /**
  * The stages {@link assembleCallPrototype} can reach on a failed operation
- * lookup. Narrower than {@link ComposeStage}: this function only ever
- * resolves a call's operation, so a caller cannot ask it to report a deploy
- * stage. Every other stage it can raise — the verifier-key, pre-call-state,
- * empty-transcript, partition and prototype stages — it chooses itself, and is
- * not a caller choice.
+ * lookup — the only stage choice a caller has, and narrower than
+ * {@link ComposeStage} for that reason.
+ *
+ * @see {@link ComposeRefusalOrder}
  */
 export type CallResolutionStage = Extract<ComposeStage, 'wrap-call' | 'call-operation'>;
 
@@ -143,27 +135,16 @@ export interface AssembleCallOptions<TOperation> {
   readonly communicationCommitmentRandomness?: string;
   readonly operations: CallOperationRegistry<TOperation>;
   readonly stage: CallResolutionStage;
-  // The era every failure raised here names. Passed rather than inferred from
-  // the ledger module: this function is generic over the module, so it has no
-  // way to ask which axis it was handed.
+  // The era every failure raised here names -- see ComposeRefusalOrder.
   readonly version: LedgerVersion;
 }
 
 /**
  * Writes the context a call recorded onto the query context its transcript is
- * about to be partitioned against — the step compact-js's own v9 leg performs
- * before it partitions (`ContractExecutable.js`: `asLedgerQueryContext` sets
- * `block` and `effects`, `partitionAllTranscripts` folds the commitment
- * indices). Constructing a `QueryContext` restores the STATE and nothing else,
- * so without this the ledger replays the program against a context the circuit
- * never ran on.
+ * about to be partitioned against. Returns the folded context, never the one
+ * it started from.
  *
- * The order matches that leg: set the two members, then fold. `insertCommitment`
- * returns a new context carrying whatever was already set, so the fold's result
- * is what everything downstream uses — never the context it started from.
- *
- * Every member is caller data the runtime validates itself, from inside wasm,
- * so the caller wraps this in its own coded stage.
+ * @see {@link ComposeRefusalOrder}
  */
 const bridgePartitionContext = <TQueryContext extends PartitionableQueryContext<TQueryContext>>(
   queryContext: TQueryContext,
@@ -179,30 +160,11 @@ const bridgePartitionContext = <TQueryContext extends PartitionableQueryContext<
 };
 
 /**
- * Resolves a call's guaranteed/fallible transcript pair.
+ * Resolves a call's guaranteed/fallible transcript pair: a partitioned source
+ * is passed through untouched, an unpartitioned one is bridged into the
+ * module's own `QueryContext` ({@link bridgePartitionContext}) and split there.
  *
- * A partitioned source is passed through untouched — the whole point of the
- * shape. Re-partitioning it would need a query context the caller no longer
- * has, to redo work compact-js already did.
- *
- * An unpartitioned source is bridged into the module's own `QueryContext` and
- * split there. The bridge is two steps: the state crosses as an envelope, then
- * the context the call recorded is written onto it
- * ({@link bridgePartitionContext}) — a context carrying only the state would
- * partition the program against one the circuit never ran on. The state
- * crossing is safe, not a lossy re-encode:
- * the `EncodedStateValue` algebra is structurally identical between
- * onchain-runtime-v3 and both ledger modules (compile-time drift gate in
- * v8-down-convert.test.ts). A state the module still cannot read is the
- * caller's, so it leaves as {@link ComposeFailedError} at stage
- * `'call-contract-state'` with the decoder's own failure on `cause`, rather
- * than as a raw WASM error. A recorded context the era cannot read leaves the
- * same way at stage `'call-partition-context'`, and a public transcript the
- * partitioner itself rejects at stage `'call-partition'`.
- *
- * `partitionTranscripts` then returning nothing for the single call submitted
- * is an internal invariant of the ledger module, not a caller error, so that
- * one throws a plain `Error` and deliberately carries no protocol error code.
+ * @see {@link ComposeRefusalOrder}
  */
 const resolvePartition = <
   TStateValue,
@@ -218,13 +180,8 @@ const resolvePartition = <
 ): readonly [Transcript<AlignedValue> | undefined, Transcript<AlignedValue> | undefined] => {
   const { transcript, contractAddress, circuitId, version } = options;
   if (transcript.kind === 'partitioned') {
-    // Only the CALLER-supplied pair is checked. An empty pair coming back from
-    // the module's own partitioner below is that module's answer for the
-    // program it was handed, and this seam does not overrule it. A partitioned
-    // source carrying neither half is different: it is a caller with nothing to
-    // compose, and a prototype built from it would claim a circuit ran while
-    // recording no operations — the same silent no-op `'call-empty'` refuses
-    // one level up.
+    // Only the CALLER-supplied pair is checked for emptiness, never the
+    // partitioner's own answer below -- see ComposeRefusalOrder.
     if (transcript.guaranteed === undefined && transcript.fallible === undefined) {
       throw new ComposeFailedError(version, 'call-transcript-empty', circuitId);
     }
@@ -245,11 +202,8 @@ const resolvePartition = <
     throw new ComposeFailedError(version, 'call-partition-context', circuitId, cause);
   }
 
-  // The public transcript is caller data in the ledger's own declared algebra,
-  // and nothing type-checks an op's operand into range, so the partitioner
-  // rejects a hand-built or re-encoded sequence with a raw runtime error whose
-  // stack starts inside wasm. Coded here so a caller catches the same shape it
-  // catches for every other caller fault on this seam.
+  // The partitioner rejects caller data with a raw error from inside wasm, so
+  // it is coded here -- see ComposeRefusalOrder.
   let partitioned: (readonly [Transcript<AlignedValue> | undefined, Transcript<AlignedValue> | undefined])[];
   try {
     partitioned = ledger.partitionTranscripts(
@@ -273,23 +227,27 @@ const resolvePartition = <
  * {@link resolvePartition}), and construct the module's
  * `ContractCallPrototype`.
  *
- * Every failure it raises is a {@link ComposeFailedError} naming `version` and
- * `circuitId`. Which stage it names:
- * - the caller's own `stage`, when `operations` has no registered operation for
- *   `circuitId`;
- * - `'call-verifier-key'`, when the operation it resolves carries no verifier
- *   key — rather than silently composing a call against a blank, unverifiable
- *   operation. This one is not a caller choice, because the diagnosis does not
- *   differ by leg: an operation without a key is unusable on either ledger axis;
- * - `'call-transcript-empty'`, `'call-contract-state'`,
- *   `'call-partition-context'` or `'call-partition'`, from resolving the
- *   transcript pair — see {@link resolvePartition};
- * - `'call-prototype'`, when the module rejects the call's own inputs.
- *
- * Nothing raised here is a raw runtime error, with one deliberate exception
- * documented on {@link resolvePartition}: a module whose partitioner returns
- * nothing has broken its own invariant, which is not a caller fault and carries
- * no protocol error code.
+ * @typeParam TQueryContext The module's own `QueryContext`. Every other type
+ * parameter is inferred from the module namespace, so callers pass the module
+ * and never spell out type arguments.
+ * @typeParam TOperation The resolved operation, constrained to
+ * {@link VerifiableOperation}.
+ * @param ledger The ledger module (ledger-v8 or ledger-v9) to assemble
+ * against.
+ * @param options The call's own inputs, the operation registry to resolve
+ * `circuitId` against, and the era to name in a failure.
+ * @returns The module's own `ContractCallPrototype` for this call.
+ * @throws ComposeFailedError naming `version` and `circuitId`, at
+ * `options.stage` when `operations` has no registered operation for
+ * `circuitId`; at `'call-verifier-key'` when the resolved operation carries no
+ * verifier key; at `'call-transcript-empty'`, `'call-contract-state'`,
+ * `'call-partition-context'` or `'call-partition'` from resolving the
+ * transcript pair; at `'call-prototype'` when the module rejects the call's
+ * own inputs.
+ * @throws Error, deliberately carrying no protocol error code, when the
+ * module's own partitioner returns no result — its invariant, not a caller
+ * fault.
+ * @see {@link ComposeRefusalOrder}
  */
 export const assembleCallPrototype = <
   TStateValue,
@@ -315,12 +273,7 @@ export const assembleCallPrototype = <
 
   const [guaranteed, fallible] = resolvePartition(ledger, options);
 
-  // Wrapped as one step rather than per argument: the constructor re-reads the
-  // transcript pair, the private outputs and the input/output values, all of
-  // which are caller data that nothing range-checks, and the failure a caller
-  // needs to act on is the same whichever field the runtime tripped over — the
-  // runtime's own message on `cause` names it. A partitioned pair is the
-  // sharpest case, having never passed through this process's own partitioner.
+  // Wrapped as one step rather than per argument -- see ComposeRefusalOrder.
   try {
     return new ledger.ContractCallPrototype(
       contractAddress,
@@ -332,11 +285,8 @@ export const assembleCallPrototype = <
       options.input,
       options.output,
       options.communicationCommitmentRandomness ?? ledger.communicationCommitmentRandomness(),
-      // The canonical, contract-qualified key location this framework's provers
-      // resolve artifacts by (see `encodeContractKeyLocation` and
-      // `ZKConfigRegistry`). A bare circuit id is ambiguous across contracts and
-      // `parseContractKeyLocation` rejects it, so a call carrying one cannot be
-      // proven through the registry or the DApp-connector path.
+      // The canonical, contract-qualified key location this framework's
+      // provers resolve artifacts by -- see ComposeRefusalOrder.
       encodeContractKeyLocation({
         contractAddress,
         circuitId,

--- a/packages/protocol/src/lib/shared/compose-options.ts
+++ b/packages/protocol/src/lib/shared/compose-options.ts
@@ -24,15 +24,13 @@ export interface ComposeEnvelopeOptions {
 
 /**
  * Rejects the two envelope options the ledger accepts but should not: an
- * empty `networkId`, and a `ttl` that is not a valid instant. Both are
- * silently absorbed by the WASM — an empty network id is baked into the
- * transaction, and an Invalid Date is recorded as the Unix epoch, yielding a
- * transaction that has already expired the moment it is composed. Neither
- * surfaces until submission, so both are refused here.
+ * empty `networkId`, and a `ttl` that is not a valid instant.
  *
- * This validates well-formedness only, never policy: which network a
- * deployment targets and how long a transaction should live remain the
- * caller's decisions.
+ * @param options The transaction-envelope options to check.
+ * @param version The era every failure raised here names.
+ * @throws ComposeOptionError naming option `'networkId'` for an empty network
+ * id, or `'ttl'` for a `ttl` that is not a valid instant.
+ * @see {@link ComposeRefusalOrder}
  */
 export const assertComposeEnvelope = (options: ComposeEnvelopeOptions, version: LedgerVersion): void => {
   if (options.networkId.length === 0) {

--- a/packages/protocol/src/lib/shared/compose-types.ts
+++ b/packages/protocol/src/lib/shared/compose-types.ts
@@ -27,24 +27,15 @@ import type {
  * The query-context state a call recorded while it ran, which its pre-call
  * state bytes do not carry.
  *
- * Partitioning an unpartitioned transcript replays its program against a query
- * context, and that context has to be the one the circuit actually ran on. A
- * context rebuilt from `preState` alone is not: constructing one restores the
- * state and nothing else. compact-js's own v9 leg carries exactly these three
- * pieces across the same boundary (`ContractExecutable.js`,
- * `asLedgerQueryContext` and `partitionAllTranscripts`).
+ * `block` and `effects` are the PRE-call values; `comIndices` is the POST-call
+ * map. Plain data on every member.
  *
- * `block` and `effects` are the PRE-call values, because the partitioner
- * recomputes both from the program it replays — post-call values would be
- * counted twice. `comIndices` is the POST-call map: the runtime registers a
- * received coin's commitment as the circuit produces it
- * (`createZswapOutput` in the retained 0.16 glue), and a call that received a
- * coin in-contract cannot be partitioned without it.
- *
- * Plain data on every member, so the whole record crosses an era boundary and
- * survives a `structuredClone`. `CallContext` and `Effects` are declared once
- * against ledger-v9 and are structurally identical on all three axes
- * (compile-time drift gate in engine-down-convert.test.ts).
+ * @see {@link ComposeRefusalOrder} for why partitioning needs the context the
+ * circuit actually ran on, and why `CallContext` and `Effects` are declared
+ * once against ledger-v9.
+ * @see {@link RetainedEraExecution} for why each member is read off the
+ * context it is.
+ * @see {@link EraSeam}
  */
 export interface PartitionContext {
   readonly block: CallContext;
@@ -57,18 +48,20 @@ export interface PartitionContext {
  * Where a call's public transcript comes from. Two shapes, because neither
  * production leg subsumes the other:
  *
- * - `'unpartitioned'` — the retained pre-fork execution leg hands over the raw
- *   op sequence a circuit emitted, together with the state it ran against.
- *   Splitting it into a guaranteed and a fallible half is the ledger's job, and
- *   needs both halves — plus the {@link PartitionContext} the leg recorded,
- *   which the state bytes alone do not carry.
- * - `'partitioned'` — the current production path receives transcripts already
- *   split by compact-js. Re-deriving the split would mean rebuilding a query
- *   context the caller no longer has, to redo work already done.
+ * - `'unpartitioned'` — the raw op sequence a circuit emitted on the retained
+ *   pre-fork execution leg, the state it ran against, and the
+ *   {@link PartitionContext} that leg recorded.
+ * - `'partitioned'` — a guaranteed/fallible pair already split by compact-js,
+ *   which is the current production path.
  *
  * Every member is plain data in the ledger's own declared algebra — no live
- * WASM handle — so a source can be built, stored and moved across a boundary
- * without the module that produced it.
+ * WASM handle.
+ *
+ * @see {@link RetainedEraExecution} for the leg that submits the unpartitioned
+ * shape.
+ * @see {@link ComposeRefusalOrder} for why an already-partitioned pair is
+ * passed through rather than re-derived.
+ * @see {@link EraSeam}
  */
 export type CallTranscriptSource =
   | {
@@ -87,14 +80,16 @@ export type CallTranscriptSource =
  * One contract call in a call transaction.
  *
  * `contractState` is the raw, serialized state the call is dispatched against,
- * as read from chain — BYTES, not a live handle, so the same entry is usable on
- * either era. It supplies the registered operation for `circuitId`, including
- * its verifier key, which the call's key location hashes; a constructor-built
- * state will not do, because it declares its entry points with blank keys.
+ * as read from chain. It supplies the registered operation for `circuitId`,
+ * including its verifier key, which the call's key location hashes; a
+ * constructor-built state will not do, because it declares its entry points
+ * with blank keys.
  *
  * `communicationCommitmentRandomness` is the randomness the runtime bound a
  * cross-contract callee to its caller with. The root call — being no one's
  * callee — omits it and gets fresh randomness.
+ *
+ * @see {@link EraSeam}
  */
 export interface ComposeCallEntry {
   readonly contractAddress: string;
@@ -113,10 +108,12 @@ export interface ComposeCallEntry {
  * `calls` is in execution-trace order: cross-contract callees first, the root
  * call last. A circuit with no cross-contract calls has a single entry.
  *
- * The two Zswap offers are serialized offer BYTES, not handles, for the same
- * reason `ComposeCallEntry.contractState` is. `networkId` and `ttl` carry the
- * caller's policy decisions — which network, how long the transaction lives —
- * but their well-formedness is checked before composition starts.
+ * The two Zswap offers are serialized offer bytes. `networkId` and `ttl` carry
+ * the caller's policy decisions — which network, how long the transaction
+ * lives.
+ *
+ * @see {@link ComposeRefusalOrder} for when the envelope options are checked.
+ * @see {@link EraSeam}
  */
 export interface ComposeCallOptions {
   readonly calls: readonly ComposeCallEntry[];
@@ -130,16 +127,15 @@ export interface ComposeCallOptions {
  * Everything a deploy transaction needs.
  *
  * `contractState` is the raw, serialized initial state the contract's
- * constructor produced — BYTES, not a live handle, so the same options are
- * usable on either era.
+ * constructor produced.
  *
  * `verifierKeys` maps entry-point name -> raw, tagged verifier key bytes
- * (`keys/<id>.verifier`). A compiled contract's constructor declares an
- * operation slot per circuit but leaves its verifier key blank, so a deploy
- * has to carry real keys or a ledger refuses it. When supplied, the map must
- * name exactly the entry points the state declares — no more, no fewer. Omit
- * it only for a state that ALREADY carries its keys; omitting it for a
- * constructor-built state deploys a contract with unregistered entry points.
+ * (`keys/<id>.verifier`). When supplied, the map must name exactly the entry
+ * points the state declares — no more, no fewer. Omit it only for a state that
+ * ALREADY carries its keys.
+ *
+ * @see {@link VerifierKeys}
+ * @see {@link EraSeam}
  */
 export interface ComposeDeployOptions {
   readonly contractState: Uint8Array;
@@ -152,15 +148,14 @@ export interface ComposeDeployOptions {
 /**
  * What a composed deploy hands back.
  *
- * Not a bare `Uint8Array`, because the transaction alone is not enough to use
- * the deployment: `contractAddress` is derived from the initial state AFTER
- * the verifier keys are registered AND a fresh nonce is minted, so a caller
- * cannot recompute it at all — repeating the registration would not reproduce
- * it — and `initialState` is the state that address was derived from — what a caller stores and later hands to a call.
+ * `contractAddress` cannot be recomputed from the state a caller passed in, so
+ * it is handed back here rather than derived. `initialState` is the state that
+ * address was derived from — what a caller stores and later hands to a call.
  *
- * All three are plain data, so the whole result survives a `structuredClone`.
- * That is a transport guarantee, not an immutability one: `readonly` freezes
- * each reference, not the bytes behind it.
+ * All three are plain data.
+ *
+ * @see {@link VerifierKeys} for why the address cannot be recomputed.
+ * @see {@link EraSeam}
  */
 export interface DeployResultPojo {
   readonly transaction: Uint8Array;

--- a/packages/protocol/src/lib/shared/contract-state.ts
+++ b/packages/protocol/src/lib/shared/contract-state.ts
@@ -43,9 +43,10 @@ export interface DecodableContractState {
  * The era module slice {@link decodeContractStateWith} needs: just the
  * `ContractState` class and its static reader.
  *
- * @see {@link ModuleGraphAndLazyLoading} for why this slice is declared
- * structurally rather than derived from one era's class, and why the module is
- * injected rather than imported.
+ * @see {@link InjectedVendorSlices} for why this slice is declared
+ * structurally rather than derived from one era's class.
+ * @see {@link ModuleGraphAndLazyLoading} for why the module is injected rather
+ * than imported.
  */
 export interface ContractStateDecoder {
   readonly ContractState: { readonly deserialize: (raw: Uint8Array) => DecodableContractState };

--- a/packages/protocol/src/lib/shared/contract-state.ts
+++ b/packages/protocol/src/lib/shared/contract-state.ts
@@ -30,9 +30,8 @@ export interface DecodableContractOperation {
  * Both eras' class satisfies it structurally, which is what lets one decoder
  * serve both axes without either era's types being named here.
  *
- * `maintenanceAuthority` and `balance` are deliberately absent: nothing in this
- * framework reads them off a decoded state, and a field carried "in case"
- * becomes a field a caller depends on.
+ * @see {@link FailClosedDecoding} for why `maintenanceAuthority` and `balance`
+ * are deliberately absent.
  */
 export interface DecodableContractState {
   readonly data: { readonly state: { readonly encode: () => EncodedStateValue } };
@@ -44,16 +43,9 @@ export interface DecodableContractState {
  * The era module slice {@link decodeContractStateWith} needs: just the
  * `ContractState` class and its static reader.
  *
- * Declared structurally rather than derived from one era's class, because this
- * decoder genuinely serves BOTH axes — the v9 arm passes ledger-v9, the v8 leg
- * passes the module `loadLedger8` handed it — and naming either era's type here
- * would pick a side. `Ledger8ContractState` (`../era/envelope.ts`) is the
- * single-era counterpart and IS derived from the vendor for that reason.
- *
- * Injection is a separate matter, and still required: a value import of either
- * era's module would statically link its WASM into whatever bundle reaches this
- * one, so a consumer of the other era would pay for a runtime it never calls.
- * Naming a type does not — type-only imports are erased.
+ * @see {@link ModuleGraphAndLazyLoading} for why this slice is declared
+ * structurally rather than derived from one era's class, and why the module is
+ * injected rather than imported.
  */
 export interface ContractStateDecoder {
   readonly ContractState: { readonly deserialize: (raw: Uint8Array) => DecodableContractState };
@@ -64,10 +56,10 @@ export interface ContractStateDecoder {
  * against it if there is one.
  *
  * `verifierKey` and `verifierKeyHash` are both absent for a blank slot — the
- * shape a constructor-built state has before a deploy fills it in. They are
- * absent rather than zero-length or a hash of nothing on purpose: hashing an
- * empty key yields a real-looking digest that a caller comparing hashes would
- * match against a contract that was never deployed.
+ * shape a constructor-built state has before a deploy fills it in.
+ *
+ * @see {@link FailClosedDecoding} for why they are absent rather than
+ * zero-length or a hash of nothing.
  */
 export interface ContractEntryPointPojo {
   readonly circuitId: string;
@@ -79,11 +71,11 @@ export interface ContractEntryPointPojo {
  * A contract state as plain data: the primary state in its encoded form, and
  * the entry points the state declares.
  *
- * `entryPoints` is an ARRAY, not a map keyed by circuit id. A contract state
- * can declare two distinct byte entry points that decode to the same name
- * (bytes that are not valid UTF-8 both resolve to the replacement character),
- * and a name-keyed result would silently drop one of them. An array leaves both
- * visible to a caller that has to reconcile them.
+ * `entryPoints` is an ARRAY, not a map keyed by circuit id: two distinct byte
+ * entry points can decode to the same name, and a caller has to reconcile
+ * them.
+ *
+ * @see {@link FailClosedDecoding}
  */
 export interface ContractStatePojo {
   readonly state: EncodedStateValue;
@@ -94,13 +86,14 @@ export interface ContractStatePojo {
  * Reads the primary state out of a raw envelope with the given era's extractor,
  * reporting every failure as {@link StateDecodeFailedError} naming `version`.
  *
- * Exists so the facade's two read methods fail the SAME way. Underneath, the
- * extractors raise `DownConvertFailedError` naming an extraction stage — a
- * class with no `version` field, and a diagnosis phrased around down-converting
- * a state for execution, which is not what a caller asking to read a state was
- * doing. A caller handed one era's bytes on the other era's object should learn
- * that from `extractState` and `decodeContractState` alike, not have to know
- * which of the two it called. The extractor's own diagnosis stays on `cause`.
+ * @param raw The serialized contract-state envelope.
+ * @param version The era whose extractor is used, and which every failure
+ * raised here names.
+ * @param extract The era's own envelope extractor.
+ * @returns The primary state read out of the envelope.
+ * @throws StateDecodeFailedError for every failure, carrying the extractor's
+ * own diagnosis on `cause`.
+ * @see {@link FailClosedDecoding}
  */
 export const extractStateWith = (
   raw: Uint8Array,
@@ -120,14 +113,18 @@ export const extractStateWith = (
  *
  * Nothing that crosses back is a live WASM handle: the primary state leaves as
  * an `EncodedStateValue` (plain objects, arrays, `Map`s, `Uint8Array`s and
- * primitives) and each entry point as a plain record. A caller therefore cannot
- * hold an object whose owning module it cannot see, and the result survives a
- * `structuredClone`.
+ * primitives) and each entry point as a plain record.
  *
- * Every failure leaves as {@link StateDecodeFailedError} naming `version` — the
- * era whose decoder was used — with the decoder's own diagnosis on `cause`. The
- * whole read is covered, not just the deserialization, so no raw runtime error
- * escapes this seam uncoded.
+ * @param raw The serialized contract-state envelope.
+ * @param version The era whose decoder is used, and which every failure raised
+ * here names.
+ * @param ledger The era module slice carrying its own `ContractState`.
+ * @returns The state and the entry points it declares, as plain data.
+ * @throws StateDecodeFailedError for every failure — the whole read is
+ * covered, not just the deserialization — with the decoder's own diagnosis on
+ * `cause`.
+ * @see {@link FailClosedDecoding}
+ * @see {@link EraSeam}
  */
 export const decodeContractStateWith = (
   raw: Uint8Array,
@@ -137,14 +134,8 @@ export const decodeContractStateWith = (
   try {
     const decoded = ledger.ContractState.deserialize(raw);
     const entryPoints = decoded.operations().map((entryPoint): ContractEntryPointPojo => {
-      // Not `?.`: `entryPoint` came from `operations()` on this same object, so
-      // a state that cannot resolve it is internally inconsistent, not a state
-      // with a blank slot. Optional chaining collapsed the two into the same
-      // answer, and `verifierKey: undefined` has a specific documented meaning
-      // — never deployed. A whole contract reading as never-deployed would send
-      // a caller comparing key hashes hunting a deployment bug that does not
-      // exist, so this leaves as StateDecodeFailedError like every other read
-      // failure here.
+      // Deliberately not optional-chained: an unresolvable entry point is an
+      // inconsistent state, not a blank slot -- see FailClosedDecoding.
       const operation = decoded.operation(entryPoint);
       if (operation === undefined) {
         throw new Error(

--- a/packages/protocol/src/lib/shared/ledger-version.ts
+++ b/packages/protocol/src/lib/shared/ledger-version.ts
@@ -19,22 +19,9 @@
  * `protocolVersionToLedger` (`../version.ts`) for how a raw `protocolVersion`
  * integer maps onto it.
  *
- * Held in a leaf module that imports nothing, and re-exported unchanged by
- * `../version.ts`, so the public surface is the one it always was. Two modules
- * need this set, and the dependency between them runs one way: `../version.ts`
- * imports `../errors.ts` for the error it throws, while `../errors.ts` imports
- * nothing but this file. Declaring the constant in `../version.ts` would
- * therefore close a cycle. Declaring it in `../errors.ts` would not, but it
- * would put the era vocabulary in the error module and make every reader of it
- * an importer of errors. A leaf both can reach keeps the direction and the
- * ownership straight.
- *
- * Frozen, not merely `as const`: it is a public exported constant, and an
- * unfrozen array is one a downstream package can mutate for every other
- * consumer in the process. The same discipline `PROTOCOL_ERROR_CODES` applies
- * to its own registry. Nothing reads the value at runtime to dispatch on — the
- * era tables are typed by `LedgerVersion` and built independently — so this
- * guards the export, not the dispatch.
+ * @see {@link SharedTableDiscipline} for why the array is frozen.
+ * @see {@link ModuleGraphAndLazyLoading} for why the constant is declared in
+ * this leaf module and re-exported by `../version.ts`.
  */
 export const LEDGER_VERSIONS = Object.freeze(['v8', 'v9'] as const);
 export type LedgerVersion = (typeof LEDGER_VERSIONS)[number];

--- a/packages/protocol/src/lib/shared/unshielded.ts
+++ b/packages/protocol/src/lib/shared/unshielded.ts
@@ -34,21 +34,13 @@ export interface CallTranscriptPair {
  * The era module slice {@link aggregateUnshieldedOffers} needs: just the
  * `UnshieldedOffer` constructor.
  *
- * Declared structurally, and generic in `TOffer`, because this function
- * genuinely runs on BOTH eras — the v9 composition arm passes ledger-v9, the v8
- * leg passes the module it was handed by `loadLedger8`. Deriving the shape from
- * either era's class would pick a side, which is why this one stays a
- * hand-written slice while the single-era injection points are derived from
- * their vendor's own declarations.
- *
- * Injection is a separate matter, and still required: a value import of either
- * era would statically link that era's WASM into whatever bundle reaches this
- * module, which for ledger-v8 is exactly what `dist-laziness.test.ts` forbids.
- * A type-only import would not, but there is no single type to name here.
- *
- * `inputs` and `signatures` are typed `never[]` rather than the ledger's own
- * parameter types: this seam only ever aggregates OUTPUTS, so `[]` is the only
- * value that can be passed, and the type says so instead of a comment.
+ * @typeParam TOffer The offer type the era's own `UnshieldedOffer.new`
+ * returns, inferred from the module that is passed.
+ * @see {@link ComposeRefusalOrder} for why this slice is hand-written and
+ * generic rather than derived from one era's class, and why `inputs` and
+ * `signatures` are typed `never[]`.
+ * @see {@link ModuleGraphAndLazyLoading} for why the module is injected rather
+ * than imported.
  */
 export interface UnshieldedOfferLedger<TOffer> {
   readonly UnshieldedOffer: {
@@ -65,33 +57,17 @@ export interface AggregatedUnshieldedOffers<TOffer> {
 /**
  * Reads the UTXO outputs a call's transcript claims on behalf of USERS.
  *
- * A contract-addressed claimed spend is skipped, and cross-contract calls make
- * that a normal, expected case rather than an oddity. It is safe to skip
- * because a cross-contract transfer is never materialized as a UTXO: the
- * ledger settles it against the callee's own balance update, under the
- * `real_unshielded_spends` superset check, and `UtxoOutput.owner` takes a user
- * address in the first place. Emitting an output for one would add a payout
- * the transaction cannot cover.
- *
- * A user-addressed spend this seam cannot pay out is REFUSED, not skipped. That
- * is a different case from a contract-addressed spend, which is not a UTXO
- * payout at all: this one is a payout the transaction has no way to make.
- * Dropping it silently composes a transaction that tells the user they were
- * paid and pays them nothing, so it leaves as a coded failure at composition
- * time instead.
- * Two token types reach that refusal — dust, which carries no raw token type to
- * pay out in, and a shielded type, whose value moves through a Zswap offer
- * rather than a UTXO.
- *
- * The check is on the ONE type this seam can pay out rather than on a list of
- * the ones it cannot. `TokenType` is a vendor union, and a shielded type
- * carries a `raw` field exactly as an unshielded one does, so an
- * exclude-what-we-know-about test emits a plausible-looking `UtxoOutput` for
- * everything it has not heard of. A fourth member added by a vendor bump has to
- * fail closed here, not compose a payout nothing can settle.
- *
- * An absent transcript is the normal shape of a call with no fallible half, not
- * an error, so it yields no outputs rather than throwing.
+ * @param transcript One half of a call's transcript pair. Absent is the normal
+ * shape of a call with no fallible half, and yields no outputs.
+ * @param version The era every failure raised here names.
+ * @param circuitId The entry point every failure raised here names.
+ * @returns One `UtxoOutput` per user-addressed unshielded spend the transcript
+ * claims. Contract-addressed spends are skipped.
+ * @throws ComposeFailedError at stage `'call-dust-payout'` for a user-addressed
+ * dust spend.
+ * @throws ComposeFailedError at stage `'call-unsupported-payout'` for a
+ * user-addressed spend of any token type other than unshielded.
+ * @see {@link ComposeRefusalOrder}
  */
 export const extractUserAddressedOutputs = (
   transcript: Transcript<AlignedValue> | undefined,
@@ -122,15 +98,16 @@ export const extractUserAddressedOutputs = (
  * Builds the one unshielded offer each segment of a transaction carries, from
  * EVERY call in the tree.
  *
- * A user-addressed output can be produced by any call, not just the root, and a
- * transaction has a single guaranteed and a single fallible offer. Assembling
- * either from the root call alone would drop a cross-contract callee's payout
- * and leave the transaction unbalanced — rejected on submission, with nothing
- * having reported a problem at composition time.
- *
- * A segment with nothing to pay out gets no offer at all rather than an empty
- * one: the ledger expects the field left unset, not a declared offer paying out
- * nothing.
+ * @typeParam TOffer The offer type `ledger.UnshieldedOffer.new` returns.
+ * @param calls Every call in the transaction's tree — cross-contract callees
+ * as well as the root call, since any of them can produce a payout.
+ * @param ledger The era module slice carrying `UnshieldedOffer`.
+ * @param version The era every failure raised here names.
+ * @returns The guaranteed and fallible offers. A segment with nothing to pay
+ * out gets no offer at all rather than an empty one.
+ * @throws ComposeFailedError from {@link extractUserAddressedOutputs} for a
+ * user-addressed spend this seam cannot pay out.
+ * @see {@link ComposeRefusalOrder}
  */
 export const aggregateUnshieldedOffers = <TOffer>(
   calls: readonly CallTranscriptPair[],

--- a/packages/protocol/src/lib/shared/verifier-keys.ts
+++ b/packages/protocol/src/lib/shared/verifier-keys.ts
@@ -19,17 +19,10 @@ import type { LedgerVersion } from './ledger-version';
 /**
  * Resolves a ledger entry-point key to its name.
  *
- * `ContractState.operations()` is declared `Array<string | Uint8Array>`, so a
- * key is not statically a string. In practice ledger-v8 decodes even a byte-set
- * entry point back to a string (pinned by the `entryPointName` suite in
- * `v8-deploy.test.ts`; the v9 side of that behaviour is not pinned
- * against the real vendor), but the declared union has to be resolved
- * somewhere, and decoding is the only resolution that keeps an error message
- * naming the entry point rather than dumping its bytes — which is what
- * `ComposeFailedError` (`../errors.ts`) promises.
- *
- * Lives in a leaf both eras can reach, so neither arm has to import the other's
- * era-named module for a `TextDecoder` call.
+ * @param id The entry point as the state declares it — already a string, or
+ * the bytes a byte-declared entry point carries.
+ * @returns `id` itself when it is a string, otherwise its UTF-8 decoding.
+ * @see {@link VerifierKeys}
  */
 export const entryPointName = (id: string | Uint8Array): string =>
   typeof id === 'string' ? id : new TextDecoder().decode(id);
@@ -46,38 +39,24 @@ export interface VerifierKeyRegistration {
 /**
  * Pairs each supplied verifier key with the entry point the state declares for
  * it, after validating the map against those entry points in BOTH directions:
+ * every key must name a declared entry point, and every declared entry point
+ * must have a key.
  *
- * - a key naming an entry point the state does not declare throws
- *   {@link ComposeFailedError} at stage `'deploy-unknown-circuit'`. This
- *   direction matters as much as the other: `setOperation` CREATES a slot
- *   rather than requiring one, so an unchecked stray key (a stale
- *   `keys/*.verifier` from an earlier compiler run) would give the deployed
- *   contract an entry point its source never had and — since the deploy derives
- *   its address from the initial state — silently deploy it at a different
- *   address than the caller's artifacts describe;
- * - a declared entry point with no key in the map throws stage
- *   `'deploy-verifier-key'`, because a ledger rejects a deploy carrying an
- *   unregistered entry point.
- *
- * Together the two make the map and the declared entry points equal sets. They
- * run on resolved NAMES, because that is how the map is keyed, so two declared
- * entry points resolving to one name would make them agree while leaving a slot
- * blank; that case throws stage `'deploy-ambiguous-circuit'` before either
- * check runs.
- *
- * Returns registrations in the map's own order, each carrying the DECLARED
- * entry point rather than its resolved name: `setOperation` handed the name
- * would leave a byte-declared slot blank and create a second, undeclared one
- * beside it.
- *
- * Shared by both eras' deploy legs, so the two cannot drift on which checks run
- * or in what order. The order is itself part of the contract: ambiguity is
- * refused before either set-comparison runs, because an ambiguous pair makes
- * both comparisons agree while leaving one slot blank.
- *
- * Resolving each key inside the loop is what removes the non-null assertion the
- * set arithmetic would otherwise need at the end: the `undefined` branch IS the
- * `'deploy-verifier-key'` check, not an unreachable case to assert away.
+ * @param entryPoints The entry points the state declares, as `operations()`
+ * returns them.
+ * @param verifierKeys Entry-point name -> raw, tagged verifier key bytes.
+ * @param version The era every failure raised here names.
+ * @returns One registration per supplied key, in the map's own order, each
+ * carrying the DECLARED entry point rather than its resolved name — which is
+ * what `setOperation` must be handed.
+ * @throws ComposeFailedError at stage `'deploy-ambiguous-circuit'` when two
+ * declared entry points resolve to the same name. Checked before either
+ * direction below.
+ * @throws ComposeFailedError at stage `'deploy-unknown-circuit'` when a key
+ * names an entry point the state does not declare.
+ * @throws ComposeFailedError at stage `'deploy-verifier-key'` when a declared
+ * entry point has no key in the map.
+ * @see {@link VerifierKeys}
  */
 export const resolveVerifierKeyRegistrations = (
   entryPoints: readonly (string | Uint8Array)[],

--- a/packages/protocol/src/lib/v8/adapt.ts
+++ b/packages/protocol/src/lib/v8/adapt.ts
@@ -24,8 +24,7 @@ import type { ProtocolV8 } from './load';
 /**
  * Bridges a raw, serialized contract state into the v8 era, reporting a
  * rejected envelope as {@link ComposeOptionError} rather than letting a raw
- * decoder failure escape — the same wrapping the v9 arm applies to the
- * identical call.
+ * decoder failure escape.
  */
 const readContractState = (raw: Uint8Array, v8: ProtocolV8): InstanceType<ProtocolV8['ContractState']> => {
   try {
@@ -37,17 +36,10 @@ const readContractState = (raw: Uint8Array, v8: ProtocolV8): InstanceType<Protoc
 
 /**
  * Reads a serialized Zswap offer into the v8 era, reporting bytes this era
- * cannot decode as {@link ComposeOptionError} — the same wrapping the v9 arm
- * applies to the identical call (`./compose-v9.ts`). An absent offer is the
- * normal shape of a call that moved no shielded coins, and stays absent.
+ * cannot decode as {@link ComposeOptionError}. An absent offer is the normal
+ * shape of a call that moved no shielded coins, and stays absent.
  *
- * Both eras carry an offer. The retained era executes coin-moving circuits and
- * hands their post-call Zswap local state back on the transcript
- * (`../engine/execute.ts`), which is what a caller turns into the offer it
- * passes here (`zswapStateToSegmentedOffer`,
- * `packages/contracts/src/utils/zswap-utils.ts`). Refusing the offer on this
- * era would take away the only way to attach those coin movements to the
- * transaction that carries the call.
+ * @see {@link ComposeRefusalOrder}
  */
 const readZswapOffer = (raw: Uint8Array | undefined, v8: ProtocolV8): UnprovenOffer | undefined => {
   if (raw === undefined) {
@@ -64,29 +56,31 @@ const readZswapOffer = (raw: Uint8Array | undefined, v8: ProtocolV8): UnprovenOf
  * Maps the era-facade's call options onto the v8-native composition leg
  * (`./compose.ts`).
  *
- * One shape the facade allows is not expressible on this era and is refused
- * rather than silently narrowed: a call tree with more than one entry. A
- * cross-contract call is a ledger-9-only feature that a pre-fork contract
- * cannot emit at all, so this era has no call tree to compose, and composing
- * only the first entry would drop the rest without a word.
+ * This era composes exactly one call: a `calls` tree with more than one entry
+ * is refused rather than silently narrowed. A Zswap offer is NOT refused.
  *
- * A Zswap offer is NOT refused — see {@link readZswapOffer}.
+ * @param options The era-facade call options.
+ * @param v8 The v8 ledger module, as handed over by `loadLedger8`
+ *   (`./load.ts`).
+ * @returns The UNPROVEN, serialized call transaction.
+ * @throws ComposeOptionError If an option cannot be used: a malformed envelope
+ *   option, unreadable offer or contract-state bytes, or more than one entry in
+ *   `calls`.
+ * @throws ComposeFailedError If `calls` is empty (stage `'call-empty'`), and
+ *   for every stage the composition leg this delegates to can raise.
+ * @see {@link ComposeRefusalOrder}
+ * @see {@link EraSeam}
  */
 export const composeEraV8CallTx = (options: ComposeCallOptions, v8: ProtocolV8): Uint8Array => {
   const { calls, networkId, ttl, guaranteedZswapOffer, fallibleZswapOffer } = options;
-  // Checked here rather than left to the inner leg, so this arm refuses the
-  // options in the SAME order the v9 arm does: envelope, then the call list,
-  // then the offers, then the era's own limits, then the state. A caller
-  // handing both an empty network id and unreadable offer bytes has one defect
-  // to fix per era, not a different one per era. The inner leg checks the
-  // envelope again; the check is idempotent, and leaving it there keeps
-  // `composeV8CallTx` safe to call directly.
+  // Checked here, not left to the inner leg, so both arms refuse in the same
+  // order; the re-check in the leg is idempotent -- see ComposeRefusalOrder.
   assertComposeEnvelope(options, 'v8');
   if (calls.length === 0) {
     throw new ComposeFailedError('v8', 'call-empty', NO_CIRCUIT);
   }
-  // Both offers are read before anything is composed, so a caller handed bad
-  // offer bytes learns that instead of paying for a full assembly first.
+  // Both offers are read before anything is composed -- see
+  // ComposeRefusalOrder.
   const guaranteedOffer = readZswapOffer(guaranteedZswapOffer, v8);
   const fallibleOffer = readZswapOffer(fallibleZswapOffer, v8);
   if (calls.length > 1) {
@@ -118,25 +112,24 @@ export const composeEraV8CallTx = (options: ComposeCallOptions, v8: ProtocolV8):
  * (`./deploy.ts`).
  *
  * `verifierKeys` is optional on the facade but required here: this era's deploy
- * leg registers the compiled contract's keys onto the initial state itself, and
- * a constructor-built state declares every entry point with a blank key. A
- * deploy composed without the map would carry unregistered entry points and be
- * refused by the ledger's own well-formedness check, so the omission is
- * reported as {@link ComposeOptionError} here instead.
+ * leg registers the compiled contract's keys onto the initial state itself, so
+ * the omission is reported as {@link ComposeOptionError}.
  *
  * The contract state crosses into the leg by BYTES, which is what that leg
- * takes: it deserializes into its own era rather than accepting a handle, so
- * no object is passed between two WASM copies.
+ * takes: it deserializes into its own era rather than accepting a handle.
  *
- * One ordering difference from the v9 arm survives on purpose. Both check the
- * envelope first and the offer second, but v9 reads the state before it looks
- * at `verifierKeys`, while this arm cannot: the state is read by the leg it
- * delegates to, and reading it here as well would deserialize the same bytes
- * twice. So a deploy that is BOTH unreadable and missing its key map reports
- * `'contractState'` on v9 and `'verifierKeys'` here. Both name a real defect in
- * the same call, and closing the gap costs a redundant deserialization of every
- * deploy to reorder a diagnosis for a caller who has two things to fix either
- * way.
+ * @param options The era-facade deploy options.
+ * @param v8 The v8 ledger module, as handed over by `loadLedger8`
+ *   (`./load.ts`).
+ * @returns The UNPROVEN, serialized deploy transaction, the address it deploys
+ *   at, and the registered initial state.
+ * @throws ComposeOptionError If an option cannot be used: a malformed envelope
+ *   option, unreadable offer bytes, or an omitted `verifierKeys` map.
+ * @throws ComposeFailedError For every stage the deploy leg this delegates to
+ *   can raise.
+ * @see {@link VerifierKeys}
+ * @see {@link ComposeRefusalOrder}
+ * @see {@link EraSeam}
  */
 export const composeEraV8DeployTx = (options: ComposeDeployOptions, v8: ProtocolV8): DeployResultPojo => {
   const { contractState, verifierKeys, networkId, ttl, guaranteedZswapOffer } = options;

--- a/packages/protocol/src/lib/v8/compose.ts
+++ b/packages/protocol/src/lib/v8/compose.ts
@@ -32,19 +32,17 @@ import type { ProtocolV8 } from './load';
  * will not do: it declares its entry points with blank keys.
  *
  * The call's own inputs are carried as plain data rather than as a whole
- * execution transcript: this leg is reached from the era facade, across which
- * only bytes and plain objects travel, so it can no longer be handed a
- * transcript holding a live pre-fork `ChargedState`.
+ * execution transcript — never a live pre-fork handle.
  *
- * The two Zswap offers are v8-native offer HANDLES, not bytes: this leg runs
- * inside the retained era with the module already in hand, so the era arm that
- * reads a caller's offer bytes (`../era/adapt-v8.ts`) hands the decoded offer
- * straight over — exactly as it already does for `contractState`. Absent
- * offers are the normal shape of a call that moved no shielded coins.
+ * The two Zswap offers are v8-native offer HANDLES, not bytes. Absent offers
+ * are the normal shape of a call that moved no shielded coins.
  *
  * `networkId` and `ttl` carry the caller's policy decisions (which network,
- * how long the transaction lives), but their well-formedness is checked here
- * — see `assertComposeEnvelope` (`../shared/compose-options.ts`).
+ * how long the transaction lives); their well-formedness is checked here — see
+ * `assertComposeEnvelope` (`../shared/compose-options.ts`).
+ *
+ * @see {@link EraSeam}
+ * @see {@link ComposeRefusalOrder}
  */
 export interface ComposeV8CallOptions {
   readonly circuitId: string;
@@ -64,27 +62,23 @@ export interface ComposeV8CallOptions {
 /**
  * Composes a v8-native call transaction from one call's inputs and immediately
  * serializes it. The call prototype comes from {@link assembleCallPrototype}
- * against the injected v8 module. This is the "same-era" leg: both the
- * circuit's execution and the call it produces are bound entirely on the
- * ledger-v8 axis, as opposed to `wrapKeepStateCall` (`../v9/wrap.ts`),
- * which binds a retained-execution transcript natively onto the current
- * ledger-v9 axis instead.
+ * against the injected v8 module.
  *
  * Never proves the transaction: the returned bytes are an UNPROVEN,
  * tag-prefixed serialization, exactly what `Transaction.serialize()` produces
- * before `.prove()` is ever called. Proving needs a proving provider and a
- * running proof server, neither of which this seam has.
+ * before `.prove()` is ever called.
  *
- * Uses `Transaction.fromPartsRandomized`, so the intent lands at a random
- * segment id and stays mergeable with other calls — matching the v9 call path
- * in `packages/contracts/src/utils/ledger-utils.ts`. Only deploys use a fixed
- * segment; see `composeV8DeployTx` (`./deploy.ts`).
- *
- * Throws `ComposeFailedError` (`../../errors.ts`) when `contractState`
- * has no registered operation for `circuitId` (stage
- * `'call-operation'`), or when the operation it does have carries no verifier
- * key (stage `'call-verifier-key'`), rather than composing a call no ledger
- * could verify.
+ * @param options The call's inputs, offers and envelope options.
+ * @param v8 The v8 ledger module, as handed over by `loadLedger8`
+ *   (`./load.ts`).
+ * @returns The UNPROVEN, serialized call transaction.
+ * @throws ComposeOptionError If `networkId` is empty or `ttl` is not a valid
+ *   instant.
+ * @throws ComposeFailedError If `contractState` has no registered operation for
+ *   `circuitId` (stage `'call-operation'`), or the operation it does have
+ *   carries no verifier key (stage `'call-verifier-key'`), plus every stage
+ *   {@link assembleCallPrototype} and {@link aggregateUnshieldedOffers} raise.
+ * @see {@link ComposeRefusalOrder}
  */
 export const composeV8CallTx = (options: ComposeV8CallOptions, v8: ProtocolV8): Uint8Array => {
   const { contractAddress, contractState, networkId, ttl, guaranteedZswapOffer, fallibleZswapOffer } = options;
@@ -105,13 +99,8 @@ export const composeV8CallTx = (options: ComposeV8CallOptions, v8: ProtocolV8): 
 
   const intent = v8.Intent.new(ttl).addCall(prototype);
 
-  // Read the partitioned pair back off the intent rather than re-deriving it:
-  // these are the exact transcripts the transaction now carries, so the offers
-  // cannot describe a different partition than the call does. This mirrors the
-  // v9 arm (`../v9/compose.ts`) — a user-addressed payout has to be
-  // attached on BOTH eras, or a call that pays one out composes into an
-  // unbalanced transaction the node rejects on submission, with nothing having
-  // reported a problem here.
+  // Read the partitioned pair back off the intent rather than re-deriving it,
+  // and attach the payout on this era too -- see ComposeRefusalOrder.
   const unshielded = aggregateUnshieldedOffers(
     intent.actions
       .filter((action) => action instanceof v8.ContractCall)

--- a/packages/protocol/src/lib/v8/deploy.ts
+++ b/packages/protocol/src/lib/v8/deploy.ts
@@ -33,15 +33,8 @@ import type { ProtocolV8 } from './load';
  * dual-instantiation of the WASM, because no object is handed between the two
  * copies.
  *
- * A `Pick` of the vendor's own class rather than a restatement of its one
- * member, so a change to `serialize` in onchain-runtime-v3 fails this build.
- *
- * Picking one member keeps it structurally loose enough that unrelated
- * serializables satisfy it, which is what lets tests substitute a fake instead
- * of invoking real WASM (the same pattern `Ledger8ContractLike` in
- * `./execute.ts` uses). The type therefore does not enforce that the bytes are
- * a contract state at all; whichever deploy leg receives them turns that
- * residual risk into a legible error rather than a raw decoder failure.
+ * @see {@link ComposeRefusalOrder}
+ * @see {@link EraSeam}
  */
 export type Ledger8DeployableContractState = Pick<OnchainRuntimeV3.ContractState, 'serialize'>;
 
@@ -65,13 +58,11 @@ export interface Ledger8ConstructorContractLike {
  * needs to build a constructor context. Injected so callers target a specific
  * WASM-backed instance.
  *
- * Narrowed rather than derived from the glue's own `createConstructorContext`:
- * that one is generic in the private state and returns a `ConstructorContext`,
- * a shape this seam never inspects — it only hands the value straight back to
- * the contract's `initialState`. Typing it as the glue's would force every
- * constructor test to build a real context to check plumbing it does not read,
- * so the return stays `unknown` and `v8-deploy.test.ts` pins that the real glue
- * satisfies the narrowing.
+ * The returned context is `unknown` on purpose: this seam never inspects it,
+ * it only hands the value straight back to the contract's `initialState`.
+ *
+ * @see {@link RetainedEraExecution}
+ * @see {@link ComposeRefusalOrder}
  */
 export interface Ledger8ConstructorRuntime {
   readonly createConstructorContext: (privateState: unknown, coinPk: string) => unknown;
@@ -97,18 +88,18 @@ export interface ConstructorResultPojo {
 
 /**
  * Runs a pre-fork (`compact-runtime@0.16`) contract's constructor
- * (`initialState`), following the `createConstructorContext` /
- * `contract.initialState(cc, ...args)` sequence the retained toolchain
- * expects, and packages the result into a {@link ConstructorResultPojo}.
+ * (`initialState`) and packages the result into a
+ * {@link ConstructorResultPojo}.
  *
- * `contractState` on that result is a pre-fork handle, so it does not go
- * straight into a deploy: both {@link composeV8DeployTx} and the era facade's
- * `composeDeployTx` take the state as BYTES, which is what `.serialize()` on
- * that handle produces.
- *
- * Produces no proof: proving applies only to the deploy transaction
- * {@link composeV8DeployTx} serializes, and not even there — see that
- * function's docs.
+ * @param options The compiled contract module, constructor arguments, private
+ *   state and coin public key.
+ * @param runtime The injected pre-fork glue slice used to build the
+ *   constructor context.
+ * @returns The freshly built contract state and the resulting private state.
+ *   The state is a pre-fork HANDLE, so it does not go straight into a deploy:
+ *   both {@link composeV8DeployTx} and the era facade's `composeDeployTx` take
+ *   it as BYTES, which is what `.serialize()` on that handle produces.
+ * @see {@link RetainedEraExecution}
  */
 export const executeConstructor = (options: ExecuteConstructorOptions, runtime: Ledger8ConstructorRuntime): ConstructorResultPojo => {
   const { contract, args, privateState, coinPk } = options;
@@ -124,37 +115,30 @@ export const executeConstructor = (options: ExecuteConstructorOptions, runtime: 
 /**
  * Everything {@link composeV8DeployTx} needs to assemble one v8-native
  * deploy transaction. `verifierKeys` maps entry-point name -> raw, tagged
- * verifier key bytes (`keys/<id>.verifier`): the compiled contract's
- * `initialState` declares an operation slot per circuit but leaves its
- * verifier key blank, so the deploy must carry real keys or a ledger refuses
- * it. The map must name exactly the entry points the contract state declares
- * — no more, no fewer; see {@link composeV8DeployTx}.
+ * verifier key bytes (`keys/<id>.verifier`), and must name exactly the entry
+ * points the contract state declares — no more, no fewer; see
+ * {@link composeV8DeployTx}.
  *
  * `networkId` and `ttl` carry the caller's policy decisions (which network,
- * how long the transaction lives), but their well-formedness is checked here
- * — see `assertComposeEnvelope` (`../shared/compose-options.ts`).
+ * how long the transaction lives); their well-formedness is checked here — see
+ * `assertComposeEnvelope` (`../shared/compose-options.ts`).
+ *
+ * @see {@link VerifierKeys}
+ * @see {@link ComposeRefusalOrder}
  */
 export interface ComposeV8DeployOptions {
   readonly contractState: Uint8Array;
   readonly verifierKeys: ReadonlyMap<string, Uint8Array>;
   readonly networkId: string;
   readonly ttl: Date;
-  /**
-   * A v8-native offer HANDLE, for the same reason `ComposeV8CallOptions`
-   * carries handles: the era arm has already read the caller's bytes with the
-   * module this leg is about to compose against.
-   */
+  /** A v8-native offer HANDLE, not bytes, as `ComposeV8CallOptions` also takes. */
   readonly guaranteedZswapOffer?: UnprovenOffer;
 }
 
 /**
  * Bridges a pre-fork contract state into the v8 era by bytes, reporting a
  * rejected envelope as {@link ComposeOptionError} rather than letting a raw
- * decoder failure escape — the same wrapping the v9 deploy leg applies to the
- * identical call (`../v9/compose.ts`). Not the same class
- * `extractEncodedStateValue` (`../era/envelope.ts`) raises for its own decode:
- * a state that cannot be READ is a different fault from an option that cannot
- * be USED, and they carry different remediations.
+ * decoder failure escape.
  */
 const bridgeContractState = (
   contractState: Uint8Array,
@@ -170,9 +154,7 @@ const bridgeContractState = (
 /**
  * Registers one verifier key, reporting bytes the ledger rejects as
  * {@link ComposeFailedError} (stage `'deploy-verifier-key-blob'`) so the
- * failure names the entry point it belongs to. The setter validates a tagged
- * `midnight:verifier-key[...]` blob, so a truncated, empty or wrong-era key
- * fails here rather than at submission.
+ * failure names the entry point it belongs to.
  */
 const registerVerifierKey = (
   ledgerContractState: InstanceType<ProtocolV8['ContractState']>,
@@ -198,29 +180,31 @@ const registerVerifierKey = (
  * `Transaction`.
  *
  * The verifier-key map is validated against the state's declared entry points
- * BEFORE anything is registered, by the resolver both eras' deploy legs share —
- * see {@link resolveVerifierKeyRegistrations} for the three refusals it owns
- * and why each one matters. Restating them here would be a second copy of one
- * contract, which is what that resolver exists to remove.
- *
- * Bytes the ledger itself rejects surface here, as stage
- * `'deploy-verifier-key-blob'` with the ledger's own failure on `cause`.
+ * BEFORE anything is registered, by {@link resolveVerifierKeyRegistrations} —
+ * the resolver both eras' deploy legs share.
  *
  * Never proves the transaction: the returned bytes are an UNPROVEN,
  * tag-prefixed serialization, exactly what `Transaction.serialize()` produces
- * before `.prove()` is ever called. Proving needs a proving provider and a
- * running proof server, neither of which this seam has.
+ * before `.prove()` is ever called.
  *
- * Uses `Transaction.fromParts`, not `fromPartsRandomized`, so the intent lands
- * at a fixed segment id — matching `createUnprovenLedgerDeployTx`
- * (`packages/contracts/src/utils/ledger-utils.ts`), which the v9 deploy path
- * already does. Only calls randomize their segment, to stay mergeable.
- *
- * Returns the address and the registered initial state alongside the
- * transaction, rather than the transaction alone. A deploy mints a fresh
- * nonce, so the address is not a function of the state a caller passed in and
- * cannot be recomputed from it — and the state the address was derived from is
- * the one a caller stores and later dispatches calls against.
+ * @param options The state bytes, the verifier-key map, the envelope options
+ *   and an optional Zswap offer.
+ * @param v8 The v8 ledger module, as handed over by `loadLedger8`
+ *   (`./load.ts`).
+ * @returns The UNPROVEN, serialized transaction, the address the deployment
+ *   will have, and the registered initial state. A deploy mints a fresh nonce,
+ *   so the address is not a function of the state a caller passed in and cannot
+ *   be recomputed from it — and the state the address was derived from is the
+ *   one a caller stores and later dispatches calls against.
+ * @throws ComposeOptionError If `networkId` is empty or `ttl` is not a valid
+ *   instant, or the state bytes cannot be read.
+ * @throws ComposeFailedError If the map and the state's declared entry points
+ *   do not agree (stages `'deploy-ambiguous-circuit'`,
+ *   `'deploy-unknown-circuit'`, `'deploy-verifier-key'`), or the ledger itself
+ *   rejects a key blob (stage `'deploy-verifier-key-blob'`, with the ledger's
+ *   own failure on `cause`).
+ * @see {@link VerifierKeys}
+ * @see {@link ComposeRefusalOrder}
  */
 export const composeV8DeployTx = (options: ComposeV8DeployOptions, v8: ProtocolV8): DeployResultPojo => {
   const { contractState, verifierKeys, networkId, ttl, guaranteedZswapOffer } = options;

--- a/packages/protocol/src/lib/v8/deploy.ts
+++ b/packages/protocol/src/lib/v8/deploy.ts
@@ -28,12 +28,10 @@ import type { ProtocolV8 } from './load';
  * returns on its result, and `.serialize()` is how a caller turns that handle
  * into the bytes every deploy leg takes.
  *
- * Crossing the era boundary by bytes rather than by handle is deliberate — it
- * is the one crossing in this engine that cannot be affected by a
- * dual-instantiation of the WASM, because no object is handed between the two
- * copies.
+ * Crosses the era boundary by bytes, not by handle.
  *
- * @see {@link ComposeRefusalOrder}
+ * @see {@link DualInstantiationGuard} for why that crossing is the one a
+ *      duplicate install cannot affect
  * @see {@link EraSeam}
  */
 export type Ledger8DeployableContractState = Pick<OnchainRuntimeV3.ContractState, 'serialize'>;

--- a/packages/protocol/src/lib/v8/down-convert.ts
+++ b/packages/protocol/src/lib/v8/down-convert.ts
@@ -16,9 +16,8 @@
 import type * as OnchainRuntimeV3 from '@midnight-ntwrk/onchain-runtime-v3';
 import type { AlignedValue, EncodedStateValue } from '@midnightntwrk/ledger-v9';
 
-// The three pre-fork instance types this module names, read off the one
-// type-only namespace import above rather than a second named import of the
-// same module. Aliases, not mirrors: they ARE the vendor's types.
+// Aliases read off the type-only namespace import above, not mirrors -- see
+// ModuleGraphAndLazyLoading.
 type ChargedState = OnchainRuntimeV3.ChargedState;
 type StateBoundedMerkleTree = OnchainRuntimeV3.StateBoundedMerkleTree;
 type StateValue = OnchainRuntimeV3.StateValue;
@@ -30,14 +29,7 @@ import type { Ledger8ContractState } from '../era/envelope';
  * The subset of the pre-fork onchain-runtime-v3 `StateValue` statics
  * {@link downConvertForExecution} needs.
  *
- * DERIVED from the vendor's own class rather than restated: a `decode` whose
- * signature moves fails this build instead of leaving a hand-written mirror
- * describing a static the runtime no longer has. The `import type * as` this
- * reads through is erased and links nothing — injection is about not importing
- * a VALUE — so the lazy acquisition path the caller owns is untouched. Narrowed to `decode` because
- * that is the only static this seam calls, and because the narrowing is what
- * lets `v8-down-convert.test.ts` drive the decode safety net with a one-member
- * double instead of a whole WASM class.
+ * @see {@link ModuleGraphAndLazyLoading}
  */
 export interface Ledger8CompactRuntimeStateValue {
   readonly decode: (typeof OnchainRuntimeV3.StateValue)['decode'];
@@ -46,24 +38,10 @@ export interface Ledger8CompactRuntimeStateValue {
 /**
  * The pre-fork runtime surface {@link downConvertForExecution} bridges into.
  *
- * `ContractState` is here to pin the *era*, not because this module calls it.
- * `StateValue.decode` and `new ChargedState(...)` are structurally identical
- * across the fork — that identity is what makes the bridge possible, and it is
- * asserted directly by the wire-shape drift detectors in
- * `v8-down-convert.test.ts`. So neither member can tell a pre-fork runtime
- * from a post-fork one, and without a third member this interface is satisfied
- * by onchain-runtime-v4 and by `compact-runtime` (which re-exports it) — both
- * public barrel exports of this very package. A caller reaching for the wrong
- * one gets no error: decode and re-encode then use the same post-fork codec, so
- * the structural comparison passes, the Merkle walk passes, and a v4
- * `ChargedState` is returned typed as a v3 one, to surface later as an opaque
- * wasm-bindgen rejection deep inside execution.
+ * `ContractState` is here to pin the *era*, not because this module calls it:
+ * do not drop it as an unused member.
  *
- * `ContractState` closes that, because its `query()` returns a `GatherResult`
- * whose `log` variant gained fields after the fork. That divergence is
- * incidental to this bridge, so it is pinned by a compile-time negative
- * assertion (`_PostForkOnchainRuntimeIsRejected`) rather than trusted: a vendor
- * bump that realigned the two shapes would otherwise silently reopen the hole.
+ * @see {@link RetainedEraExecution}
  */
 export interface Ledger8CompactRuntime {
   readonly ContractState: Ledger8ContractState;
@@ -75,11 +53,11 @@ export interface Ledger8CompactRuntime {
  * The result of a down-convert: only the primary state data a pre-fork
  * circuit reads during execution.
  *
- * Deliberately not a full pre-fork `ContractState`: this bridge produces only
- * the `ChargedState`, so it does not fabricate blank defaults for
- * `.operations`, `.maintenanceAuthority`, or `.balance`. Those remain the
- * caller's to carry — execution receives balances via `CallContext.balance`,
- * not via this state.
+ * Deliberately not a full pre-fork `ContractState`: it carries no
+ * `.operations`, `.maintenanceAuthority` or `.balance`, which remain the
+ * caller's to carry.
+ *
+ * @see {@link RetainedEraExecution}
  */
 export interface DownConvertedState {
   readonly data: ChargedState;
@@ -89,17 +67,13 @@ export interface DownConvertedState {
  * Structural equality over the `EncodedStateValue` algebra — plain objects,
  * arrays, `Map`s, `Uint8Array`s and primitives.
  *
- * Hand-rolled rather than `node:util`'s `isDeepStrictEqual`, which does not
- * resolve in a browser bundle. `Map`s are compared pairwise in iteration
- * order, deliberately: both runtimes emit map entries in a deterministic,
- * insertion-order-independent order that the two of them agree on, so a value
- * and its re-encoding iterate identically whatever order the entries were
- * inserted in. Note that order is not ascending by key — it is a canonical
- * hash order, so do not reason about it as sorted. That agreement is a
- * cross-runtime property, not a single-codec one — the source encoding comes
- * from ledger-v9 and the re-encoding from onchain-runtime-v3 — so it is pinned
- * by tests that build the two sides with the two different codecs, not only by
- * the same-codec round trip.
+ * `Map`s are compared pairwise in iteration order, deliberately, and that order
+ * is not ascending by key — do not reason about it as sorted.
+ *
+ * @param a One value in the algebra.
+ * @param b The value to compare it against.
+ * @returns `true` when the two are structurally equal.
+ * @see {@link RetainedEraExecution}
  */
 export const structurallyEqual = (a: unknown, b: unknown): boolean => {
   if (a === b) {
@@ -133,21 +107,8 @@ export const structurallyEqual = (a: unknown, b: unknown): boolean => {
   const aRecord: Record<string, unknown> = { ...a };
   const bRecord: Record<string, unknown> = { ...b };
   const aKeys = Object.keys(aRecord);
-  // `key in bRecord`, not just a matching key count: without it two objects
-  // that share no key at all compare equal whenever the diverging key's value
-  // in `a` is `undefined`, because both lookups then read `undefined` and
-  // short-circuit. No *record* in today's algebra holds an undefined-valued
-  // field — the one `undefined` it contains is the second slot of a
-  // boundedMerkleTree leaf tuple (`[Uint8Array, undefined]`), which arrives
-  // through the array branch above and never reaches this comparison. So this
-  // guards against a record gaining one rather than fixing a live defect.
-  //
-  // It is a partial guard, not a total one: `bRecord` is a plain object, so
-  // `in` also succeeds for every `Object.prototype` member. Keys in the pinned
-  // algebra are only `tag`/`content`/`value`/`alignment`/`length`, none of them
-  // inherited, so the hole is unreachable today — but `Object.hasOwn` would
-  // close it outright and is the right move the moment this helper is used on
-  // anything wider.
+  // `key in bRecord`, not just a matching key count, and a partial guard only --
+  // see RetainedEraExecution and SharedTableDiscipline.
   return (
     aKeys.length === Object.keys(bRecord).length &&
     aKeys.every((key) => key in bRecord && structurallyEqual(aRecord[key], bRecord[key]))
@@ -158,13 +119,14 @@ export const structurallyEqual = (a: unknown, b: unknown): boolean => {
  * Reads a bounded Merkle tree's root, failing with
  * {@link MerkleNotRehashedError} when the tree has not been rehashed.
  *
- * Three shapes of "no root" are treated alike, because all three mean the same
- * thing to a caller and only one is in the vendor's type: `undefined` (what
- * the typings document), `null` (what a `None` can serialize to), and a throw
- * — the wasm-bindgen shim for `root()` rethrows a Rust `Err` rather than
- * always resolving to a value. Letting that throw escape would demote it to a
- * generic down-convert failure and tell the caller to check its envelope bytes
- * when the actual remediation is to rehash the tree.
+ * Three shapes of "no root" are treated alike: `undefined`, `null`, and a
+ * throw out of the wasm-bindgen shim for `root()`.
+ *
+ * @param tree The bounded Merkle tree to read.
+ * @returns The tree's root.
+ * @throws MerkleNotRehashedError If the tree has no readable root, in any of
+ *   those three shapes.
+ * @see {@link RetainedEraExecution}
  */
 export const checkRoot = (tree: StateBoundedMerkleTree): AlignedValue => {
   let root: AlignedValue | undefined;
@@ -184,31 +146,17 @@ export const checkRoot = (tree: StateBoundedMerkleTree): AlignedValue => {
  * Asserts that every bounded Merkle tree in a `StateValue` tree already has
  * its node hashes computed, recursing through the only two container variants
  * in the algebra (`array` and `map`) and ignoring the leaf variants (`cell`,
- * `null`, and `boundedMerkleTree`'s own contents). Throws
- * {@link MerkleNotRehashedError} (via {@link checkRoot}) on the first tree
- * without a readable root.
+ * `null`, and `boundedMerkleTree`'s own contents).
  *
- * Fail-fast by design: an `encode()`/`decode()` round trip materializes a
- * tree's hashes on the pinned onchain-runtime-v3/ledger-v9 versions, and
- * every state reaching {@link downConvertForExecution} has crossed one — so a
- * rootless tree here can only mean an upstream programming error, which this
- * surfaces loudly instead of silently repairing. That round-trip behaviour is
- * a vendor property rather than a guarantee, so it is pinned by a test
- * (`materializes the hashes of a tree that was never rehashed`) that fails if
- * a vendor bump changes it.
+ * Does not mutate or rebuild the state: a rootless tree is refused, never
+ * repaired.
  *
- * Does not mutate or rebuild the state. It is not allocation-free: each
- * `asArray()`/`asMap()` step marshals fresh wrapper objects out of WASM.
- *
- * The non-null assertions below are guarded by the preceding `type()` call:
- * the `as*` accessors return `undefined` only on a variant mismatch, which
- * the switch has already excluded. `map.get(key)` is likewise asserted
- * because a key marshalled out by `keys()` resolves back through `get()`.
- * Both are observed behaviour of onchain-runtime-v3 rather than
- * vendor-documented invariants — the vendor's own types are not authoritative
- * about definedness here (`asCell()` is declared non-optional yet returns
- * `undefined` for a `null` state value) — so they are pinned by tests over a
- * multi-entry map rather than by prose alone.
+ * @param sv The `StateValue` tree to walk.
+ * @throws MerkleNotRehashedError On the first tree without a readable root,
+ *   via {@link checkRoot}.
+ * @throws DownConvertFailedError If the walk meets a `StateValue` variant the
+ *   pinned typings do not declare.
+ * @see {@link RetainedEraExecution}
  */
 export const assertMerkleTreesRehashed = (sv: StateValue): void => {
   const variant = sv.type();
@@ -228,18 +176,8 @@ export const assertMerkleTreesRehashed = (sv: StateValue): void => {
     case 'null':
       return;
     default: {
-      // Compile-time exhaustiveness, in the style of version.ts's
-      // `_allLedgerVersionsAreMapped`: a vendor bump that adds a variant stops
-      // this assignment type-checking, so the omission is a build failure
-      // rather than a review miss.
-      //
-      // The runtime throw is not redundant with it. The `StateValue` reaching
-      // this walk comes from a caller-injected runtime, whose WASM can emit a
-      // tag the pinned `.d.ts` does not declare — and these declarations are
-      // known to be unfaithful (see the `asCell()` note below). Returning
-      // `void` on an unrecognised variant would skip every Merkle tree nested
-      // inside it without a word, which is the exact silent-wrong-data
-      // outcome this module exists to prevent.
+      // Compile-time exhaustiveness plus a runtime throw; neither is redundant
+      // with the other -- see SharedTableDiscipline.
       const unhandled: never = variant;
       throw new DownConvertFailedError(
         'state down-convert',
@@ -256,36 +194,27 @@ export const assertMerkleTreesRehashed = (sv: StateValue): void => {
  * {@link assertMerkleTreesRehashed}) that every bounded Merkle tree it
  * contains already has its hashes computed.
  *
- * Never returns a silently empty or partial state. Every failure leaves as a
- * {@link DownConvertFailedError} carrying `{ cause }`, or a
- * {@link MerkleNotRehashedError} — including failures from the Merkle walk
- * and from `ChargedState` construction, so no uncoded error escapes a seam
- * whose whole contract is code-based discrimination.
+ * Never returns a silently empty or partial state: every failure leaves as a
+ * coded error. Structural integrity is checked by re-encoding the decoded value
+ * and comparing it to the input, which costs one extra encode plus a deep
+ * comparison per call.
  *
- * Structural integrity is checked by re-encoding the decoded value and
- * comparing it to the input, which catches loss at every depth (a shortened
- * array, a dropped map entry, a changed cell, a substituted subtree) rather
- * than only a wholesale collapse to `null`. This costs one extra encode plus a
- * deep comparison per call, and it is deliberate: the alternative is a bridge
- * that can hand a circuit silently wrong data.
+ * `ledger8Runtime` is checked before anything is decoded. Only the two members
+ * this function actually calls are checked; `ContractState` is on
+ * {@link Ledger8CompactRuntime} to pin the era, and is never dereferenced here.
  *
- * `ledger8Runtime` is checked before anything is decoded, for the same reason
- * `extractEncodedStateValue` checks the runtime it is handed: a runtime missing
- * a binding this function dereferences would otherwise raise a bare `TypeError`
- * that the catch below relabels {@link DownConvertFailedError}, an error whose
- * message sends the caller to audit input bytes that are not the problem. Only
- * the two members this function actually calls are checked; `ContractState` is
- * on {@link Ledger8CompactRuntime} to pin the era, and is never dereferenced
- * here.
- *
- * What it does not cover: anything the pre-fork encoder re-derives rather than
- * carries. A bounded Merkle tree encodes as its height and leaves, never its
- * node hashes, so a tree whose internal hashes were re-materialized
- * differently across the fork boundary still re-encodes byte-identically here.
- * {@link assertMerkleTreesRehashed} establishes only that each tree has a
- * readable root, not that the root matches the source's. Comparing roots
- * across the boundary needs the source-side tree, which this function never
- * sees — it belongs at the envelope seam.
+ * @param state The already-extracted post-fork encoded state value.
+ * @param ledger8Runtime The injected pre-fork runtime slice.
+ * @returns The pre-fork state a v8-era circuit executes against.
+ * @throws Ledger8RuntimeInvalidError If `ledger8Runtime` is missing
+ *   `StateValue.decode` or `ChargedState`.
+ * @throws DownConvertFailedError If the state cannot be decoded, does not
+ *   re-encode to its source, or the Merkle walk meets an undeclared variant —
+ *   carrying the underlying failure on `cause`.
+ * @throws MerkleNotRehashedError If any bounded Merkle tree in the state has no
+ *   readable root.
+ * @see {@link RetainedEraExecution}
+ * @see {@link FailClosedDecoding}
  */
 export const downConvertForExecution = (
   state: EncodedStateValue,

--- a/packages/protocol/src/lib/v8/down-convert.ts
+++ b/packages/protocol/src/lib/v8/down-convert.ts
@@ -29,7 +29,7 @@ import type { Ledger8ContractState } from '../era/envelope';
  * The subset of the pre-fork onchain-runtime-v3 `StateValue` statics
  * {@link downConvertForExecution} needs.
  *
- * @see {@link ModuleGraphAndLazyLoading}
+ * @see {@link InjectedVendorSlices}
  */
 export interface Ledger8CompactRuntimeStateValue {
   readonly decode: (typeof OnchainRuntimeV3.StateValue)['decode'];

--- a/packages/protocol/src/lib/v8/engine.ts
+++ b/packages/protocol/src/lib/v8/engine.ts
@@ -42,16 +42,10 @@ export type {
  * EXECUTION capabilities, with the 0.16 runtime instance already captured in
  * closure — no method here takes a runtime or module parameter.
  *
- * Scoped to what only the retained era can do. Reading a contract state and
- * composing a call or a deploy are era-symmetric operations: both eras do them,
- * with the same inputs and the same result shape, so they belong on the era
- * facade (`../era/era.ts`) where a caller can reach them without knowing which
- * era it holds. What is left here is what only the retained era can do —
- * down-convert a post-fork state for pre-fork execution, run a pre-fork circuit
- * or constructor, and bind a pre-fork transcript natively onto v9.
- *
  * Every method is synchronous: this object is handed over only after the
- * retained toolchain has been acquired, so there is nothing left to await.
+ * retained toolchain has been acquired.
+ *
+ * @see {@link EraSeam}
  */
 export interface Ledger8Engine {
   downConvertForExecution(state: EncodedStateValue): DownConvertedState;
@@ -65,29 +59,21 @@ export interface Ledger8Engine {
  * and `@midnight-ntwrk/onchain-runtime-v3` — and builds a {@link Ledger8Engine}
  * bound to it.
  *
- * `../../engine.ts` re-exports this module as the `./engine` build entry
- * (`dist/engine.js`), reached only by the dynamic import in
- * `lib/v8/load-engine.ts`. Evaluating it — which is what pulls in the glue
- * and `onchain-runtime-v3` WASM — happens only on that import, never as a side
- * effect of loading the package root.
- *
  * Runs {@link assertSharedLedger8Instance} exactly once, on the
- * `onchain-runtime-v3` axis: it compares this package's own copy against the
- * copy the 0.16 glue resolves for its own dependency (a genuine second
- * acquisition path — a duplicate install would resolve these differently),
- * so a dual-instantiation fails loudly before any contract execution can
- * silently corrupt on a physical-instance mismatch. No other WASM package
- * this module acquires has a comparable second acquisition path, so no other
- * axis is asserted. Any acquisition failure surfaces through the facade
- * (`lib/v8/load-engine.ts`) as `Ledger8RuntimeMissingError` (`../../errors.ts`).
+ * `onchain-runtime-v3` axis. Any acquisition failure surfaces through the
+ * facade (`lib/v8/load-engine.ts`) as `Ledger8RuntimeMissingError`
+ * (`../../errors.ts`).
  *
- * Deliberately does NOT acquire the v8 ledger module. Nothing on this surface
- * needs it — call and deploy composition live on the era facade
- * (`../era/era.ts`), which acquires the module itself when a caller asks for
- * the v8 era. A consumer that only executes circuits and binds them onto v9
- * therefore never instantiates the multi-megabyte v8 WASM, and never
- * hard-depends on ledger-v8 resolving. Gated by
- * `v8-load-engine-laziness.test.ts`.
+ * Does NOT acquire the v8 ledger module: a consumer that only executes
+ * circuits and binds them onto v9 never instantiates the multi-megabyte v8
+ * WASM, and never hard-depends on ledger-v8 resolving.
+ *
+ * @returns The engine surface, with the acquired runtime captured in closure.
+ * @throws Ledger8InstanceMismatchError If `onchain-runtime-v3` resolved to two
+ *   physically distinct copies in this process.
+ * @see {@link EraSeam}
+ * @see {@link DualInstantiationGuard}
+ * @see {@link ModuleGraphAndLazyLoading}
  */
 export const createLedger8Engine = async (): Promise<Ledger8Engine> => {
   const [glue, ocrt3] = await Promise.all([
@@ -97,11 +83,9 @@ export const createLedger8Engine = async (): Promise<Ledger8Engine> => {
 
   assertSharedLedger8Instance('onchain-runtime-v3', ocrt3.ChargedState, glue.ChargedState);
 
-  // `ContractState` comes from ocrt3 while the other two come from the glue.
-  // That is sound only because the assertion above has already established the
-  // two are one physical copy: had they been distinct, it would have thrown
-  // rather than let a mixed runtime be assembled here. The member is what pins
-  // this object to the pre-fork era -- see `Ledger8CompactRuntime`.
+  // `ContractState` from ocrt3, the other two from the glue: sound only because
+  // of the assertion above -- see DualInstantiationGuard. The member is what
+  // pins this object to the pre-fork era -- see `Ledger8CompactRuntime`.
   const ledger8CompactRuntime: Ledger8CompactRuntime = {
     ContractState: ocrt3.ContractState,
     StateValue: glue.StateValue,

--- a/packages/protocol/src/lib/v8/execute.ts
+++ b/packages/protocol/src/lib/v8/execute.ts
@@ -31,11 +31,6 @@ import type { DownConvertedState } from './down-convert';
  * partition the call's public transcript against the context it really ran on
  * (see {@link PartitionContext}).
  *
- * `comIndices` is read off the POST-call context, `block` and `effects` off the
- * pre-call one — the split {@link PartitionContext} explains. All four are
- * declared here because the runtime exposes them on the same object; which one
- * each is read from is {@link executeCircuit}'s choice, not this type's.
- *
  * A `Pick` of the vendor's own class, not a restatement of it: the member names
  * and their types come from onchain-runtime-v3, so a rename there fails this
  * build instead of leaving a mirror that describes a property the runtime no
@@ -43,6 +38,8 @@ import type { DownConvertedState } from './down-convert';
  * `QueryContext` is a WASM class with dozens of members, and this seam reads
  * four — the narrowing is what lets the execution tests hand `executeCircuit` a
  * plain object double instead of standing up real WASM.
+ *
+ * @see {@link RetainedEraExecution}
  */
 export type Ledger8QueryContext = Pick<
   OnchainRuntimeV3.QueryContext,
@@ -54,17 +51,14 @@ export type Ledger8QueryContext = Pick<
  * (`compact-runtime@0.16`) `createCircuitContext` call and a circuit's
  * updated context after it runs.
  *
- * `currentZswapLocalState` is the runtime's own BYTE-encoded shape — what the
- * 0.16 glue really puts on a `CircuitContext` — and is declared as the vendor
- * type rather than an opaque one, because {@link executeCircuit} hands it on to
- * a caller instead of only testing it for emptiness.
- *
  * Not the glue's `CircuitContext` itself: that one carries a real
  * `QueryContext`, a WASM class no test double can satisfy, and this seam reads
  * a handful of properties off it. The narrowing is the difference between
  * execution tests that check plumbing with a literal and tests that must stand
  * up WASM to do it — see {@link Ledger8QueryContext}, which derives those
  * properties from the vendor's class so the narrowing cannot drift from it.
+ *
+ * @see {@link RetainedEraExecution}
  */
 export interface Ledger8CircuitContext {
   readonly currentQueryContext: Ledger8QueryContext;
@@ -79,6 +73,8 @@ export interface Ledger8CircuitContext {
  * plain data with no WASM handle in it, so there was nothing for a mirror to
  * narrow — only a shape to drift out of sync. `Readonly` is this package's own
  * addition, and the only one.
+ *
+ * @see {@link EraSeam}
  */
 export type Ledger8ProofData = Readonly<ProofData>;
 
@@ -87,8 +83,9 @@ export type Ledger8ProofData = Readonly<ProofData>;
  *
  * Tracks the glue's `CircuitResults` but is not derived from it: `context` is
  * the narrowed {@link Ledger8CircuitContext} for the reason given there, and
- * `gasCost` is absent because nothing here reads it. `proofData` IS the
- * vendor's own type — see {@link Ledger8ProofData}.
+ * `proofData` IS the vendor's own type — see {@link Ledger8ProofData}.
+ *
+ * @see {@link RetainedEraExecution}
  */
 export interface Ledger8CircuitResult {
   readonly result: unknown;
@@ -102,10 +99,9 @@ export type Ledger8ImpureCircuit = (ctx: Ledger8CircuitContext, ...args: readonl
 /**
  * The subset of a compiled pre-fork (`compact-runtime@0.16`) contract module
  * {@link executeCircuit} needs: only `impureCircuits`, the map every
- * generated contract exposes its callable entry points under. The other own
- * properties a real compiled contract carries (`witnesses`, `circuits`,
- * `provableCircuits`, `initialState`) are never read here — execution only
- * ever dispatches through `impureCircuits`.
+ * generated contract exposes its callable entry points under.
+ *
+ * @see {@link RetainedEraExecution}
  */
 export interface Ledger8ContractLike {
   readonly impureCircuits: Readonly<Record<string, Ledger8ImpureCircuit>>;
@@ -113,17 +109,12 @@ export interface Ledger8ContractLike {
 
 /**
  * The subset of the pre-fork `compact-runtime@0.16` glue {@link executeCircuit}
- * needs to build a circuit context. Injected — like {@link Ledger8CompactRuntime}
- * in `./down-convert.ts` — so callers target a specific WASM-backed
- * instance and tests can substitute a controlled fake.
+ * needs to build a circuit context, injected rather than imported.
+ *
+ * @see {@link RetainedEraExecution}
  */
 export interface Ledger8ExecutionRuntime {
-  /**
-   * The glue's own encoded -> decoded conversion for a Zswap local state.
-   * Injected for the same reason the rest of this interface is, and needed here
-   * so a caller never has to acquire the retained 0.16 glue itself just to read
-   * which coins a call moved.
-   */
+  /** The glue's own encoded -> decoded conversion for a Zswap local state. */
   readonly decodeZswapLocalState: (state: EncodedZswapLocalState) => ZswapLocalState;
   /**
    * Narrowed rather than derived, unlike its sibling below. The glue's own
@@ -131,8 +122,7 @@ export interface Ledger8ExecutionRuntime {
    * `CircuitContext` carrying a real `QueryContext` — a WASM class no test
    * double can satisfy — so deriving it would make every execution test stand
    * up real WASM to check plumbing. The narrowing returns
-   * {@link Ledger8CircuitContext} instead, and `v8-load-engine.test.ts` pins
-   * that the real glue still satisfies it.
+   * {@link Ledger8CircuitContext} instead.
    */
   readonly createCircuitContext: (
     contractAddress: string,
@@ -142,10 +132,7 @@ export interface Ledger8ExecutionRuntime {
     gasLimit: undefined,
     costModel: CostModel
   ) => Ledger8CircuitContext;
-  /**
-   * A `Pick` of the vendor's class: `initialCostModel` is the only static this
-   * seam calls, and the narrowing is what lets a test inject a stub cost model.
-   */
+  /** A `Pick` of the vendor's class: `initialCostModel` is the only static this seam calls. */
   readonly CostModel: Pick<typeof OnchainRuntimeV3.CostModel, 'initialCostModel'>;
 }
 
@@ -155,27 +142,20 @@ export interface Ledger8ExecutionRuntime {
  * artifact {@link wrapKeepStateCall} (`../v9/wrap.ts`) needs to assemble a
  * v9-native `ContractCallPrototype`.
  *
- * `preContractState`/`postContractState` are {@link DownConvertedState}s —
- * the same execution-only state shape `downConvertForExecution` already
- * produces — not full pre-fork `ContractState`s: they carry only `.data`, so a
- * consumer cannot reach `.operations`, `.maintenanceAuthority` or `.balance`
- * through them.
+ * `preContractState`/`postContractState` are {@link DownConvertedState}s, not
+ * full pre-fork `ContractState`s: they carry only `.data`.
  *
  * `partitionContext` is the query-context state the call ran with, which the
- * carried state bytes do not hold — see {@link PartitionContext}. Composing a
- * call without it partitions the transcript against a context the circuit
- * never ran on; a call that received a coin in-contract cannot be partitioned
- * at all.
+ * carried state bytes do not hold — see {@link PartitionContext}. A composition
+ * leg needs it to partition the call's transcript.
  *
  * `zswapLocalState` is the post-call Zswap local state, DECODED into the
  * runtime's public shape: the coins the circuit spent and produced. A caller
  * turns it into the transaction's segmented Zswap offer
  * (`zswapStateToSegmentedOffer`, `packages/contracts/src/utils/zswap-utils.ts`)
- * and hands that offer to whichever composition leg it targets. Carrying it is
- * what makes a coin-moving circuit composable on the retained era at all —
- * omitting it would leave the caller composing a transaction that is missing
- * the coin movements the circuit recorded, and the node rejects that as
- * unbalanced on submission.
+ * and hands that offer to whichever composition leg it targets.
+ *
+ * @see {@link RetainedEraExecution}
  */
 export interface TranscriptPojo {
   readonly circuitId: string;
@@ -204,24 +184,21 @@ export interface ExecuteCircuitOptions {
 
 /**
  * Runs one impure circuit on a pre-fork (`compact-runtime@0.16`) contract
- * instance, following the exact `createCircuitContext` /
- * `impureCircuits[id](ctx, ...args)` sequence the retained toolchain expects
- * (the spike's `runCircuit`), and packages every artifact
- * {@link wrapKeepStateCall} needs into a {@link TranscriptPojo}.
- *
- * Throws a plain `Error` — not a {@link PROTOCOL_ERROR_CODES}-carrying class —
- * when `circuitId` names no entry point on `contract.impureCircuits`. This is
- * a caller-programming-error case (an unknown circuit name passed by the
- * caller), not one of the decode/runtime-instance failure modes this engine
- * wraps elsewhere; it mirrors the plain `Error` the spike itself throws for
- * the analogous "operation missing on contract state" case. The lookup is an
- * own-property one: `impureCircuits` is a plain object literal on every
- * compiled contract, so a bare index would resolve `toString` or `constructor`
- * off the prototype chain and dispatch into it.
+ * instance and packages every artifact {@link wrapKeepStateCall} needs into a
+ * {@link TranscriptPojo}.
  *
  * A circuit that moved coins runs like any other: its post-call Zswap local
  * state leaves on {@link TranscriptPojo}, decoded through the injected runtime,
  * for the caller to turn into the transaction's Zswap offer.
+ *
+ * @param options The contract module, circuit id, arguments, down-converted
+ *   state, contract address, coin public key and private state.
+ * @param ledger8Runtime The injected pre-fork glue slice.
+ * @returns Every artifact a v9-native call prototype needs.
+ * @throws Error A plain `Error` — not a {@link PROTOCOL_ERROR_CODES}-carrying
+ *   class — when `circuitId` names no entry point on
+ *   `contract.impureCircuits`.
+ * @see {@link RetainedEraExecution}
  */
 export const executeCircuit = (options: ExecuteCircuitOptions, ledger8Runtime: Ledger8ExecutionRuntime): TranscriptPojo => {
   const { contract, circuitId, args, state, address, coinPk, privateState } = options;

--- a/packages/protocol/src/lib/v8/execute.ts
+++ b/packages/protocol/src/lib/v8/execute.ts
@@ -117,12 +117,10 @@ export interface Ledger8ExecutionRuntime {
   /** The glue's own encoded -> decoded conversion for a Zswap local state. */
   readonly decodeZswapLocalState: (state: EncodedZswapLocalState) => ZswapLocalState;
   /**
-   * Narrowed rather than derived, unlike its sibling below. The glue's own
-   * `createCircuitContext` is generic in the private state and returns a
-   * `CircuitContext` carrying a real `QueryContext` — a WASM class no test
-   * double can satisfy — so deriving it would make every execution test stand
-   * up real WASM to check plumbing. The narrowing returns
-   * {@link Ledger8CircuitContext} instead.
+   * Narrowed rather than derived, and so returns
+   * {@link Ledger8CircuitContext} rather than the glue's own `CircuitContext`.
+   *
+   * @see {@link RetainedEraExecution} for what the narrowing buys
    */
   readonly createCircuitContext: (
     contractAddress: string,

--- a/packages/protocol/src/lib/v8/instance-guard.ts
+++ b/packages/protocol/src/lib/v8/instance-guard.ts
@@ -26,13 +26,9 @@ import {
  *
  * Kept here rather than exported from `errors.ts`, which is a build entry:
  * nothing outside this module needs to test an axis, and the engine's whole
- * design is to stay off the public surface. The duplication of the one literal
- * is checked, not trusted — `satisfies` fails to compile if
- * {@link Ledger8InstanceAxis} gains a member this table does not name.
+ * design is to stay off the public surface.
  *
- * Null-prototype and frozen for the reason `ENVELOPE_DECODERS` is: the value
- * indexing it is only type-checked for TypeScript callers, and a plain object
- * literal answers `true` for every `Object.prototype` member.
+ * @see {@link SharedTableDiscipline}
  */
 const KNOWN_AXES: Readonly<Record<Ledger8InstanceAxis, true>> = Object.freeze(
   Object.assign(Object.create(null) as Record<Ledger8InstanceAxis, true>, {
@@ -47,67 +43,38 @@ const isKnownAxis = (axis: unknown): axis is Ledger8InstanceAxis =>
  * Fails fast on a dual-instantiation of a WASM package the down-convert
  * engine depends on, along one named `axis`.
  *
- * A duplicate install resolves to two physically distinct module instances —
- * same shape, different WASM linear memory, different classes. What happens
- * when they mix depends on which position the foreign object is in, and only
- * one of the two is checked:
- *
- * - As an **argument** to a wasm-bound function, wasm-bindgen emits
- *   `_assertClass`, which throws `expected instance of <Class>`. Loud, though
- *   deep inside a decode and naming neither the package nor the duplicate
- *   install.
- * - As the **receiver** of a wasm-bound method, nothing is checked. The glue
- *   reads `this.__wbg_ptr` and calls into its own linear memory with a pointer
- *   that belongs to the other copy's heap. Measured on the pinned version, that
- *   returns a plausible, wrong value: a cell built in one copy read back
- *   through the other's `encode()` yields different bytes with no error, and
- *   `type()` still reports the correct variant. Whether it happens to come back
- *   right depends on how the two heaps line up, so it is not reliably
- *   reproducible — and a test that passes proves nothing about production.
- *
- * So this guard is not only a diagnosis-improver. For the receiver direction it
- * is the only thing standing between a duplicate install and silently wrong
- * contract state, which is why it must run before any state crosses the bridge
- * rather than being treated as optional belt-and-braces.
- *
- * Reference equality is the probe: two references to the *same* physical copy
- * are always `===`; two sourced from different physical copies never are,
- * even at the same package version.
- *
  * Pass a **shared binding** — a class the package exports, such as
- * `ChargedState` or `StateValue` — never a module namespace object. A
- * namespace is per-module, so a re-export produces a different one even when
- * there is exactly one physical copy behind it; comparing namespaces would
- * report a mismatch on a healthy install and send the user hunting a duplicate
- * that does not exist. A re-export preserves the identity of the binding
- * itself, which is why the binding is the sound probe and the namespace is not.
+ * `ChargedState` or `StateValue` — never a module namespace object.
  *
- * Both probes are compared symmetrically — there is no expected side — so the
- * two arguments are interchangeable. What matters is that they are obtained
- * from **two different acquisition paths** (two distinct import specifiers,
- * or an import versus a caller-supplied module). Passing the same binding
- * twice satisfies the check trivially and proves nothing; the caller owns
- * that, because nothing in the signature can enforce it.
+ * The two probes are compared symmetrically, so they are interchangeable, but
+ * they must be obtained from **two different acquisition paths** (two distinct
+ * import specifiers, or an import versus a caller-supplied module). Passing the
+ * same binding twice satisfies the check trivially and proves nothing; the
+ * caller owns that, because nothing in the signature can enforce it.
  *
- * A nullish probe (`null`/`undefined`) on either side is rejected before the
- * `===` comparison runs, rather than compared directly: two nullish values
- * are always `===` to each other, so a caller that optional-chained a missing
- * export on both sides (or simply forgot to pass a probe) would otherwise
- * pass this fail-fast safety net by accident instead of failing it. It is
- * reported as {@link Ledger8RuntimeInvalidError}, not as a mismatch: a missing
- * probe is a binding the caller did not hand over, which is the same fault the
- * envelope seam reports under that code. Calling it a dual-instantiation would
- * assert two physical copies exist and send the reader to `npm why` after a
- * duplicate that is not there.
- *
- * `axis` is validated against the closed union before either probe is looked
- * at, for the same reason `extractEncodedStateValue` validates `version`: it is
- * only type-checked for TypeScript callers, and it selects the package names
- * the remediation hint tells the reader to trace.
- *
- * An axis earns an assertion only when the package genuinely reaches this
- * process through two acquisition paths — see {@link Ledger8InstanceAxis} for
- * why `'onchain-runtime-v3'` is the only member today.
+ * @param axis The physical-copy axis to check, validated against
+ *   {@link Ledger8InstanceAxis} before either probe is looked at.
+ * @param probeA A shared binding, obtained through one acquisition path.
+ * @param probeB The same binding, obtained through a different acquisition
+ *   path.
+ * @throws UnknownLedger8AxisError If `axis` is not a member of
+ *   {@link Ledger8InstanceAxis}.
+ * @throws Ledger8RuntimeInvalidError If either probe is `null` or `undefined`.
+ *   A missing probe is a binding the caller did not hand over, so it is not
+ *   reported as a mismatch.
+ * @throws Ledger8InstanceMismatchError If the two probes are not
+ *   reference-equal, i.e. the package resolved to two physically distinct
+ *   copies in this process.
+ * @example
+ * ```typescript
+ * const [glue, ocrt3] = await Promise.all([
+ *   import('compact-runtime-ledger8'),
+ *   import('@midnight-ntwrk/onchain-runtime-v3')
+ * ]);
+ * // Two acquisition paths to the same binding, never a namespace object.
+ * assertSharedLedger8Instance('onchain-runtime-v3', ocrt3.ChargedState, glue.ChargedState);
+ * ```
+ * @see {@link DualInstantiationGuard}
  */
 export const assertSharedLedger8Instance = (axis: Ledger8InstanceAxis, probeA: unknown, probeB: unknown): void => {
   if (!isKnownAxis(axis)) {

--- a/packages/protocol/src/lib/v8/load-engine.ts
+++ b/packages/protocol/src/lib/v8/load-engine.ts
@@ -36,11 +36,14 @@ let enginePromise: Promise<Engine.Ledger8Engine> | undefined;
  * `@midnight-ntwrk/onchain-runtime-v3` WASM load only on the first call — never
  * as a side effect of importing the package root.
  *
- * A failed load is not memoised: the next call retries the import. A rejection
- * that already carries a protocol error code propagates unchanged, keeping its
- * class, code and discriminants intact for callers; any other failure (e.g. a
- * raw module-resolution error on the engine chunk itself) is wrapped in
- * {@link Ledger8RuntimeMissingError}.
+ * A failed load is not memoised: the next call retries the import. Exactly two
+ * rejections propagate unchanged — {@link Ledger8RuntimeMissingError} from the
+ * retained-runtime acquisition, and {@link Ledger8InstanceMismatchError} from
+ * the construction-time instance guard — keeping their class, code and
+ * discriminants intact for callers. Every other failure is wrapped in
+ * {@link Ledger8RuntimeMissingError}, including the coded
+ * `Ledger8RuntimeInvalidError` that same guard raises for an incomplete
+ * runtime, and a raw module-resolution error on the engine chunk itself.
  *
  * @returns The engine's public surface, memoised after the first successful
  *   load.

--- a/packages/protocol/src/lib/v8/load-engine.ts
+++ b/packages/protocol/src/lib/v8/load-engine.ts
@@ -16,10 +16,8 @@
 import { Ledger8InstanceMismatchError, Ledger8RuntimeMissingError } from '../../errors';
 import type * as Engine from './engine.js';
 
-// Type-only, so the root barrel can name every option and result type a
-// caller needs without linking the engine chunk. Without these a consumer
-// holding a Ledger8Engine cannot annotate a variable or write a helper
-// without a second, subpath-gated import.
+// Type-only: a value re-export here would link the engine chunk into the root
+// barrel -- see ModuleGraphAndLazyLoading.
 export type {
   DownConvertedState,
   EncodedStateValue,
@@ -34,22 +32,24 @@ let enginePromise: Promise<Engine.Ledger8Engine> | undefined;
 /**
  * The only sanctioned runtime path to the engine's public surface.
  *
- * Like {@link loadLedger8}, the relative specifier names the `./engine` build
- * entry, which rollup emits as its own chunk and links only through this
- * dynamic import, so the retained `compact-runtime@0.16` glue and
- * `@midnight-ntwrk/onchain-runtime-v3` WASM load only on the first call —
- * never as a side effect of importing the package root. Enforced by
- * dist-laziness.test.ts (the index bundle must never link the `./engine`
- * subpath, `@midnight-ntwrk/onchain-runtime-v3`, or the
- * `compact-runtime-ledger8` glue alias statically).
+ * The retained `compact-runtime@0.16` glue and
+ * `@midnight-ntwrk/onchain-runtime-v3` WASM load only on the first call — never
+ * as a side effect of importing the package root.
  *
- * A failed load is not memoised: the next call retries the import. A
- * rejection that already carries a protocol error code —
- * {@link Ledger8RuntimeMissingError} from the retained-runtime acquisition, or
- * {@link Ledger8InstanceMismatchError} from the construction-time instance
- * guard — propagates unchanged, keeping its class, code and discriminants
- * intact for callers; any other failure (e.g. a raw module-resolution error
- * on the engine chunk itself) is wrapped in {@link Ledger8RuntimeMissingError}.
+ * A failed load is not memoised: the next call retries the import. A rejection
+ * that already carries a protocol error code propagates unchanged, keeping its
+ * class, code and discriminants intact for callers; any other failure (e.g. a
+ * raw module-resolution error on the engine chunk itself) is wrapped in
+ * {@link Ledger8RuntimeMissingError}.
+ *
+ * @returns The engine's public surface, memoised after the first successful
+ *   load.
+ * @throws Ledger8RuntimeMissingError If the retained runtime, or the `./engine`
+ *   chunk itself, cannot be acquired.
+ * @throws Ledger8InstanceMismatchError If the construction-time instance guard
+ *   found `onchain-runtime-v3` resolved to two physically distinct copies.
+ * @see {@link ModuleGraphAndLazyLoading}
+ * @see {@link EraSeam}
  */
 export const loadLedger8Engine = (): Promise<Engine.Ledger8Engine> =>
   (enginePromise ??= import('../../engine.js')

--- a/packages/protocol/src/lib/v8/load.ts
+++ b/packages/protocol/src/lib/v8/load.ts
@@ -23,19 +23,17 @@ let v8ModulePromise: Promise<ProtocolV8> | undefined;
 /**
  * The only sanctioned runtime path to the v8 ledger era.
  *
- * Lives under `lib/` because every module directly under `src/` is a build
- * entry paired with an `exports` subpath (see export-surface.test.ts), and the
- * accessor is published through the root barrel instead of a subpath of its
- * own.
- *
- * The relative specifier names the `./v8` build entry, which rollup emits as
- * its own chunk and links only through this dynamic import, so the v8 WASM
- * loads on the first call and not before. Enforced by v8-surface.test.ts (no
- * other module under src/ may import the v8 module at runtime) and
- * dist-laziness.test.ts (the index bundle must never link it statically).
+ * The v8 WASM loads on the first call and not before.
  *
  * A failed load is not memoised: the rejection propagates as
  * {@link Ledger8RuntimeMissingError} and the next call retries the import.
+ *
+ * @returns The v8 ledger module, memoised after the first successful load.
+ * @throws Ledger8RuntimeMissingError If the `./v8` chunk cannot be imported.
+ *   The returned promise rejects with it, carrying the underlying failure on
+ *   `cause`.
+ * @see {@link ModuleGraphAndLazyLoading}
+ * @see {@link EraSeam}
  */
 export const loadLedger8 = (): Promise<ProtocolV8> =>
   (v8ModulePromise ??= import('../../v8.js').catch((error: unknown) => {

--- a/packages/protocol/src/lib/v9/compose.ts
+++ b/packages/protocol/src/lib/v9/compose.ts
@@ -24,8 +24,7 @@ import { entryPointName, resolveVerifierKeyRegistrations } from '../shared/verif
 
 /**
  * Bridges a raw, serialized contract state into the v9 era, reporting a
- * rejected envelope as {@link ComposeOptionError} rather than letting a raw
- * decoder failure escape.
+ * rejected envelope as {@link ComposeOptionError} -- see ComposeRefusalOrder.
  */
 const readContractState = (raw: Uint8Array): ledgerV9.ContractState => {
   try {
@@ -57,31 +56,15 @@ const readZswapOffer = (raw: Uint8Array | undefined): ledgerV9.UnprovenOffer | u
  *
  * Never proves the transaction: the returned bytes are an UNPROVEN,
  * tag-prefixed serialization, exactly what `Transaction.serialize()` produces
- * before `.prove()` is ever called. Proving needs a proving provider and a
- * running proof server, neither of which this seam has.
+ * before `.prove()` is ever called.
  *
- * Uses `Transaction.fromPartsRandomized`, so the intent lands at a random
- * segment id and stays mergeable with other calls. Only deploys use a fixed
- * segment.
- *
- * The transaction-wide options are all checked before anything is composed: the
- * envelope first, then the call list, then both offers — so a caller handed bad
- * offer bytes learns that instead of paying for a full assembly first. Each
- * call's own contract state is read as that call is assembled, so a bad state
- * late in a tree is reported after the earlier calls have been built. Nothing is
- * emitted either way: the throw discards the whole intent.
- *
- * Every failure a caller can cause is coded. An empty call list is refused with
- * {@link ComposeFailedError} at stage `'call-empty'`, and an unreadable contract
- * state, Zswap offer, network id or ttl with {@link ComposeOptionError}. The
- * shared assembler contributes stages `'call-operation'`, `'call-verifier-key'`,
- * `'call-contract-state'`, `'call-transcript-empty'`, `'call-partition'` and
- * `'call-prototype'`; a payout the transaction cannot settle surfaces as
- * `'call-dust-payout'` or `'call-unsupported-payout'`.
- *
- * The transaction's two unshielded offers aggregate the user-addressed outputs
- * of EVERY call in the tree, not just the root — see
- * {@link aggregateUnshieldedOffers}.
+ * @param options The calls to compose and the transaction-wide envelope.
+ * @returns The serialized UNPROVEN transaction.
+ * @throws ComposeFailedError if the call list is empty (stage `'call-empty'`)
+ * or a call cannot be assembled; `stage` names which step refused it.
+ * @throws ComposeOptionError if the network id, the ttl, a Zswap offer or a
+ * call's contract state is unusable.
+ * @see {@link ComposeRefusalOrder}
  */
 export const composeV9CallTx = (options: ComposeCallOptions): Uint8Array => {
   const { calls, networkId, ttl, guaranteedZswapOffer, fallibleZswapOffer } = options;
@@ -90,8 +73,7 @@ export const composeV9CallTx = (options: ComposeCallOptions): Uint8Array => {
     throw new ComposeFailedError('v9', 'call-empty', NO_CIRCUIT);
   }
 
-  // Read both offers before composing anything, so a caller handed bad offer
-  // bytes learns that instead of paying for a full assembly first.
+  // Read both offers before composing anything -- see ComposeRefusalOrder.
   const guaranteedOffer = readZswapOffer(guaranteedZswapOffer);
   const fallibleOffer = readZswapOffer(fallibleZswapOffer);
 
@@ -114,8 +96,7 @@ export const composeV9CallTx = (options: ComposeCallOptions): Uint8Array => {
   }
 
   // Read the partitioned pairs back off the intent rather than re-deriving
-  // them: these are the exact transcripts the transaction now carries, so the
-  // offers cannot describe a different partition than the calls do.
+  // them -- see ComposeRefusalOrder.
   const unshielded = aggregateUnshieldedOffers(
     intent.actions
       .filter((action) => action instanceof ledgerV9.ContractCall)
@@ -139,9 +120,8 @@ export const composeV9CallTx = (options: ComposeCallOptions): Uint8Array => {
 
 /**
  * Registers a verifier key for every entry point the state declares, against
- * the map validated by {@link resolveVerifierKeyRegistrations} — the shared
- * resolver both eras' deploy legs use, so the two cannot drift on which checks
- * run or in what order.
+ * the map validated by {@link resolveVerifierKeyRegistrations} -- see
+ * VerifierKeys.
  */
 const registerVerifierKeys = (
   contractState: ledgerV9.ContractState,
@@ -164,32 +144,13 @@ const registerVerifierKeys = (
 
 /**
  * Refuses a state that still declares an entry point with a blank verifier key
- * when no key map was supplied.
- *
- * `verifierKeys` is optional so that a state which ALREADY carries its keys can
- * be deployed as-is. Omitting it for a constructor-built state is a different
- * thing entirely: every entry point is declared blank, the deploy derives its
- * address from that blank state, and the contract lands on chain unable to
- * verify any call against it. Nothing fails until the first call, which reports
- * `'call-verifier-key'` a long way from the cause. The v8 arm refuses the
- * omission outright; this makes the two arms agree without taking away the one
- * case the optionality exists for.
+ * when no key map was supplied -- see VerifierKeys.
  */
 const assertStateCarriesKeys = (contractState: ledgerV9.ContractState): void => {
   for (const entryPoint of contractState.operations()) {
-    // `?.` collapses "no operation resolves" into "operation has a blank key",
-    // which `../shared/contract-state.ts` deliberately refuses to do for the same
-    // call. It is safe here because both answers have the one remediation this
-    // function exists to demand — supply the map — whereas a decoded state hands
-    // its caller a verifierKey field whose absence means "never deployed".
-    //
-    // Raised as the OPTION error, not as `ComposeFailedError`'s
-    // `'deploy-verifier-key'` stage, even though that stage means exactly this
-    // condition and would name the offending entry point. The v8 arm refuses the
-    // same omission as `ComposeOptionError('v8', 'verifierKeys')`, and a caller
-    // writing one handler across both eras matters more than naming which of a
-    // contract's slots was blank. Naming it as well needs a `circuitId` on
-    // `ComposeOptionError`, which is a wider change than this seam should make.
+    // `?.` is deliberate here, unlike in `../shared/contract-state.ts`, and so
+    // is raising the OPTION error rather than the `'deploy-verifier-key'` stage
+    // -- see VerifierKeys.
     if (contractState.operation(entryPoint)?.verifierKey === undefined) {
       throw new ComposeOptionError('v9', 'verifierKeys');
     }
@@ -206,14 +167,22 @@ const assertStateCarriesKeys = (contractState: ledgerV9.ContractState): void => 
  * tag-prefixed serialization, exactly what `Transaction.serialize()` produces
  * before `.prove()` is ever called.
  *
- * Uses `Transaction.fromParts`, not `fromPartsRandomized`, so the intent lands
- * at a fixed segment id. Only calls randomize their segment, to stay mergeable.
- *
  * With `verifierKeys` supplied, every declared entry point is registered before
- * the address is derived — see {@link registerVerifierKeys} for the checks that
- * run first. Without it, the state is deployed exactly as given, which is right
- * only for a state that already carries its keys — and that is checked rather
- * than assumed, see {@link assertStateCarriesKeys}.
+ * the address is derived. Without it, the state is deployed exactly as given —
+ * which is checked rather than assumed, see {@link assertStateCarriesKeys}.
+ *
+ * @param options The serialized initial state, its verifier keys, and the
+ * transaction-wide envelope.
+ * @returns The serialized UNPROVEN transaction, the address the deployment
+ * will have, and the initial state that address was derived from.
+ * @throws ComposeFailedError if the supplied keys do not match the state's
+ * declared entry points, or if the ledger rejects a key blob; `stage` names
+ * which check refused it.
+ * @throws ComposeOptionError if the network id, the ttl, the Zswap offer or
+ * the state bytes are unusable, or if `verifierKeys` was omitted for a state
+ * that still declares a blank key.
+ * @see {@link VerifierKeys}
+ * @see {@link ComposeRefusalOrder}
  */
 export const composeV9DeployTx = (options: ComposeDeployOptions): DeployResultPojo => {
   const { contractState, verifierKeys, networkId, ttl, guaranteedZswapOffer } = options;

--- a/packages/protocol/src/lib/v9/wrap.ts
+++ b/packages/protocol/src/lib/v9/wrap.ts
@@ -36,31 +36,29 @@ export interface WrapKeepStateCallOptions {
  * Wraps a {@link TranscriptPojo} — the output of {@link executeCircuit}
  * (`./execute.ts`) — into a v9-native `ContractCallPrototype`, ready for
  * `Intent.new(ttl).addCall(...)`, via {@link assembleCallPrototype}
- * (`./assemble-call.ts`) against the ledger-v9 module. This is the
- * "keep-state" leg: the contract keeps running on the retained pre-fork
- * execution engine after the fork, but the resulting call is bound NATIVELY
- * against the current ledger-v9 axis from the start — no v8-tx carrier, no
- * later re-bind.
+ * (`./assemble-call.ts`) against the ledger-v9 module.
  *
  * `options.contractState` is the migrated, post-fork v9 `ContractState` —
  * read from chain, or otherwise carrying the contract's real registered
- * operations. A keep-state call never registers a new verifier key (unlike
- * a deploy); it reuses whichever key was already registered on-chain by the
- * contract's original (pre-fork) deploy and carried through the migration —
- * so `contractState` must already carry that operation, or this throws
- * `ComposeFailedError` (`../../errors.ts`) rather than silently
- * falling back to a blank, unverifiable operation: stage `'wrap-call'` when
- * no operation is registered for the circuit at all, and
- * `'call-verifier-key'` when the one registered carries no verifier key.
+ * operations. It must already carry the operation for the circuit: a
+ * keep-state call registers no new verifier key.
+ *
+ * @param options The transcript to wrap, the contract's address, and the
+ * migrated post-fork state to resolve the circuit's operation against.
+ * @returns The v9-native call prototype.
+ * @throws ComposeFailedError at stage `'wrap-call'` if `contractState`
+ * registers no operation for the circuit, and at `'call-verifier-key'` if the
+ * registered operation carries no verifier key — rather than falling back to a
+ * blank, unverifiable operation.
+ * @see {@link RetainedEraExecution}
  */
 export const wrapKeepStateCall = (options: WrapKeepStateCallOptions): ledgerV9.ContractCallPrototype => {
   const { transcript, contractAddress, contractState } = options;
   return assembleCallPrototype(ledgerV9, {
     circuitId: transcript.circuitId,
     contractAddress,
-    // The retained execution leg partitions nothing: it hands over the raw op
-    // sequence the circuit emitted, against the state it ran on — plus the
-    // context it recorded while running, which the state bytes do not carry.
+    // The retained execution leg partitions nothing: it always submits the raw
+    // op sequence as `'unpartitioned'` -- see RetainedEraExecution.
     transcript: {
       kind: 'unpartitioned',
       preState: transcript.preContractState.data.state.encode(),

--- a/packages/protocol/src/version.ts
+++ b/packages/protocol/src/version.ts
@@ -16,11 +16,8 @@
 import { UnknownProtocolVersionError, type VersionResolutionPath } from './errors';
 import { LEDGER_VERSIONS, type LedgerVersion } from './lib/shared/ledger-version';
 
-// Re-exported rather than declared here: `./errors` also needs `LedgerVersion`
-// to type the era its composition failures name, and this module imports
-// `./errors`. The constant therefore lives in a leaf module both can reach —
-// see `./lib/shared/ledger-version.ts`. Consumers keep importing both names from here
-// (and from the root barrel) exactly as before.
+// Declared in the leaf module `./lib/shared/ledger-version`, which `./errors`
+// can also reach; declaring it here would close a cycle — see ModuleGraphAndLazyLoading.
 export { LEDGER_VERSIONS, type LedgerVersion };
 
 /**
@@ -28,6 +25,9 @@ export { LEDGER_VERSIONS, type LedgerVersion };
  * typically an indexer or node client. Consumed by {@link networkHeadVersion}.
  */
 export interface ProtocolVersionSource {
+  /**
+   * @returns The network's current head `protocolVersion` integer.
+   */
   queryLatestProtocolVersion(): Promise<number>;
 }
 
@@ -40,16 +40,8 @@ export interface VersionedRecord {
   readonly protocolVersion: number;
 }
 
-// The protocolVersion integer encodes the NODE version as
-// major * 1_000_000 + minor * 1_000 + patch, so a whole node major occupies a
-// 1_000_000-wide range. That encoding is the one used by
-// midnightntwrk/midnight-indexer (indexer-common/src/domain/protocol_version.rs).
-//
-// The table below is deliberately NARROWER than the indexer's: only majors 1
-// and 2 are mapped. midnight-js ships against node 1.x and 2.x, so a 0.x
-// protocolVersion — which the indexer does map — is treated here as an unknown
-// version rather than a supported era. This is a fail-closed choice, not a
-// mirror; do not "restore" 0.x to match the indexer without a caller needing it.
+// Deliberately narrower than the indexer's table: do not "restore" the 0.x
+// major to match it without a caller needing it — see SharedTableDiscipline.
 const NODE_MAJOR_TO_LEDGER = {
   1: 'v8',
   2: 'v9'
@@ -57,16 +49,12 @@ const NODE_MAJOR_TO_LEDGER = {
 
 type MappedLedgerVersion = (typeof NODE_MAJOR_TO_LEDGER)[keyof typeof NODE_MAJOR_TO_LEDGER];
 
-// Compile-time-only guard: if LEDGER_VERSIONS ever grows without a matching
-// entry being added to the table above, this assignment stops type-checking
-// (the conditional type resolves to `never`).
+// Compile-time-only guard: a `LEDGER_VERSIONS` member with no entry in the
+// table above stops this assignment type-checking — see SharedTableDiscipline.
 const _allLedgerVersionsAreMapped: Exclude<LedgerVersion, MappedLedgerVersion> extends never ? true : never = true;
 
-// Kept as a small typed function (rather than indexing the `as const` table
-// directly) because a `number`-typed key cannot index an object type with only
-// numeric literal properties — the `Partial<Record<number, ...>>` parameter
-// type is what makes the `=== undefined` guard below type-driven instead of
-// relying on a cast.
+// A typed function rather than a direct index, because a `number`-typed key
+// cannot index the `as const` table — see SharedTableDiscipline.
 const lookupLedger = (table: Partial<Record<number, LedgerVersion>>, key: number): LedgerVersion | undefined =>
   table[key];
 
@@ -79,21 +67,22 @@ const lookupLedger = (table: Partial<Record<number, LedgerVersion>>, key: number
  * | 1_000_000 – 1_999_999 | 1.x          | v8     |
  * | 2_000_000 – 2_999_999 | 2.x          | v9     |
  *
- * Throws {@link UnknownProtocolVersionError}:
- * - with `reason: 'malformed'` when `protocolVersion` is not a non-negative
- *   integer;
- * - with `reason: 'unknown'` when it is a well-formed integer outside every
- *   range above.
- *
- * `path` defaults to `'construct'`, which decides which of the two error
- * codes a failure carries.
- *
  * Most call sites should not call this directly. Prefer
  * {@link versionOfRecord} for a `protocolVersion` read off an existing
  * indexer/node record, or {@link networkHeadVersion} for the network's
  * current head version — both tag the resulting error with the correct
  * `path` automatically. Pass `path` explicitly here only when neither helper
  * fits the call site.
+ *
+ * @param protocolVersion The raw integer read from an indexer or node record.
+ * @param path Which resolution path a failure is attributed to. Defaults to
+ * `'construct'`, and decides which of the two error codes a failure carries.
+ * @returns The {@link LedgerVersion} that `protocolVersion`'s node major maps
+ * onto.
+ * @throws {@link UnknownProtocolVersionError} with `reason: 'malformed'` when
+ * `protocolVersion` is not a non-negative integer, and with `reason: 'unknown'`
+ * when it is a well-formed integer outside every range above.
+ * @see {@link SharedTableDiscipline}
  */
 export const protocolVersionToLedger = (
   protocolVersion: number,
@@ -111,18 +100,25 @@ export const protocolVersionToLedger = (
 
 /**
  * Resolves the ledger version for a record's `protocolVersion` field (e.g. a
- * transaction or block already read from the indexer). Any resulting
- * {@link UnknownProtocolVersionError} is tagged with the `read` path.
+ * transaction or block already read from the indexer).
+ *
+ * @param record Any object carrying a raw `protocolVersion` integer field.
+ * @returns The {@link LedgerVersion} that record was written under.
+ * @throws {@link UnknownProtocolVersionError} tagged with the `read` path, on
+ * the same two conditions as {@link protocolVersionToLedger}.
  */
 export const versionOfRecord = (record: VersionedRecord): LedgerVersion =>
   protocolVersionToLedger(record.protocolVersion, 'read');
 
 /**
  * Queries `source` for the network's current head protocol version and
- * resolves it to a {@link LedgerVersion}. Any resulting
- * {@link UnknownProtocolVersionError} is tagged with the `construct` path.
- * A rejection from `source.queryLatestProtocolVersion()` propagates
- * unchanged.
+ * resolves it to a {@link LedgerVersion}.
+ *
+ * @param source The indexer or node client to ask for the head version.
+ * @returns A promise for the {@link LedgerVersion} at the network head.
+ * @throws {@link UnknownProtocolVersionError} tagged with the `construct`
+ * path, on the same two conditions as {@link protocolVersionToLedger}. A
+ * rejection from `source.queryLatestProtocolVersion()` propagates unchanged.
  */
 export const networkHeadVersion = async (source: ProtocolVersionSource): Promise<LedgerVersion> =>
   protocolVersionToLedger(await source.queryLatestProtocolVersion(), 'construct');

--- a/packages/protocol/typedoc.json
+++ b/packages/protocol/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "projectDocuments": ["docs/*.md"]
+}


### PR DESCRIPTION
## Summary

`packages/protocol/src` carried **1978 lines of comment against 1560 lines of
code**. 91% of that mass (1801 lines) sat in TSDoc blocks above exported
symbols, and the package had **zero** `@param` / `@returns` / `@throws` tags —
so the docstrings were narrative prose with no separable API contract. Sibling
packages do use tags (`types` 133 lines, `contracts` 127, `utils` 47).

The same rationale was also restated across files: the `Object.freeze`
argument in **five** files, compile-time exhaustiveness in **six**,
`Object.create(null)` in three, "only bytes and plain objects cross the seam"
in three. Five places to update for one decision.

This splits the things that were glued together:

| | Where it lives now |
|---|---|
| **API contract** — what a symbol does, its parameters, what it returns, what it throws | TSDoc, in tagged form |
| **Context** — why it is built this way | one document, stated once |
| **Decision** — a choice that constrains future work | an ADR, where this repo keeps them |

**This is not a line reduction.** Comment lines in `src` fall 1978 → 1610
while 296 tag lines are added, so prose falls by roughly 660; the documents add
1300. Net repo lines go **up**. The win is one source of truth and a real API
contract, not less text.

### The nine documents

Registered with TypeDoc through `projectDocuments`, so each is a page in the
generated reference and `@see {@link Title}` from a docstring resolves to it —
and a renamed or deleted document breaks the docs build instead of rotting
silently. Indexed from the package README, which is also the package landing
page in the generated reference.

| Document | Lines |
|---|---|
| `EraSeam` | 153 |
| `RetainedEraExecution` | 302 |
| `DualInstantiationGuard` | 182 |
| `FailClosedDecoding` | 216 |
| `ComposeRefusalOrder` | 265 |
| `VerifierKeys` | 123 |
| `ModuleGraphAndLazyLoading` | 176 |
| `SharedTableDiscipline` | 221 |
| `InjectedVendorSlices` | 209 |

The highest-stakes move is the 66-line block above
`assertSharedLedger8Instance`: the wasm-bindgen measurement it carried — what a
duplicate install does in the argument position (`_assertClass` throws) versus
the receiver position (nothing is checked, a plausible wrong value comes back)
— existed nowhere else in the repository.

## One decision promoted to an ADR

The transport rule the seam is built on — what may cross the era boundary — is
an architecture decision, not package context, so it is recorded where this repo
keeps those. `docs/adr/0007-cross-the-era-boundary-with-plain-data-only.md` now
holds it, and `era-seam.md` defers to it exactly as
`module-graph-and-lazy-loading.md` already defers to ADR-0004. The `LedgerEra`
docstring keeps the fact a caller needs and drops the rationale. ADR 0006 is
taken on this stack's base, and the competing 0006-0009 belong to the closed
#1141, so 0007 is free.

### A sixteenth correction, found by writing it

`era-seam.md` presented "every value crossing the era boundary is plain data,
never a live WASM handle" as a property of the WHOLE seam. It is not.
`LedgerEra` satisfies it on all four methods; `Ledger8Engine` satisfies it on
none of its four. `DownConvertedState.data` is an `onchain-runtime-v3`
`ChargedState` — `export class` at `onchain-runtime-v3.d.ts:1004`, built with
`new ledger8Runtime.ChargedState(...)`. `TranscriptPojo` carries two of them as
`preContractState` / `postContractState`. `ConstructorResultPojo.contractState`
is a pre-fork state handle, which its own docstring already called a HANDLE.
And `wrapKeepStateCall` returns a ledger-v9 `ContractCallPrototype`, also a
class. `readonly` throughout and a `Pojo` suffix turn out not to be evidence of
plain data.

The rule the code actually follows is narrower, and none of those four break
it: no live handle passes between two ERAS, and a crossing point encodes first.
`wrapKeepStateCall` calls `transcript.preContractState.data.state.encode()`
(`lib/v9/wrap.ts:64`) before the value reaches ledger-v9. Handles circulate
freely inside a single era, which is what keeps the retained pipeline —
down-convert, execute, wrap — from paying an encode at every step. The ADR
states the rule that way, gives both consequences, and names the gate that
mechanises the `LedgerEra` half: `era-parity.test.ts` calls `structuredClone`
over all four results on both eras, so a handle fails the gate instead of
shipping. The `Ledger8Engine` half has no such gate, and the ADR says so.

`packages/protocol/README.md` states the same fact a third time, but scoped
correctly to `LedgerEra` and addressed to a consumer — the category this PR
deliberately leaves in place — so it stays.

## Three corrections, NOT moves

Found while relocating prose, disclosed separately because they change what the
documentation *says*:

1. **`era.ts` `composeCallTx` was wrong about Zswap.** It claimed the retained
   pre-fork era "refuses a Zswap offer outright". `composeEraV8CallTx`
   (`lib/v8/adapt.ts:90-91`) reads both `guaranteedZswapOffer` and
   `fallibleZswapOffer` and passes them into `composeV8CallTx` (109-110), and
   `readZswapOffer` documents the opposite at length. The #1218 description
   already carried this correction; the docstring never got it. The one-call
   limit is the real difference and is now the only one stated.
2. **`ComposeFailedError`'s cause enumeration was stale.** It named two stages;
   five carry a `cause`, across six throw sites (`v9/compose.ts:139`,
   `v8/deploy.ts:188`, `assemble-call.ts:239/245/260/347`). Replaced by a
   pointer to `@param cause`.
3. **Four incomplete "Thrown by" statements** now name their real throw sites,
   which is what turning them into `@throws` required.
   `Ledger8RuntimeMissingError` was an exported error class with no
   documentation at all.

## Twelve more corrections, from a review of the documents against the code

After the move, two independent tech-writer reviews read the documents against
the code with no knowledge of how they were produced. They found twelve claims
that were wrong or imprecise. All are corrected, each verified against the code
before the fix:

- `compose-refusal-order` named `engine-down-convert.test.ts` as a drift gate.
  **No such file exists** — the gate is `_CallContextUnchanged`,
  `_EffectsUnchanged`, `_V8CallContextUnchanged` and `_V8EffectsUnchanged` at
  the bottom of `v8-down-convert.test.ts`, which the paragraph above already
  named correctly.
- `retained-era-execution` said `PartitionContext` carries four members; it
  carries three (`block`, `effects`, `comIndices`).
- `retained-era-execution` named `v8-load-engine.test.ts` as pinning that the
  real glue satisfies the execution slice. That file contains **zero**
  references to `Ledger8ExecutionRuntime`; the compile-time pin is
  `createLedger8Engine` itself.
- `CostModel` was described as narrowed rather than derived. It is
  `Pick<typeof OnchainRuntimeV3.CostModel, 'initialCostModel'>` — both.
- `CallOperationRegistry`'s `TOperation` was said to be constrained. It is
  unconstrained; the bound is on `assembleCallPrototype`.
- `module-graph` claimed the engine re-export list names "every type a caller
  needs". See the export hole below.
- Four smaller ones: a wrong pin for the blank-verifier-key refusal, "the
  deploy tests need no real WASM" when only one test uses a double, an
  incomplete failure enumeration, and `Ledger8CompactRuntimeStateValue`
  described as a `Pick` when it reads its member by indexed access.
- Two artefacts of the extraction itself: `dual-instantiation-guard` stated the
  `_assertClass` argument twice in ten lines, and opened a section on a
  dangling "So this guard is not only ...", where "So" referred to text that
  stayed behind in the code.

The hit rate is worth stating plainly: roughly fifty technical claims were
sampled across the set and twelve needed correcting. The reviews also confirmed
the parts that hold — the 126 `@see {@link Title}` pointers and the document
titles are a perfect bijection in both directions, and every other named test,
error stage and vendor quotation checks out.

### A ninth document, and two copies reduced to one

The derive-versus-structural-versus-narrow topic was spread across four
documents as instalments, each restating the general rule before adding its own
slice. It was the last fifth of the two longest documents, so
`compose-refusal-order` ended on type design rather than refusal order. It now
has one home, `InjectedVendorSlices`, and those two documents are 265 and 302
lines, down from 323 and 335.

Two arguments had been copied rather than relocated and are down to one copy:
the `version`-guard reasoning now lives only in `SharedTableDiscipline`, and the
acquired-versus-incomplete-runtime distinction only in `FailClosedDecoding`,
with `errors.ts` keeping the part a caller needs to tell the two classes apart.

## What deliberately stayed in the code

- Anything a caller reads: what a symbol does, signature facts the types do not
  state ("required for every era, not just v8", "a failed load is not
  memoised", "the address cannot be recomputed from the input"), and the
  `ComposeStage` / `ComposeOption` catalogues, which are the contract for
  switching on `stage` and `option`.
- Short imperatives read at the moment of editing, e.g. that the node-major
  table is deliberately narrower than the indexer's and must not be "restored",
  and that `lookupLedger` is a typed function because a `number` key cannot
  index the `as const` table — the note that stops the "looks redundant, delete
  it" edit.
- `lib/era/era.ts` was excluded from trimming: it is the `LedgerEra` interface
  and its docstrings ARE the public documentation of the facade. It gained tags
  and grew.

## Evidence

**No line of code changed.** For every file, the non-comment lines are
byte-identical to the base commit:

```sh
BASE=d4f83075
for f in $(git ls-tree -r --name-only $BASE -- packages/protocol/src | grep -v '/test/'); do
  diff <(git show $BASE:$f | grep -vE '^[[:space:]]*(\*|//|/\*)') \
       <(grep -vE '^[[:space:]]*(\*|//|/\*)' "$f") >/dev/null || echo "CODE CHANGED: $f"
done
```

Output is empty. `gitnexus detect_changes` agrees independently: 34 files
changed, **0 changed symbols**, 0 affected processes.

**Nothing was lost.** Each of the nine reconciliation passes recorded every
passage it moved, and the later removal stage acted only on those records —
anything not recorded as moved stayed. A section-aware audit over all 24 source
files found six blocks whose only mention was a bounce to a document that never
took them; five were compose catalogues in `errors.ts` that a dedicated pass
then judged to be caller contract and kept.

**Zero new TypeDoc warnings.** Corrected from an earlier version of this
description, which quoted 115 -> 111. Those figures came from a per-package
probe (`npx typedoc --options packages/protocol/typedoc.json`), a configuration
CI never runs: 102 of them were `does not have any documentation`, which does
not fire in the shipping build at all.

The build CI actually runs is `yarn build:markdown-docs` at the repo root,
`entryPointStrategy: "packages"`. It reports **85 warnings repo-wide, 9 of them
from protocol**, and zero `notDocumented`. Attribution of those 9, checked
against the base commit:

| Cause | Count | Introduced by this PR? |
|---|---|---|
| Dangling `{@link}` already in the code at base — `executeCircuit`, `createLedger8Engine`, `wrapKeepStateCall` ×2 | 4 | **No.** Present at `d4f83075`; this PR removed two of the seven `executeCircuit` occurrences. They surface now only because protocol finally has generated pages for its own API. |
| `entryPoints: ["src/index.ts"]` meeting #1218's API surface — `V8`, `Ledger8ContractLike`, `Op`, `ConstructorResultPojo`, `ExecuteConstructorOptions` referenced but not included | 5 | **No.** Caused by `packages/protocol/typedoc.json`, which does not exist at base and which #1222 also adds. See the note in #1222. |
| Moving rationale into documents | **0** | — |

So the substantive claim holds — the rationale move introduces no warning — but
the number to hold this PR to is 9 in the shipping build, not 111 in a probe.

## Known gaps, not fixed here

- **An export hole this PR documents but must not fix.**
  `lib/v8/load-engine.ts` re-exports six engine types and omits
  `ExecuteConstructorOptions` and `ConstructorResultPojo`, so
  `executeConstructor` is the one method on the seam whose argument and result
  a caller cannot annotate from the root barrel. TypeDoc reports both as
  referenced-but-not-included. `module-graph-and-lazy-loading.md` now states
  the omission instead of claiming the list is complete. Closing it is a
  one-line change to the re-export list, deliberately left out so a docs-only
  commit does not alter the package's export surface.
- **`yarn typecheck:tests` runs only in `.husky/pre-push`, in no CI workflow.**
  Every compile-time gate these documents lean on — `_PostForkOnchainRuntimeIsRejected`,
  the drift gates, the "real glue satisfies the slice" assignments — is
  therefore evaluated by a local hook, not by CI, so a green PR can bypass
  them. That is a repo-wide gap, not this PR's to close, but it means sentences
  like "a vendor bump would otherwise silently reopen the hole" describe a gate
  CI does not enforce.
- `errors.ts:376-380` and `:545-546` state the cause-taxonomy and
  never-render-caller-text properties for the compose classes;
  `FailClosedDecoding` covers only the decode classes. Leaving them is safe —
  they read as caller contract where they sit.
- `lib/v8/execute.ts` carries `{@link wrapKeepStateCall}` in the
  `TranscriptPojo` docstring, which already failed to resolve at base. Inside
  the pre-existing baseline, left alone rather than widening scope.

## Merge order

This PR creates `packages/protocol/typedoc.json`, and so does #1222, which
targets `main`. If #1222 lands first, expect a trivial add/add conflict on that
one file — take this branch's version, which is #1222's two keys plus
`projectDocuments`. Nothing else overlaps.

`docs/api` is deliberately untouched: it is generated and owned by
`.github/workflows/docs-api.yml`, which opens its own PR after a push to
`main`.

## Test plan

- [x] `yarn build` — 16/16 tasks successful
- [x] `yarn lint ./packages` — clean
- [x] `yarn typecheck:tests` — clean
- [x] `yarn test` — 31/31 tasks successful
- [x] TypeDoc: zero new warnings against a baseline that isolates this change
- [x] All nine documents emitted as `documents/*.md`; every `@see {@link}`
      added resolves
- [x] Code-unchanged check empty on every commit; `detect_changes` reports 0
      changed symbols
- [x] Licence headers byte-identical in all 24 source files
- [x] Nothing under `docs/api` committed

