### PR TITLE
feat(midnight-js): re-export ledger era vocabulary from the barrel

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -294,55 +294,74 @@ import { setNetworkId } from '@midnight-ntwrk/midnight-js/network-id';
 
 The barrel also publishes the ledger era vocabulary as named exports, so a
 consumer can say which era produced a payload or a record without depending on
-`@midnight-ntwrk/midnight-js-protocol` directly:
+`@midnight-ntwrk/midnight-js-protocol` directly. `versionOfRecord` resolves the
+era of an existing record; `networkHeadVersion` resolves the era a transaction
+built now would land in.
 
 ```typescript
 import {
-  LEDGER_VERSIONS,         // the closed, frozen set: ['v8', 'v9']
-  type LedgerVersion,      // 'v8' | 'v9'
-  protocolVersionToLedger, // a raw protocolVersion integer -> LedgerVersion
-  versionOfRecord,         // a record carrying protocolVersion -> LedgerVersion
-  networkHeadVersion       // asks a source for the network head -> LedgerVersion
+  LEDGER_VERSIONS,    // the closed, frozen set: ['v8', 'v9']
+  type LedgerVersion, // 'v8' | 'v9'
+  networkHeadVersion,
+  versionOfRecord
 } from '@midnight-ntwrk/midnight-js';
 
 // Any record carrying a raw protocolVersion, e.g. a transaction or block
 // already read from the indexer.
-const tx = { protocolVersion: 1_000_000 };
+const era: LedgerVersion = versionOfRecord({ protocolVersion: 1_000_000 }); // 'v8'
 
-const era: LedgerVersion = versionOfRecord(tx); // 'v8' for node 1.x, 'v9' for 2.x
+// The era at the network head, asked of a provider on every call.
+const head: LedgerVersion = await networkHeadVersion(providers.publicDataProvider);
 ```
 
-All three resolvers throw `UnknownProtocolVersionError` when a
-`protocolVersion` maps to no known era, so the error class and the code table
-are published alongside them:
+Both resolvers refuse rather than guess: they raise `UnknownProtocolVersionError`
+when a `protocolVersion` is malformed (not a non-negative integer) or is
+well-formed but maps to no era this build knows. `versionOfRecord` throws;
+`networkHeadVersion` is `async` and rejects, passing a rejection from the
+source itself through unchanged. Handle it by class and rethrow anything else:
 
 ```typescript
 import {
-  PROTOCOL_ERROR_CODES,
   type ProtocolVersionUnknownReason,
   UnknownProtocolVersionError,
-  utils,
   versionOfRecord,
   type VersionResolutionPath
 } from '@midnight-ntwrk/midnight-js';
 
+// Node major 9 is one this build has no era for, so this takes the failure path.
 try {
-  const era = versionOfRecord(tx); // tx as above
+  const era = versionOfRecord({ protocolVersion: 9_000_000 });
   console.log(`written under ledger ${era}`);
 } catch (error) {
-  if (utils.hasErrorCode(error, PROTOCOL_ERROR_CODES.UNKNOWN_PROTOCOL_VERSION_READ)) {
-    // a record this build has no era for
+  // Anything that is not ours is not ours to interpret. Never swallow it.
+  if (!(error instanceof UnknownProtocolVersionError)) {
+    throw error;
   }
-  if (error instanceof UnknownProtocolVersionError) {
-    const path: VersionResolutionPath = error.path;            // 'read' | 'construct'
-    const reason: ProtocolVersionUnknownReason = error.reason; // 'unknown' | 'malformed'
-    console.warn(`no era on the ${path} path: ${reason}`);
-  }
+
+  const path: VersionResolutionPath = error.path;            // 'read' | 'construct'
+  const reason: ProtocolVersionUnknownReason = error.reason; // 'unknown' | 'malformed'
+
+  // 'unknown' means this build predates the network; 'malformed' means the
+  // wrong field was wired into the resolver. Different fixes, so do not
+  // collapse them into one warning.
+  throw new Error(`no era on the ${path} path: ${reason}`, { cause: error });
 }
 ```
 
-The retained pre-fork ledger runtime is **not** re-exported from the barrel,
-and importing the barrel does not load it.
+To discriminate on a stable string instead of a class, every error here also
+carries a `code`: `utils.hasErrorCode(error, PROTOCOL_ERROR_CODES.UNKNOWN_PROTOCOL_VERSION_READ)`.
+
+The retained pre-fork (`v8`) pipeline raises its own errors, whose classes the
+barrel also publishes so a consumer can read their payload without a cast:
+`Ledger8RuntimeMissingError` (`subpath`), `ComposeFailedError` (`version`,
+`stage`, `circuitId`), `ComposeOptionError` (`version`, `option`),
+`StateDecodeFailedError` (`version`) and `UnknownLedgerVersionError`
+(`requestedVersion`).
+
+The retained pre-fork ledger runtime itself is **not** re-exported from the
+barrel and is absent from its static import graph, loaded only on demand when a
+`v8` contract is actually touched. Importing the barrel does pull the `v9`
+ledger and onchain-runtime, because `contracts` needs them.
 
 ### Network Setup
 

--- a/llms.txt
+++ b/llms.txt
@@ -292,6 +292,58 @@ import { deployContract } from '@midnight-ntwrk/midnight-js/contracts';
 import { setNetworkId } from '@midnight-ntwrk/midnight-js/network-id';
 ```
 
+The barrel also publishes the ledger era vocabulary as named exports, so a
+consumer can say which era produced a payload or a record without depending on
+`@midnight-ntwrk/midnight-js-protocol` directly:
+
+```typescript
+import {
+  LEDGER_VERSIONS,         // the closed, frozen set: ['v8', 'v9']
+  type LedgerVersion,      // 'v8' | 'v9'
+  protocolVersionToLedger, // a raw protocolVersion integer -> LedgerVersion
+  versionOfRecord,         // a record carrying protocolVersion -> LedgerVersion
+  networkHeadVersion       // asks a source for the network head -> LedgerVersion
+} from '@midnight-ntwrk/midnight-js';
+
+// Any record carrying a raw protocolVersion, e.g. a transaction or block
+// already read from the indexer.
+const tx = { protocolVersion: 1_000_000 };
+
+const era: LedgerVersion = versionOfRecord(tx); // 'v8' for node 1.x, 'v9' for 2.x
+```
+
+All three resolvers throw `UnknownProtocolVersionError` when a
+`protocolVersion` maps to no known era, so the error class and the code table
+are published alongside them:
+
+```typescript
+import {
+  PROTOCOL_ERROR_CODES,
+  type ProtocolVersionUnknownReason,
+  UnknownProtocolVersionError,
+  utils,
+  versionOfRecord,
+  type VersionResolutionPath
+} from '@midnight-ntwrk/midnight-js';
+
+try {
+  const era = versionOfRecord(tx); // tx as above
+  console.log(`written under ledger ${era}`);
+} catch (error) {
+  if (utils.hasErrorCode(error, PROTOCOL_ERROR_CODES.UNKNOWN_PROTOCOL_VERSION_READ)) {
+    // a record this build has no era for
+  }
+  if (error instanceof UnknownProtocolVersionError) {
+    const path: VersionResolutionPath = error.path;            // 'read' | 'construct'
+    const reason: ProtocolVersionUnknownReason = error.reason; // 'unknown' | 'malformed'
+    console.warn(`no era on the ${path} path: ${reason}`);
+  }
+}
+```
+
+The retained pre-fork ledger runtime is **not** re-exported from the barrel,
+and importing the barrel does not load it.
+
 ### Network Setup
 
 ```typescript

--- a/llms.txt
+++ b/llms.txt
@@ -356,7 +356,8 @@ barrel also publishes so a consumer can read their payload without a cast:
 `Ledger8RuntimeMissingError` (`subpath`), `ComposeFailedError` (`version`,
 `stage`, `circuitId`), `ComposeOptionError` (`version`, `option`),
 `StateDecodeFailedError` (`version`) and `UnknownLedgerVersionError`
-(`requestedVersion`).
+(`requestedVersion`). `PayloadNotATransactionError` is published alongside them
+for the `proveTx` rejection path.
 
 The retained pre-fork ledger runtime itself is **not** re-exported from the
 barrel and is absent from its static import graph, loaded only on demand when a

--- a/packages/midnight-js/README.md
+++ b/packages/midnight-js/README.md
@@ -31,6 +31,58 @@ const deployed = await contracts.deployContract(providers, {
 | `types`      | `@midnight-ntwrk/midnight-js-types`      | Shared types, interfaces, and provider contracts|
 | `utils`      | `@midnight-ntwrk/midnight-js-utils`      | Hex encoding, address validation, and utilities |
 
+## Ledger Era Vocabulary
+
+The network runs one of two ledger eras, `v8` or `v9`. The names for saying
+which era produced a payload or a record are re-exported from the barrel
+directly, alongside the namespaces above:
+
+```typescript
+import {
+  LEDGER_VERSIONS,         // the closed, frozen set: ['v8', 'v9']
+  type LedgerVersion,      // 'v8' | 'v9'
+  protocolVersionToLedger, // a raw protocolVersion integer -> LedgerVersion
+  versionOfRecord,         // a record carrying protocolVersion -> LedgerVersion
+  networkHeadVersion       // asks a source for the network head -> LedgerVersion
+} from '@midnight-ntwrk/midnight-js';
+```
+
+The three resolvers throw `UnknownProtocolVersionError` when a
+`protocolVersion` has no known era, so the error and its codes are published
+alongside them:
+
+```typescript
+import {
+  PROTOCOL_ERROR_CODES,
+  type ProtocolVersionUnknownReason,
+  UnknownProtocolVersionError,
+  utils,
+  versionOfRecord,
+  type VersionResolutionPath
+} from '@midnight-ntwrk/midnight-js';
+
+// Any record carrying a raw protocolVersion -- e.g. a transaction or block
+// already read from the indexer.
+const record = { protocolVersion: 1_000_000 };
+
+try {
+  const era = versionOfRecord(record);
+  console.log(`this record was written under ledger ${era}`);
+} catch (error) {
+  if (utils.hasErrorCode(error, PROTOCOL_ERROR_CODES.UNKNOWN_PROTOCOL_VERSION_READ)) {
+    // a record this build has no era for
+  }
+  if (error instanceof UnknownProtocolVersionError) {
+    const path: VersionResolutionPath = error.path;
+    const reason: ProtocolVersionUnknownReason = error.reason;
+    console.warn(`could not resolve an era on the ${path} path: ${reason}`);
+  }
+}
+```
+
+The pre-fork ledger runtime itself is **not** re-exported here, and importing
+the barrel does not load it.
+
 ## Sub-path Imports
 
 Each module is also available as a sub-path import for tree-shaking:
@@ -47,6 +99,9 @@ import { toHex, fromHex } from '@midnight-ntwrk/midnight-js/utils';
 ```typescript
 // Namespace imports (all modules)
 import { contracts, networkId, types, utils } from '@midnight-ntwrk/midnight-js';
+
+// Ledger era vocabulary (named, not namespaced)
+import { LEDGER_VERSIONS, type LedgerVersion } from '@midnight-ntwrk/midnight-js';
 
 // Sub-path imports (individual modules)
 import { ... } from '@midnight-ntwrk/midnight-js/contracts';

--- a/packages/midnight-js/README.md
+++ b/packages/midnight-js/README.md
@@ -39,49 +39,97 @@ directly, alongside the namespaces above:
 
 ```typescript
 import {
-  LEDGER_VERSIONS,         // the closed, frozen set: ['v8', 'v9']
-  type LedgerVersion,      // 'v8' | 'v9'
-  protocolVersionToLedger, // a raw protocolVersion integer -> LedgerVersion
-  versionOfRecord,         // a record carrying protocolVersion -> LedgerVersion
-  networkHeadVersion       // asks a source for the network head -> LedgerVersion
+  LEDGER_VERSIONS,    // the closed, frozen set: ['v8', 'v9']
+  type LedgerVersion, // 'v8' | 'v9'
+  versionOfRecord,    // a record carrying protocolVersion -> LedgerVersion
+  networkHeadVersion  // asks a source for the network head -> LedgerVersion
 } from '@midnight-ntwrk/midnight-js';
 ```
 
-The three resolvers throw `UnknownProtocolVersionError` when a
-`protocolVersion` has no known era, so the error and its codes are published
-alongside them:
+Use `versionOfRecord` for a `protocolVersion` read off an existing record, and
+`networkHeadVersion` for the era a transaction built now would land in. Each
+tags its failures with the path it was called on, so a handler can tell the two
+apart.
+
+Both refuse rather than guess. They raise `UnknownProtocolVersionError` when a
+`protocolVersion` is malformed (not a non-negative integer) or is well-formed
+but maps to no era this build knows. `versionOfRecord` throws;
+`networkHeadVersion` is `async`, so it rejects instead, and a rejection from
+the source itself propagates unchanged.
 
 ```typescript
 import {
-  PROTOCOL_ERROR_CODES,
   type ProtocolVersionUnknownReason,
   UnknownProtocolVersionError,
-  utils,
   versionOfRecord,
   type VersionResolutionPath
 } from '@midnight-ntwrk/midnight-js';
 
 // Any record carrying a raw protocolVersion -- e.g. a transaction or block
-// already read from the indexer.
-const record = { protocolVersion: 1_000_000 };
+// already read from the indexer. Node major 9 is one this build has no era
+// for, so this record takes the failure path.
+const record = { protocolVersion: 9_000_000 };
 
 try {
   const era = versionOfRecord(record);
   console.log(`this record was written under ledger ${era}`);
 } catch (error) {
-  if (utils.hasErrorCode(error, PROTOCOL_ERROR_CODES.UNKNOWN_PROTOCOL_VERSION_READ)) {
-    // a record this build has no era for
+  // Anything that is not ours is not ours to interpret. Never swallow it.
+  if (!(error instanceof UnknownProtocolVersionError)) {
+    throw error;
   }
-  if (error instanceof UnknownProtocolVersionError) {
-    const path: VersionResolutionPath = error.path;
-    const reason: ProtocolVersionUnknownReason = error.reason;
-    console.warn(`could not resolve an era on the ${path} path: ${reason}`);
-  }
+
+  const path: VersionResolutionPath = error.path;            // 'read' | 'construct'
+  const reason: ProtocolVersionUnknownReason = error.reason; // 'unknown' | 'malformed'
+
+  throw new Error(
+    reason === 'unknown'
+      ? `This record is from a ledger era this build does not know (${path} path). Upgrade midnight-js.`
+      : `The protocolVersion handed to versionOfRecord was malformed (${path} path). Check the source record.`,
+    { cause: error }
+  );
 }
 ```
 
-The pre-fork ledger runtime itself is **not** re-exported here, and importing
-the barrel does not load it.
+Both eras are worth handling explicitly, because the two reasons need different
+responses: `'unknown'` means this framework build predates the network, and
+`'malformed'` means the wrong field was wired into the resolver.
+
+If you would rather discriminate on a stable string than on a class, every
+error here also carries a `code`. `PROTOCOL_ERROR_CODES` names them and
+`utils.hasErrorCode` is the guard:
+
+```typescript
+import { PROTOCOL_ERROR_CODES, utils } from '@midnight-ntwrk/midnight-js';
+
+if (utils.hasErrorCode(error, PROTOCOL_ERROR_CODES.UNKNOWN_PROTOCOL_VERSION_READ)) {
+  // the era of an existing record could not be resolved
+}
+```
+
+### Errors from the retained era
+
+Deploying to or calling a `v8` contract runs through the retained pre-fork
+pipeline, which raises errors of its own. The barrel publishes those classes
+too, so you can catch them and read their payload without a cast:
+
+| Class | Payload | Means |
+| ----- | ------- | ----- |
+| `Ledger8RuntimeMissingError` | `subpath` | the retained runtime chunk could not be loaded at all |
+| `ComposeFailedError` | `version`, `stage`, `circuitId` | a circuit operation is missing or under-registered |
+| `ComposeOptionError` | `version`, `option` | one composition option cannot be used |
+| `StateDecodeFailedError` | `version` | a contract-state envelope could not be read as that era |
+| `UnknownLedgerVersionError` | `requestedVersion` | an era outside `LEDGER_VERSIONS` was requested |
+
+### What importing the barrel loads
+
+The retained pre-fork (`v8`) ledger runtime is **not** re-exported here, and it
+is absent from the barrel's static import graph. It is loaded on demand, only
+once you actually touch a `v8` contract.
+
+Importing the barrel is not otherwise free: it pulls the `v9` ledger and
+onchain-runtime, because `contracts` needs them. The sub-path imports below let
+you take one module without the rest.
 
 ## Sub-path Imports
 

--- a/packages/midnight-js/README.md
+++ b/packages/midnight-js/README.md
@@ -120,6 +120,7 @@ too, so you can catch them and read their payload without a cast:
 | `ComposeOptionError` | `version`, `option` | one composition option cannot be used |
 | `StateDecodeFailedError` | `version` | a contract-state envelope could not be read as that era |
 | `UnknownLedgerVersionError` | `requestedVersion` | an era outside `LEDGER_VERSIONS` was requested |
+| `PayloadNotATransactionError` | none | a `v8` payload sent for proving was not a transaction |
 
 ### What importing the barrel loads
 

--- a/packages/midnight-js/docs/barrel-published-surface.md
+++ b/packages/midnight-js/docs/barrel-published-surface.md
@@ -1,0 +1,124 @@
+---
+title: BarrelPublishedSurface
+---
+
+# What the barrel publishes, and what importing it costs
+
+`@midnight-ntwrk/midnight-js` is the front door: the package a dApp developer
+installs first and imports without thinking about layering. Two decisions
+follow from that and are recorded here rather than in the source, because both
+are arguments rather than instructions — which names qualify for the top level,
+and which protocol entry points the barrel is allowed to reach for.
+
+## The four namespaces, plus a named vocabulary
+
+The bulk of the surface is four namespaces — `contracts`, `networkId`, `types`,
+`utils` — each a whole package. Alongside them sits one group of *named*
+exports: the ledger era vocabulary.
+
+The reason it is named rather than namespaced is not import cost. Measured on
+the checkout that introduced it, the barrel took ~148.0 ms to import before the
+change, ~147.1 ms after it, and ~148.0 ms with a wholesale
+`export * as protocol` instead. Those numbers are indistinguishable, and they
+are indistinguishable for a reason worth writing down: protocol's root barrel
+is *already* on every barrel consumer's eager path, because
+`packages/contracts/src/internal/ledger8-entry.ts` statically imports
+`loadLedger8Engine` from it. Importing protocol's root after the barrel costs
+~0.11 ms — it is already fully loaded.
+
+So the shape was decided on two other grounds:
+
+- The cost equality is an accident of `contracts` reaching for the root.
+  `export * as protocol` would convert that accident into a load-bearing
+  constraint, blocking the very optimisation someone will eventually want.
+- A wholesale namespace would publish `loadLedger8`, `loadLedger8Engine`,
+  `ledger` and `onchainRuntime` from the barrel — the opposite of keeping the
+  retained-era runtime off the eager path.
+
+## Which names qualify
+
+A value is published here when a consumer needs it to say which era produced a
+payload or a record, or to handle the failure when that resolution has no
+answer.
+
+A **type** is published when it is named in the public shape of a value
+published here — a parameter of an exported function, its return type, or a
+public field of an exported error class. That rule is why
+`VersionResolutionPath` is present (the error's `path`) and why
+`RetainedEraSubpath`, `ComposeStage` and `ComposeOption` came in with the
+classes whose payloads name them.
+
+Two deliberate exclusions:
+
+- **`protocolVersionToLedger`.** Its own documentation says most call sites
+  should not call it directly, and its `path` parameter defaults to
+  `'construct'`. A consumer holding a record's `protocolVersion` naturally
+  writes `protocolVersionToLedger(record.protocolVersion)`, gets an error
+  tagged `construct`, and a handler written for the `read` code silently does
+  not fire. `versionOfRecord` and `networkHeadVersion` cover both paths and tag
+  each one automatically, so the raw resolver adds a footgun and no capability.
+- **`ProtocolErrorCode`.** Nothing on this surface names it:
+  `UnknownProtocolVersionError.code` is declared as the two-member literal
+  union, not the wide alias, so a `switch` over `PROTOCOL_ERROR_CODES` members
+  type-checks without it. A consumer who wants the union as a *declaration* can
+  reach `utils.MidnightJsErrorCode`, which is already published and is a strict
+  superset.
+
+## Error codes travel with their classes
+
+`PROTOCOL_ERROR_CODES` is published whole. That adds no information a consumer
+did not already have — `utils.MIDNIGHT_JS_ERROR_CODES` already aggregates every
+protocol code, and `utils` is one of the four namespaces — but it gives named
+members to discriminate on instead of hand-written strings.
+
+Publishing codes alone was not enough. `contracts` calls into the retained-era
+pipeline from public entry points without wrapping what it throws, so these
+protocol errors reach a barrel consumer directly:
+
+| Class | Raised from | Payload the consumer needs |
+|---|---|---|
+| `Ledger8RuntimeMissingError` | `lib/v8/load.ts`, `lib/v8/load-engine.ts`, via `contracts/src/internal/ledger8-entry.ts` | `subpath` — which chunk failed |
+| `ComposeFailedError` | `lib/shared/assemble-call.ts` and the era compose legs | `version`, `stage`, `circuitId` |
+| `ComposeOptionError` | `lib/shared/compose-options.ts` and the era adapt legs | `version`, `option` |
+| `StateDecodeFailedError` | `lib/shared/contract-state.ts` | `version` |
+| `UnknownLedgerVersionError` | `contracts/src/internal/era.ts`, `lib/era/load-era.ts` | `requestedVersion` |
+
+`hasErrorCode` narrows only to `Error & { code }`, so without the class a
+consumer could detect one of these and then not read the field that decides the
+remediation — `Ledger8InstanceMismatchError` builds its whole "run `yarn why`
+on these packages" advice out of `axis`. Reading it would have required a cast,
+which this repo does not accept. Publishing each class next to its code is what
+closes that.
+
+The remaining codes in the table have live throwers too, but deeper inside the
+v8 conversion pipeline; their classes stay behind until a consumer has a reason
+to branch on one. Note that the comment in `packages/utils/src/error-codes.ts`
+claiming `LEDGER8_INSTANCE_MISMATCH`, `DOWN_CONVERT_FAILED` and
+`MERKLE_NOT_REHASHED` have no thrower is stale — all three are thrown from
+`lib/v8/instance-guard.ts` and `lib/v8/down-convert.ts`.
+
+## Which protocol entry points the barrel may reach for
+
+The vocabulary comes off the `protocol/version` and `protocol/errors` leaf
+subpaths. `version` reaches exactly `errors` and the `ledger-version`
+declaration the two share, and neither pulls anything further at runtime.
+Protocol's root barrel by contrast eagerly pulls the v9 ledger,
+onchain-runtime, compact-js, compact-runtime and platform bindings.
+
+Stated plainly, because the distinction is easy to lose: **importing the barrel
+is not cheap today.** It loads on the order of a hundred modules and
+instantiates the v9 ledger and onchain-runtime WASM artifacts, because
+`contracts` pulls protocol's root. What the leaf subpaths buy is that the
+*barrel itself* does not add a second, direct pin of that cost — so shaking it
+out later stays possible instead of becoming a breaking change.
+
+The retained pre-fork (v8) runtime is a different matter, and the promise there
+is absolute: it is absent from the barrel's static closure entirely, reached
+only through the loaders that dynamically import it. There is no `protocol/v8`
+re-export in any form. The mechanism is decided in
+`docs/adr/0004-lazy-v8-era-access-via-protocol-subpath.md`; this document does
+not restate it.
+
+Both halves are held by `src/test/dist-laziness.test.ts`, which walks the built
+static closure. Without it, repointing the re-exports at protocol's root would
+look identical in review, typecheck clean, and leave every other test green.

--- a/packages/midnight-js/docs/barrel-published-surface.md
+++ b/packages/midnight-js/docs/barrel-published-surface.md
@@ -82,6 +82,7 @@ protocol errors reach a barrel consumer directly:
 | `ComposeOptionError` | `lib/shared/compose-options.ts` and the era adapt legs | `version`, `option` |
 | `StateDecodeFailedError` | `lib/shared/contract-state.ts` | `version` |
 | `UnknownLedgerVersionError` | `contracts/src/internal/era.ts`, `lib/era/load-era.ts` | `requestedVersion` |
+| `PayloadNotATransactionError` | `lib/prove`, as a `proveTx` rejection | none; caught, not constructed |
 
 `hasErrorCode` narrows only to `Error & { code }`, so without the class a
 consumer could detect one of these and then not read the field that decides the
@@ -89,6 +90,12 @@ remediation — `Ledger8InstanceMismatchError` builds its whole "run `yarn why`
 on these packages" advice out of `axis`. Reading it would have required a cast,
 which this repo does not accept. Publishing each class next to its code is what
 closes that.
+
+`PayloadNotATransactionError` is the one that does not come from the era
+pipeline: a proof provider raises it from `proveV8Transaction`, and it reaches
+application code as a `proveTx` rejection out of `contracts.deployContract` or
+`submitCallTx`. Its constructor is private and its only public member is
+`code`, so it is published purely so a consumer can `instanceof` it.
 
 The remaining codes in the table have live throwers too, but deeper inside the
 v8 conversion pipeline; their classes stay behind until a consumer has a reason

--- a/packages/midnight-js/src/index.ts
+++ b/packages/midnight-js/src/index.ts
@@ -17,3 +17,50 @@ export * as contracts from '@midnight-ntwrk/midnight-js-contracts';
 export * as networkId from '@midnight-ntwrk/midnight-js-network-id';
 export * as types from '@midnight-ntwrk/midnight-js-types';
 export * as utils from '@midnight-ntwrk/midnight-js-utils';
+
+// The era vocabulary: what a consumer needs to say which ledger produced a
+// payload or a record, to resolve one from a raw `protocolVersion`, and to
+// handle the failure when that resolution has no answer.
+//
+// Inclusion rule for the type-only names below: a type is published here when
+// it is named in the public shape of a value published here -- the parameters
+// of an exported function (optional ones included), its return type, or a
+// public field of the exported error class. That is why `VersionResolutionPath`
+// is present (second parameter of `protocolVersionToLedger`, and the error's
+// `path`) and `ProtocolErrorCode` is not: nothing on this surface names it, and
+// discriminating goes through the `PROTOCOL_ERROR_CODES` members, which carry
+// their own literal types.
+//
+// Named re-exports off the `protocol/version` subpath rather than a whole
+// `protocol` namespace. `version` reaches exactly two modules of its own,
+// `protocol/errors` and the `ledger-version` declaration the two share, and
+// neither pulls anything further at runtime. Protocol's root barrel by
+// contrast eagerly pulls the ledger, onchain-runtime, compact-js and platform
+// bindings -- a cost this package's own dependencies happen to pay today, but
+// one nothing on this surface needs, and one the barrel must not pin in
+// place.
+//
+// Deliberately no `protocol/v8` re-export in any form: the retained pre-fork
+// runtime stays off every consumer's eager path, reached only through the
+// loaders that dynamically import it.
+export {
+  LEDGER_VERSIONS,
+  type LedgerVersion,
+  networkHeadVersion,
+  type ProtocolVersionSource,
+  protocolVersionToLedger,
+  type VersionedRecord,
+  versionOfRecord
+} from '@midnight-ntwrk/midnight-js-protocol/version';
+
+// The three resolvers above all throw this one error, so it travels with them:
+// published together, a consumer can catch it, tell it apart with
+// `utils.hasErrorCode`, and narrow on `path`/`reason` without hardcoding a code
+// string. `protocol/errors` imports nothing at runtime, and `protocol/version`
+// already pulls it, so this adds no module to the graph.
+export {
+  PROTOCOL_ERROR_CODES,
+  type ProtocolVersionUnknownReason,
+  UnknownProtocolVersionError,
+  type VersionResolutionPath
+} from '@midnight-ntwrk/midnight-js-protocol/errors';

--- a/packages/midnight-js/src/index.ts
+++ b/packages/midnight-js/src/index.ts
@@ -19,48 +19,40 @@ export * as types from '@midnight-ntwrk/midnight-js-types';
 export * as utils from '@midnight-ntwrk/midnight-js-utils';
 
 // The era vocabulary: what a consumer needs to say which ledger produced a
-// payload or a record, to resolve one from a raw `protocolVersion`, and to
-// handle the failure when that resolution has no answer.
-//
-// Inclusion rule for the type-only names below: a type is published here when
-// it is named in the public shape of a value published here -- the parameters
-// of an exported function (optional ones included), its return type, or a
-// public field of the exported error class. That is why `VersionResolutionPath`
-// is present (second parameter of `protocolVersionToLedger`, and the error's
-// `path`) and `ProtocolErrorCode` is not: nothing on this surface names it, and
-// discriminating goes through the `PROTOCOL_ERROR_CODES` members, which carry
-// their own literal types.
-//
-// Named re-exports off the `protocol/version` subpath rather than a whole
-// `protocol` namespace. `version` reaches exactly two modules of its own,
-// `protocol/errors` and the `ledger-version` declaration the two share, and
-// neither pulls anything further at runtime. Protocol's root barrel by
-// contrast eagerly pulls the ledger, onchain-runtime, compact-js and platform
-// bindings -- a cost this package's own dependencies happen to pay today, but
-// one nothing on this surface needs, and one the barrel must not pin in
-// place.
-//
-// Deliberately no `protocol/v8` re-export in any form: the retained pre-fork
-// runtime stays off every consumer's eager path, reached only through the
-// loaders that dynamically import it.
+// payload or a record, and to handle the failure when that resolution has no
+// answer. Which names qualify, what importing the barrel does and does not
+// cost, and why these come off leaf subpaths rather than protocol's root
+// barrel are all recorded in BarrelPublishedSurface.
 export {
   LEDGER_VERSIONS,
   type LedgerVersion,
   networkHeadVersion,
   type ProtocolVersionSource,
-  protocolVersionToLedger,
   type VersionedRecord,
   versionOfRecord
 } from '@midnight-ntwrk/midnight-js-protocol/version';
 
-// The three resolvers above all throw this one error, so it travels with them:
-// published together, a consumer can catch it, tell it apart with
-// `utils.hasErrorCode`, and narrow on `path`/`reason` without hardcoding a code
-// string. `protocol/errors` imports nothing at runtime, and `protocol/version`
-// already pulls it, so this adds no module to the graph.
+// The resolvers above reject or throw with `UnknownProtocolVersionError`. The
+// remaining classes are the protocol errors that reach a barrel consumer
+// unwrapped through `contracts`; each travels with the code it carries and the
+// types its payload names, so one can catch by class and read the payload
+// without a cast. See BarrelPublishedSurface.
 export {
+  ComposeFailedError,
+  type ComposeOption,
+  ComposeOptionError,
+  type ComposeStage,
+  Ledger8RuntimeMissingError,
   PROTOCOL_ERROR_CODES,
   type ProtocolVersionUnknownReason,
+  type RetainedEraSubpath,
+  StateDecodeFailedError,
+  UnknownLedgerVersionError,
   UnknownProtocolVersionError,
   type VersionResolutionPath
 } from '@midnight-ntwrk/midnight-js-protocol/errors';
+
+// No `protocol/v8` re-export in any form, in either block above: the retained
+// pre-fork runtime is reachable only through the loaders that dynamically
+// import it -- see docs/adr/0004-lazy-v8-era-access-via-protocol-subpath.md.
+// `src/test/dist-laziness.test.ts` is what holds that in place.

--- a/packages/midnight-js/src/index.ts
+++ b/packages/midnight-js/src/index.ts
@@ -36,13 +36,16 @@ export {
 // remaining classes are the protocol errors that reach a barrel consumer
 // unwrapped through `contracts`; each travels with the code it carries and the
 // types its payload names, so one can catch by class and read the payload
-// without a cast. See BarrelPublishedSurface.
+// without a cast. `PayloadNotATransactionError` arrives as a `proveTx`
+// rejection rather than from the era pipeline, and has a private constructor:
+// it is published to be caught, not built. See BarrelPublishedSurface.
 export {
   ComposeFailedError,
   type ComposeOption,
   ComposeOptionError,
   type ComposeStage,
   Ledger8RuntimeMissingError,
+  PayloadNotATransactionError,
   PROTOCOL_ERROR_CODES,
   type ProtocolVersionUnknownReason,
   type RetainedEraSubpath,

--- a/packages/midnight-js/src/test/dist-laziness.test.ts
+++ b/packages/midnight-js/src/test/dist-laziness.test.ts
@@ -35,8 +35,8 @@
  * The retained pre-fork (v8) runtime is a separate matter: it stays off the
  * eager path entirely, and the second assertion holds that.
  *
- * Modelled on `packages/utils/src/test/dist-laziness.test.ts`, which guards
- * the same class of invariant for the retained-era proving seam.
+ * Modelled on `packages/protocol/src/test/dist-laziness.test.ts`, which guards
+ * the same class of invariant for the v8 and engine chunks.
  */
 
 import { existsSync, readFileSync } from 'node:fs';

--- a/packages/midnight-js/src/test/dist-laziness.test.ts
+++ b/packages/midnight-js/src/test/dist-laziness.test.ts
@@ -1,0 +1,135 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Guards which protocol entry points the barrel's own module reaches for.
+ *
+ * The era vocabulary comes off the `protocol/version` and `protocol/errors`
+ * leaf subpaths. Those two reach one another and a shared leaf declaration and
+ * nothing else at runtime, whereas protocol's ROOT barrel eagerly pulls the
+ * v9 ledger, onchain-runtime, compact-js, compact-runtime and platform
+ * bindings. Repointing the re-exports at the root would look identical in
+ * review, typecheck clean, and leave every test green -- which is what this
+ * suite is for.
+ *
+ * What this suite does NOT claim: that importing the barrel is cheap.
+ * `midnight-js-contracts`, which the barrel re-exports, statically imports
+ * protocol's root today, so the root and the v9 runtime are already on every
+ * barrel consumer's eager path. The gate below is narrower and still worth
+ * having -- it stops the barrel adding a second, direct pin of its own, and
+ * keeps the option of shaking that cost out later open rather than
+ * load-bearing. See BarrelPublishedSurface.
+ *
+ * The retained pre-fork (v8) runtime is a separate matter: it stays off the
+ * eager path entirely, and the second assertion holds that.
+ *
+ * Modelled on `packages/utils/src/test/dist-laziness.test.ts`, which guards
+ * the same class of invariant for the retained-era proving seam.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const PKG_ROOT = resolve(__dirname, '..', '..');
+const DIST_INDEX_PATH = 'dist/index.js';
+
+/** The protocol package ROOT. Its `version` and `errors` leaves are the sanctioned way in. */
+const PROTOCOL_BARREL = '@midnight-ntwrk/midnight-js-protocol';
+
+/** The subpaths carrying the retained pre-fork runtime. Off the eager path in any form. */
+const RETAINED_ERA_SUBPATHS = [`${PROTOCOL_BARREL}/v8`, `${PROTOCOL_BARREL}/engine`];
+
+// Never skipped when dist/ is absent: a skip is reported as a pass, so the gate
+// would silently stop guarding. Turbo's `test` task dependsOn `build`, so dist/
+// exists in CI and in `yarn test`. A bare `vitest run` without a prior build
+// fails instead, with a message saying how to fix it.
+const readDistFile = (path: string): string => {
+  const absolute = resolve(PKG_ROOT, path);
+  if (!existsSync(absolute)) {
+    throw new Error(
+      `${path} is missing: this suite inspects the rollup output. Run "yarn build" first, or run "yarn turbo test", which builds before testing.`
+    );
+  }
+  return readFileSync(absolute, 'utf8');
+};
+
+// Matches both `… from './x.js'` and the bare `import './x.js';` rollup emits
+// for a side-effect-only chunk.
+const relativeStaticImportsOf = (content: string): string[] =>
+  [...content.matchAll(/(?:from|^\s*import)\s*['"](\.[^'"]*)['"]/gm)].map(([, specifier]) => specifier);
+
+// Asserted over the whole static closure rather than dist/index.js alone: the
+// barrel emits one flat chunk today, but if rollup ever splits it, a static
+// link hidden in a shared chunk is exactly what would otherwise slip through.
+const eagerClosureOf = (entry: string): string[] => {
+  const seen = new Set<string>();
+  const pending = [entry];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (current === undefined || seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+    for (const specifier of relativeStaticImportsOf(readDistFile(current))) {
+      pending.push(join(dirname(current), specifier));
+    }
+  }
+
+  return [...seen];
+};
+
+const eagerContents = (entry: string): string => eagerClosureOf(entry).map((chunk) => readDistFile(chunk)).join('\n');
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+describe('dist laziness gate', () => {
+  it('reaches protocol only through its leaf subpaths, never the root barrel', () => {
+    const content = eagerContents(DIST_INDEX_PATH);
+
+    // Anchored on the closing quote so the LEAF subpaths this package does
+    // import -- `/version` and `/errors` -- do not match. Only the bare root,
+    // the expensive one, is caught.
+    expect(content).not.toMatch(
+      new RegExp(`(?:from|^\\s*import)\\s*['"]${escapeRegExp(PROTOCOL_BARREL)}['"]`, 'm')
+    );
+  });
+
+  it('does not name the retained pre-fork runtime subpaths in any form', () => {
+    const content = eagerContents(DIST_INDEX_PATH);
+
+    // Deliberately a plain substring check rather than an import-shaped one:
+    // a dynamic `import()` of these from the barrel would be just as wrong as
+    // a static one, because the barrel has no era-dispatch job to do.
+    for (const subpath of RETAINED_ERA_SUBPATHS) {
+      expect(content).not.toContain(subpath);
+    }
+  });
+
+  it('still exports the era vocabulary from the built package', async () => {
+    // The static walk says the root barrel CAN stay unreferenced. This says
+    // the names that needed it are genuinely still there, so the assertions
+    // above are statements about shipped code rather than about a bundle that
+    // quietly lost the vocabulary.
+    const barrel = await import('@midnight-ntwrk/midnight-js');
+
+    expect(typeof barrel.versionOfRecord).toBe('function');
+    expect(typeof barrel.networkHeadVersion).toBe('function');
+    expect(barrel.LEDGER_VERSIONS).toEqual(['v8', 'v9']);
+    expect(typeof barrel.UnknownProtocolVersionError).toBe('function');
+  });
+});

--- a/packages/midnight-js/src/test/index.test.ts
+++ b/packages/midnight-js/src/test/index.test.ts
@@ -16,10 +16,51 @@
 import { describe, expect, it } from 'vitest';
 
 import * as contracts from '../contracts';
+import type {
+  LedgerVersion,
+  ProtocolVersionSource,
+  ProtocolVersionUnknownReason,
+  VersionedRecord,
+  VersionResolutionPath
+} from '../index';
 import * as midnightJs from '../index';
 import * as networkId from '../network-id';
 import * as types from '../types';
 import * as utils from '../utils';
+
+// The barrel's published surface, asserted by strict equality below: a name
+// added here without a matching export -- or exported without being listed --
+// fails the test. That equality is what keeps a provider package, or any other
+// unintended re-export, off the barrel.
+//
+// Runtime names only. The five type-only exports (`LedgerVersion`,
+// `ProtocolVersionSource`, `VersionedRecord`, `VersionResolutionPath`,
+// `ProtocolVersionUnknownReason`) never appear in `Object.keys`; each is
+// instead load-bearing in a type annotation below, so `typecheck:tests:core`
+// fails if the barrel drops one.
+const EXPECTED_BARREL_EXPORTS = [
+  'LEDGER_VERSIONS',
+  'PROTOCOL_ERROR_CODES',
+  'UnknownProtocolVersionError',
+  'contracts',
+  'networkHeadVersion',
+  'networkId',
+  'protocolVersionToLedger',
+  'types',
+  'utils',
+  'versionOfRecord'
+];
+
+// Returns what `run` threw. Throws itself when `run` returns instead, so a
+// test that stops throwing fails loudly rather than asserting on `undefined`.
+const captureThrown = (run: () => unknown): unknown => {
+  try {
+    run();
+  } catch (error) {
+    return error;
+  }
+  throw new Error('expected the call to throw, but it returned normally');
+};
 
 describe('barrel exports', () => {
   it('should export contracts namespace', () => {
@@ -43,10 +84,70 @@ describe('barrel exports', () => {
     expect(typeof midnightJs.utils).toBe('object');
   });
 
-  it('should not export provider packages', () => {
-    const exportedKeys = Object.keys(midnightJs);
-    expect(exportedKeys).toEqual(expect.arrayContaining(['contracts', 'networkId', 'types', 'utils']));
-    expect(exportedKeys).toHaveLength(4);
+  it('should export exactly the published surface, and nothing else', () => {
+    expect(Object.keys(midnightJs).sort()).toEqual([...EXPECTED_BARREL_EXPORTS].sort());
+  });
+});
+
+describe('ledger version vocabulary', () => {
+  it('should export the closed set of ledger versions', () => {
+    const eras: readonly LedgerVersion[] = midnightJs.LEDGER_VERSIONS;
+    expect(eras).toEqual(['v8', 'v9']);
+  });
+
+  it('should map a raw protocolVersion onto its ledger era', () => {
+    expect(midnightJs.protocolVersionToLedger(1_000_000)).toBe('v8');
+    expect(midnightJs.protocolVersionToLedger(2_000_000)).toBe('v9');
+  });
+
+  it('should resolve the era a record was written under', () => {
+    const record: VersionedRecord = { protocolVersion: 1_000_000 };
+    expect(midnightJs.versionOfRecord(record)).toBe('v8');
+  });
+
+  it('should resolve the era at the network head', async () => {
+    const source: ProtocolVersionSource = { queryLatestProtocolVersion: () => Promise.resolve(2_000_000) };
+    await expect(midnightJs.networkHeadVersion(source)).resolves.toBe('v9');
+  });
+});
+
+describe('ledger version failures', () => {
+  it('should let a caller tell the read path from the construct path by code', () => {
+    const fromRead = captureThrown(() => midnightJs.versionOfRecord({ protocolVersion: 9_000_000 }));
+    const fromConstruct = captureThrown(() => midnightJs.protocolVersionToLedger(9_000_000));
+
+    expect(
+      midnightJs.utils.hasErrorCode(fromRead, midnightJs.PROTOCOL_ERROR_CODES.UNKNOWN_PROTOCOL_VERSION_READ)
+    ).toBe(true);
+    expect(
+      midnightJs.utils.hasErrorCode(fromConstruct, midnightJs.PROTOCOL_ERROR_CODES.UNKNOWN_PROTOCOL_VERSION_CONSTRUCT)
+    ).toBe(true);
+    // Both negatives are load-bearing, not decoration. `hasErrorCode(e, code)`
+    // falls back to "carries any registered code" when `code` is `undefined`,
+    // so a positive assertion alone would still pass if the member it names
+    // vanished. Each member therefore appears once expected true and once
+    // expected false, which no `undefined` can satisfy at the same time.
+    expect(
+      midnightJs.utils.hasErrorCode(fromRead, midnightJs.PROTOCOL_ERROR_CODES.UNKNOWN_PROTOCOL_VERSION_CONSTRUCT)
+    ).toBe(false);
+    expect(
+      midnightJs.utils.hasErrorCode(fromConstruct, midnightJs.PROTOCOL_ERROR_CODES.UNKNOWN_PROTOCOL_VERSION_READ)
+    ).toBe(false);
+  });
+
+  it('should throw the error class the barrel publishes, carrying the path and reason', () => {
+    const thrown = captureThrown(() => midnightJs.protocolVersionToLedger(1.5));
+    expect(thrown).toBeInstanceOf(midnightJs.UnknownProtocolVersionError);
+    // Narrows without a cast, and only succeeds if the class the barrel
+    // publishes is the same module instance the thrown error was built from.
+    if (!(thrown instanceof midnightJs.UnknownProtocolVersionError)) {
+      throw new Error(`expected an UnknownProtocolVersionError, got ${String(thrown)}`);
+    }
+
+    const path: VersionResolutionPath = thrown.path;
+    const reason: ProtocolVersionUnknownReason = thrown.reason;
+    expect(path).toBe('construct');
+    expect(reason).toBe('malformed');
   });
 });
 

--- a/packages/midnight-js/src/test/index.test.ts
+++ b/packages/midnight-js/src/test/index.test.ts
@@ -17,9 +17,12 @@ import { describe, expect, it } from 'vitest';
 
 import * as contracts from '../contracts';
 import type {
+  ComposeOption,
+  ComposeStage,
   LedgerVersion,
   ProtocolVersionSource,
   ProtocolVersionUnknownReason,
+  RetainedEraSubpath,
   VersionedRecord,
   VersionResolutionPath
 } from '../index';
@@ -33,19 +36,23 @@ import * as utils from '../utils';
 // fails the test. That equality is what keeps a provider package, or any other
 // unintended re-export, off the barrel.
 //
-// Runtime names only. The five type-only exports (`LedgerVersion`,
-// `ProtocolVersionSource`, `VersionedRecord`, `VersionResolutionPath`,
-// `ProtocolVersionUnknownReason`) never appear in `Object.keys`; each is
-// instead load-bearing in a type annotation below, so `typecheck:tests:core`
-// fails if the barrel drops one.
+// Runtime names only -- a type-only export never appears in `Object.keys`, so
+// this list cannot gate one. The eight type-only exports are gated instead by
+// the `import type` above: dropping any of them from the barrel makes that
+// statement unresolvable, and `typecheck:tests:core` fails. The annotations
+// further down assert assignability on top of that.
 const EXPECTED_BARREL_EXPORTS = [
+  'ComposeFailedError',
+  'ComposeOptionError',
   'LEDGER_VERSIONS',
+  'Ledger8RuntimeMissingError',
   'PROTOCOL_ERROR_CODES',
+  'StateDecodeFailedError',
+  'UnknownLedgerVersionError',
   'UnknownProtocolVersionError',
   'contracts',
   'networkHeadVersion',
   'networkId',
-  'protocolVersionToLedger',
   'types',
   'utils',
   'versionOfRecord'
@@ -61,6 +68,21 @@ const captureThrown = (run: () => unknown): unknown => {
   }
   throw new Error('expected the call to throw, but it returned normally');
 };
+
+// The async sibling of `captureThrown`. `networkHeadVersion` is the barrel's
+// only construct-path resolver, and it rejects rather than throws.
+const captureRejected = async (run: () => Promise<unknown>): Promise<unknown> => {
+  try {
+    await run();
+  } catch (error) {
+    return error;
+  }
+  throw new Error('expected the call to reject, but it resolved normally');
+};
+
+const headSource = (protocolVersion: number): ProtocolVersionSource => ({
+  queryLatestProtocolVersion: () => Promise.resolve(protocolVersion)
+});
 
 describe('barrel exports', () => {
   it('should export contracts namespace', () => {
@@ -95,26 +117,20 @@ describe('ledger version vocabulary', () => {
     expect(eras).toEqual(['v8', 'v9']);
   });
 
-  it('should map a raw protocolVersion onto its ledger era', () => {
-    expect(midnightJs.protocolVersionToLedger(1_000_000)).toBe('v8');
-    expect(midnightJs.protocolVersionToLedger(2_000_000)).toBe('v9');
-  });
-
   it('should resolve the era a record was written under', () => {
     const record: VersionedRecord = { protocolVersion: 1_000_000 };
     expect(midnightJs.versionOfRecord(record)).toBe('v8');
   });
 
   it('should resolve the era at the network head', async () => {
-    const source: ProtocolVersionSource = { queryLatestProtocolVersion: () => Promise.resolve(2_000_000) };
-    await expect(midnightJs.networkHeadVersion(source)).resolves.toBe('v9');
+    await expect(midnightJs.networkHeadVersion(headSource(2_000_000))).resolves.toBe('v9');
   });
 });
 
 describe('ledger version failures', () => {
-  it('should let a caller tell the read path from the construct path by code', () => {
+  it('should let a caller tell the read path from the construct path by code', async () => {
     const fromRead = captureThrown(() => midnightJs.versionOfRecord({ protocolVersion: 9_000_000 }));
-    const fromConstruct = captureThrown(() => midnightJs.protocolVersionToLedger(9_000_000));
+    const fromConstruct = await captureRejected(() => midnightJs.networkHeadVersion(headSource(9_000_000)));
 
     expect(
       midnightJs.utils.hasErrorCode(fromRead, midnightJs.PROTOCOL_ERROR_CODES.UNKNOWN_PROTOCOL_VERSION_READ)
@@ -122,11 +138,12 @@ describe('ledger version failures', () => {
     expect(
       midnightJs.utils.hasErrorCode(fromConstruct, midnightJs.PROTOCOL_ERROR_CODES.UNKNOWN_PROTOCOL_VERSION_CONSTRUCT)
     ).toBe(true);
-    // Both negatives are load-bearing, not decoration. `hasErrorCode(e, code)`
-    // falls back to "carries any registered code" when `code` is `undefined`,
-    // so a positive assertion alone would still pass if the member it names
-    // vanished. Each member therefore appears once expected true and once
-    // expected false, which no `undefined` can satisfy at the same time.
+    // Both negatives are load-bearing, not decoration. A renamed member is a
+    // compile error, but two members that accidentally share one string are
+    // not, and `hasErrorCode(e, code)` falls back to "carries any registered
+    // code" when `code` is `undefined`. Each member therefore appears once
+    // expected true and once expected false, which neither a shared literal
+    // nor an `undefined` can satisfy at the same time.
     expect(
       midnightJs.utils.hasErrorCode(fromRead, midnightJs.PROTOCOL_ERROR_CODES.UNKNOWN_PROTOCOL_VERSION_CONSTRUCT)
     ).toBe(false);
@@ -135,8 +152,8 @@ describe('ledger version failures', () => {
     ).toBe(false);
   });
 
-  it('should throw the error class the barrel publishes, carrying the path and reason', () => {
-    const thrown = captureThrown(() => midnightJs.protocolVersionToLedger(1.5));
+  it('should reject with the error class the barrel publishes, carrying the path and reason', async () => {
+    const thrown = await captureRejected(() => midnightJs.networkHeadVersion(headSource(1.5)));
     expect(thrown).toBeInstanceOf(midnightJs.UnknownProtocolVersionError);
     // Narrows without a cast, and only succeeds if the class the barrel
     // publishes is the same module instance the thrown error was built from.
@@ -148,6 +165,66 @@ describe('ledger version failures', () => {
     const reason: ProtocolVersionUnknownReason = thrown.reason;
     expect(path).toBe('construct');
     expect(reason).toBe('malformed');
+  });
+
+  it('should propagate a head-source rejection unchanged', async () => {
+    const cause = new Error('indexer unreachable');
+    const thrown = await captureRejected(() =>
+      midnightJs.networkHeadVersion({ queryLatestProtocolVersion: () => Promise.reject(cause) })
+    );
+
+    expect(thrown).toBe(cause);
+    expect(thrown).not.toBeInstanceOf(midnightJs.UnknownProtocolVersionError);
+  });
+});
+
+describe('retained-era error classes', () => {
+  // These codes were already reachable through `utils.MIDNIGHT_JS_ERROR_CODES`
+  // before the classes were published; what a barrel consumer could not do was
+  // `instanceof` the class or read its payload without a cast. Both halves are
+  // asserted here, so publishing a code whose class stays behind -- or a class
+  // whose payload type stays behind -- fails.
+  it('should pair each published error class with its published code', () => {
+    expect(
+      midnightJs.utils.hasErrorCode(
+        new midnightJs.Ledger8RuntimeMissingError('/engine', new Error('resolution failed')),
+        midnightJs.PROTOCOL_ERROR_CODES.LEDGER8_RUNTIME_MISSING
+      )
+    ).toBe(true);
+    expect(
+      midnightJs.utils.hasErrorCode(
+        new midnightJs.ComposeFailedError('v9', 'call-empty', 'increment'),
+        midnightJs.PROTOCOL_ERROR_CODES.COMPOSE_FAILED
+      )
+    ).toBe(true);
+    expect(
+      midnightJs.utils.hasErrorCode(
+        new midnightJs.ComposeOptionError('v8', 'ttl'),
+        midnightJs.PROTOCOL_ERROR_CODES.COMPOSE_OPTION_INVALID
+      )
+    ).toBe(true);
+    expect(
+      midnightJs.utils.hasErrorCode(
+        new midnightJs.StateDecodeFailedError('v8', new Error('truncated')),
+        midnightJs.PROTOCOL_ERROR_CODES.STATE_DECODE_FAILED
+      )
+    ).toBe(true);
+    expect(
+      midnightJs.utils.hasErrorCode(
+        new midnightJs.UnknownLedgerVersionError('v7'),
+        midnightJs.PROTOCOL_ERROR_CODES.UNKNOWN_LEDGER_VERSION
+      )
+    ).toBe(true);
+  });
+
+  it('should let a caller read each error payload without a cast', () => {
+    const subpath: RetainedEraSubpath = new midnightJs.Ledger8RuntimeMissingError('/v8', new Error('boom')).subpath;
+    const stage: ComposeStage = new midnightJs.ComposeFailedError('v9', 'call-empty', 'increment').stage;
+    const option: ComposeOption = new midnightJs.ComposeOptionError('v8', 'ttl').option;
+    const decodedEra: LedgerVersion = new midnightJs.StateDecodeFailedError('v8', new Error('boom')).version;
+    const requested: string = new midnightJs.UnknownLedgerVersionError('v7').requestedVersion;
+
+    expect([subpath, stage, option, decodedEra, requested]).toEqual(['/v8', 'call-empty', 'ttl', 'v8', 'v7']);
   });
 });
 

--- a/packages/midnight-js/src/test/index.test.ts
+++ b/packages/midnight-js/src/test/index.test.ts
@@ -47,6 +47,7 @@ const EXPECTED_BARREL_EXPORTS = [
   'LEDGER_VERSIONS',
   'Ledger8RuntimeMissingError',
   'PROTOCOL_ERROR_CODES',
+  'PayloadNotATransactionError',
   'StateDecodeFailedError',
   'UnknownLedgerVersionError',
   'UnknownProtocolVersionError',
@@ -213,6 +214,14 @@ describe('retained-era error classes', () => {
       midnightJs.utils.hasErrorCode(
         new midnightJs.UnknownLedgerVersionError('v7'),
         midnightJs.PROTOCOL_ERROR_CODES.UNKNOWN_LEDGER_VERSION
+      )
+    ).toBe(true);
+    // Built through a static factory, not `new`: the constructor is private,
+    // because this one is published to be caught rather than constructed.
+    expect(
+      midnightJs.utils.hasErrorCode(
+        midnightJs.PayloadNotATransactionError.notBytes('not bytes'),
+        midnightJs.PROTOCOL_ERROR_CODES.PAYLOAD_NOT_A_TRANSACTION
       )
     ).toBe(true);
   });

--- a/packages/midnight-js/typedoc.json
+++ b/packages/midnight-js/typedoc.json
@@ -3,6 +3,7 @@
     "../../typedoc.base.json"
   ],
   "projectDocuments": [
+    "docs/*.md",
     "../contracts/docs/*.md"
   ]
 }


### PR DESCRIPTION
## Summary

Puts the ledger-era vocabulary on the barrel package, so a dApp developer can narrow on which era produced a payload or a record without reaching past `@midnight-ntwrk/midnight-js`, and replaces a weak export-surface test with strict sorted-key equality.

Published: `LEDGER_VERSIONS`, `versionOfRecord`, `networkHeadVersion`, plus the types those name in their public shapes; `UnknownProtocolVersionError` and `PROTOCOL_ERROR_CODES` so a consumer can catch and discriminate without hardcoding a code string; and the six protocol error classes that reach a barrel consumer unwrapped through `contracts` -- `Ledger8RuntimeMissingError`, `ComposeFailedError`, `ComposeOptionError`, `StateDecodeFailedError`, `UnknownLedgerVersionError` and `PayloadNotATransactionError` -- each with the types its payload names. The last of those came in when the parent moved it into `protocol/errors`: its code landed in `PROTOCOL_ERROR_CODES`, which this barrel publishes whole, so publishing the code without the class would have been the exact asymmetry this PR argues against.

Why each name qualifies, what importing the barrel does and does not cost, and why these come off leaf subpaths rather than protocol's root barrel are recorded in `packages/midnight-js/docs/barrel-published-surface.md` rather than in source comments.

### Scope: barrel only

Task 4.6 also describes two CI packaging gates -- an isolated-linker install smoke over packed tarballs, and a Vite laziness fixture. Those are a **separate PR** by owner decision: neither pnpm nor Vite nor any npm-pack smoke exists anywhere in this repo, so they are greenfield infrastructure with their own review surface and failure modes, and bundling them with a small barrel change makes both harder to review.

The unit-level laziness gate is **not** one of those two, and it is included here: `packages/midnight-js/src/test/dist-laziness.test.ts` is a plain vitest suite modelled on the existing `packages/utils` one, needing no new infrastructure.

`assertNever`, which the task also lists, does not exist anywhere in the repo and is deliberately **not** created here. An exported helper with no caller is dead code; its first real caller is the narrowing recipe a later task writes. The same reasoning is why no `isLedgerVersion` guard is added.

### Two deliberate exclusions

`protocolVersionToLedger` is **not** published. Its own documentation says most call sites should not call it directly, and its `path` parameter defaults to `'construct'` -- so a consumer holding a record's `protocolVersion` writes `protocolVersionToLedger(record.protocolVersion)`, gets a `construct`-tagged error, and a handler written for the `read` code silently does not fire. `versionOfRecord` and `networkHeadVersion` cover both paths and tag each automatically. It remains available from `@midnight-ntwrk/midnight-js-protocol/version`.

`ProtocolErrorCode` is **not** published: nothing on this surface names it. `UnknownProtocolVersionError.code` is declared as the two-member literal union, so a `switch` over `PROTOCOL_ERROR_CODES` members type-checks without it, and `utils.MidnightJsErrorCode` is already on the barrel as a strict superset for anyone who wants the union as a declaration.

### Why named re-exports and not `export * as protocol`

The intended tie-breaker was import cost, and it could not decide: baseline barrel 148.0 ms, this change 147.1 ms, a wholesale namespace 148.0 ms. The reason is the finding -- **protocol's root is already on every barrel consumer's eager path today**, because `packages/contracts/src/internal/ledger8-entry.ts:36` statically imports `loadLedger8Engine` from it. Importing protocol's root after the barrel costs 0.11 ms; it is already fully loaded.

So the shape was decided on two other grounds. The cost equality is an accident of `contracts` reaching for the root, and `export * as protocol` would convert that accident into a load-bearing constraint blocking the very optimisation someone will want. And a wholesale namespace would publish `loadLedger8`, `loadLedger8Engine`, `ledger` and `onchainRuntime` from the barrel, which is the opposite of keeping the retained-era runtime off the eager path.

Note for the packaging-gates PR: **the Vite laziness fixture may go red on that pre-existing eager root load rather than on anything the barrel does.** Worth knowing before debugging it.

### Verified, not assumed

- `ledger-v8` is absent from the barrel's static closure; the only edges to protocol's `v8.js` and `engine.js` are dynamic `import()`. Loading ledger-v8 on demand costs 13.6 ms, i.e. it was never resolved. `dist-laziness.test.ts` now holds this rather than leaving it to a comment.
- The laziness gate was proven to fail on the regression it exists for: repointing both re-exports at protocol's root and rebuilding turns it red. Before it existed, that same regression left every test and lint check green.
- Each of the three new type-only exports (`RetainedEraSubpath`, `ComposeStage`, `ComposeOption`) was deleted in turn and confirmed to fail `typecheck:tests:core` with `TS2305`.
- Cross-package class identity holds: an error thrown **inside** protocol is `instanceof` the barrel's `UnknownProtocolVersionError`, so catching by class from the barrel works for errors raised deep in protocol.
- Publishing `PROTOCOL_ERROR_CODES` whole is ergonomics rather than new capability: `utils.MIDNIGHT_JS_ERROR_CODES` already aggregates every protocol code and `utils` is one of the four namespaces, so the strings were reachable already. What was missing, and is fixed here, is the class to `instanceof` and the typed payload to read -- `hasErrorCode` narrows only to `Error & { code }`, so reading `subpath` or `stage` previously required a cast.

### Honest about cost

The docs no longer imply that importing the barrel is cheap. It pulls the v9 ledger and onchain-runtime today, because `contracts` needs them. The promise that holds absolutely is narrower and now stated as such: the retained pre-fork runtime is absent from the barrel's static closure and is loaded only on demand.

### Known follow-up, not addressed here

`LEDGER_VERSIONS` is published with the tuple type `readonly ["v8", "v9"]`, which pins order and length for consumers and makes `LEDGER_VERSIONS.includes(someString)` fail to compile. The fix is `readonly LedgerVersion[]` at the declaration in `packages/protocol`, so it is out of scope for a barrel change.

## Test plan

- [x] Tests written first (TDD), verified they fail before the implementation
- [x] All existing tests pass (no regressions)
- [x] Lint clean, build succeeds

midnight-js 20/20; full `turbo test` across packages 28/28 after merging the parent; lint, constraints, typecheck and build all clean. The export-surface assertion was proven to fail in both directions -- a leaked export and a removed one. The code-discrimination assertions carry mirror negatives, because `hasErrorCode(e, undefined)` silently degrades to "carries any registered code": before that hardening, substituting a code member with `undefined` left the suite fully green.

