### PR TITLE
ci: grant nightly-e2e the actions:read its build workflow requires

### DIFF
--- a/.github/scripts/check-workflow-permissions.mjs
+++ b/.github/scripts/check-workflow-permissions.mjs
@@ -20,20 +20,30 @@
 // omitted `actions: read`.
 //
 // This gate reads the same relationship statically and names the missing scope.
+// It is run by `.github/workflows/workflow-permissions.yml`, which deliberately
+// calls no reusable workflow of its own -- see the comment there.
 
 import { readFileSync } from 'node:fs';
 import { readdir } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 
 import { parse } from 'yaml';
 
-const WORKFLOW_DIRECTORY = '.github/workflows';
+/** Resolved from this file, not from `process.cwd()`, so the gate runs from anywhere. */
+export const WORKFLOW_DIRECTORY = fileURLToPath(new URL('../workflows', import.meta.url));
 
 /** Permission levels, ordered. A caller must hold at least the level its callee asks for. */
 const LEVELS = { none: 0, read: 1, write: 2 };
 
-/** Every scope GitHub can grant, needed to expand the `read-all` / `write-all` shorthands. */
+/**
+ * Every scope GitHub can grant, needed to expand the `read-all` / `write-all`
+ * shorthands. Scopes outside this list still compare correctly against each
+ * other; the list only bounds what the two shorthands are taken to cover, so a
+ * scope GitHub adds later would be over-reported against a `read-all` caller
+ * rather than silently skipped.
+ */
 const ALL_SCOPES = [
   'actions',
   'attestations',
@@ -59,7 +69,7 @@ const ALL_SCOPES = [
  * empty one: absent means "inherit whatever the repository default is", which
  * cannot be resolved statically, while `{}` means "grant nothing".
  */
-const normalisePermissions = (value) => {
+export const normalisePermissions = (value) => {
   if (value === undefined || value === null) {
     return undefined;
   }
@@ -72,34 +82,76 @@ const normalisePermissions = (value) => {
   if (typeof value !== 'object') {
     throw new Error(`Unrecognised permissions value: ${JSON.stringify(value)}`);
   }
+  for (const [scope, level] of Object.entries(value)) {
+    if (LEVELS[level] === undefined) {
+      throw new Error(`Unrecognised permission level for '${scope}': ${JSON.stringify(level)}`);
+    }
+  }
   return value;
 };
 
 const levelOf = (permissions, scope) => LEVELS[permissions?.[scope] ?? 'none'] ?? 0;
 
-const workflowFiles = async () => {
-  const entries = await readdir(WORKFLOW_DIRECTORY);
-  return entries.filter((entry) => entry.endsWith('.yml') || entry.endsWith('.yaml')).sort();
+/**
+ * Everything a called workflow asks the run's token to carry.
+ *
+ * The workflow-level block is not the whole answer. A job inside the callee may
+ * declare its own, and that block is a request in exactly the same way -- so a
+ * callee whose top level looks modest can still over-ask one job down and abort
+ * the run just as thoroughly. The requirement is therefore the per-scope maximum
+ * across the workflow-level block and every job-level block.
+ *
+ * Taking the maximum also makes the check sound across a chain: when A calls B
+ * and B calls C, C's demands surface in B's requirement, so the A-to-B pair
+ * catches a shortfall that only C would have exposed at run time.
+ */
+export const requiredPermissions = (workflow) => {
+  const blocks = [
+    normalisePermissions(workflow?.permissions),
+    ...Object.values(workflow?.jobs ?? {}).map((job) => normalisePermissions(job?.permissions))
+  ].filter((block) => block !== undefined);
+
+  if (blocks.length === 0) {
+    return undefined;
+  }
+
+  const required = {};
+  for (const block of blocks) {
+    for (const [scope, level] of Object.entries(block)) {
+      if (levelOf(required, scope) < LEVELS[level]) {
+        required[scope] = level;
+      }
+    }
+  }
+  return required;
 };
 
-const main = async () => {
-  const files = await workflowFiles();
-  const parsed = new Map(
-    files.map((file) => [file, parse(readFileSync(path.join(WORKFLOW_DIRECTORY, file), 'utf8'))])
-  );
-
+/**
+ * @param {Map<string, unknown>} workflows parsed workflow documents, keyed by file name
+ * @returns {{violations: string[], externalCalls: string[]}}
+ */
+export const findViolations = (workflows) => {
   const violations = [];
+  const externalCalls = [];
 
-  for (const [file, workflow] of parsed) {
+  for (const [file, workflow] of workflows) {
     const workflowPermissions = normalisePermissions(workflow?.permissions);
 
     for (const [jobName, job] of Object.entries(workflow?.jobs ?? {})) {
       const uses = job?.uses;
-      if (typeof uses !== 'string' || !uses.startsWith('./.github/workflows/')) {
+      if (typeof uses !== 'string') {
         continue;
       }
+      if (!uses.startsWith('./.github/workflows/')) {
+        // A reusable workflow in another repository. Its `permissions:` block is
+        // not readable from here, so it is reported as unchecked rather than
+        // folded into a pass.
+        externalCalls.push(`${file} job '${jobName}' -> ${uses}`);
+        continue;
+      }
+
       const calleeFile = path.basename(uses);
-      const callee = parsed.get(calleeFile);
+      const callee = workflows.get(calleeFile);
       if (callee === undefined) {
         violations.push(`${file} job '${jobName}' calls ${uses}, which does not exist`);
         continue;
@@ -108,7 +160,7 @@ const main = async () => {
       // A job-level block replaces the workflow-level one outright rather than
       // adding to it, so it is the whole grant when present.
       const granted = normalisePermissions(job.permissions) ?? workflowPermissions;
-      const required = normalisePermissions(callee.permissions);
+      const required = requiredPermissions(callee);
       if (required === undefined) {
         continue;
       }
@@ -131,15 +183,51 @@ const main = async () => {
     }
   }
 
+  return { violations, externalCalls };
+};
+
+/** Parses every workflow in `.github/workflows`, keyed by file name. */
+export const readWorkflows = async () => {
+  const entries = await readdir(WORKFLOW_DIRECTORY);
+  const files = entries.filter((entry) => entry.endsWith('.yml') || entry.endsWith('.yaml')).sort();
+  return new Map(files.map((file) => [file, parse(readFileSync(path.join(WORKFLOW_DIRECTORY, file), 'utf8'))]));
+};
+
+const main = async () => {
+  const workflows = await readWorkflows();
+  const { violations, externalCalls } = findViolations(workflows);
+
   if (violations.length > 0) {
     for (const violation of violations) {
       console.error(`::error::${violation}`);
     }
     console.error(`\n${violations.length} reusable-workflow permission violation(s) found.`);
-    process.exit(1);
+    return 1;
   }
 
-  console.log(`Checked ${files.length} workflow files; every reusable-workflow call is granted what it requires.`);
+  console.log(
+    `Checked ${workflows.size} workflow files; every local reusable-workflow call is granted what it requires.`
+  );
+  if (externalCalls.length > 0) {
+    console.log(
+      `\n${externalCalls.length} call(s) to reusable workflows in other repositories were NOT checked ` +
+        `-- their permissions are not readable from here:`
+    );
+    for (const call of externalCalls) {
+      console.log(`  ${call}`);
+    }
+  }
+  return 0;
 };
 
-await main();
+const runDirectly =
+  process.argv[1] !== undefined && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (runDirectly) {
+  try {
+    process.exitCode = await main();
+  } catch (error) {
+    console.error(`::error::check-workflow-permissions could not complete: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/.github/scripts/check-workflow-permissions.mjs
+++ b/.github/scripts/check-workflow-permissions.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+// This file is part of midnight-js.
+// Copyright (C) 2025-2026 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// A reusable workflow cannot be granted more than its caller holds. When it asks
+// for more, GitHub does not fail the job -- it refuses to start the run at all,
+// which surfaces as `startup_failure` with zero jobs and no annotation to read.
+// That is invisible on a schedule: `nightly-e2e.yml` sat in exactly this state
+// for weeks because it was the only caller of `ci-testkit-js-build.yml` that
+// omitted `actions: read`.
+//
+// This gate reads the same relationship statically and names the missing scope.
+
+import { readFileSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+import { parse } from 'yaml';
+
+const WORKFLOW_DIRECTORY = '.github/workflows';
+
+/** Permission levels, ordered. A caller must hold at least the level its callee asks for. */
+const LEVELS = { none: 0, read: 1, write: 2 };
+
+/** Every scope GitHub can grant, needed to expand the `read-all` / `write-all` shorthands. */
+const ALL_SCOPES = [
+  'actions',
+  'attestations',
+  'checks',
+  'contents',
+  'deployments',
+  'discussions',
+  'id-token',
+  'issues',
+  'models',
+  'packages',
+  'pages',
+  'pull-requests',
+  'repository-projects',
+  'security-events',
+  'statuses'
+];
+
+/**
+ * Normalises a `permissions:` value into a scope-to-level map.
+ *
+ * Returns `undefined` for an absent block, which is a different thing from an
+ * empty one: absent means "inherit whatever the repository default is", which
+ * cannot be resolved statically, while `{}` means "grant nothing".
+ */
+const normalisePermissions = (value) => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (value === 'read-all') {
+    return Object.fromEntries(ALL_SCOPES.map((scope) => [scope, 'read']));
+  }
+  if (value === 'write-all') {
+    return Object.fromEntries(ALL_SCOPES.map((scope) => [scope, 'write']));
+  }
+  if (typeof value !== 'object') {
+    throw new Error(`Unrecognised permissions value: ${JSON.stringify(value)}`);
+  }
+  return value;
+};
+
+const levelOf = (permissions, scope) => LEVELS[permissions?.[scope] ?? 'none'] ?? 0;
+
+const workflowFiles = async () => {
+  const entries = await readdir(WORKFLOW_DIRECTORY);
+  return entries.filter((entry) => entry.endsWith('.yml') || entry.endsWith('.yaml')).sort();
+};
+
+const main = async () => {
+  const files = await workflowFiles();
+  const parsed = new Map(
+    files.map((file) => [file, parse(readFileSync(path.join(WORKFLOW_DIRECTORY, file), 'utf8'))])
+  );
+
+  const violations = [];
+
+  for (const [file, workflow] of parsed) {
+    const workflowPermissions = normalisePermissions(workflow?.permissions);
+
+    for (const [jobName, job] of Object.entries(workflow?.jobs ?? {})) {
+      const uses = job?.uses;
+      if (typeof uses !== 'string' || !uses.startsWith('./.github/workflows/')) {
+        continue;
+      }
+      const calleeFile = path.basename(uses);
+      const callee = parsed.get(calleeFile);
+      if (callee === undefined) {
+        violations.push(`${file} job '${jobName}' calls ${uses}, which does not exist`);
+        continue;
+      }
+
+      // A job-level block replaces the workflow-level one outright rather than
+      // adding to it, so it is the whole grant when present.
+      const granted = normalisePermissions(job.permissions) ?? workflowPermissions;
+      const required = normalisePermissions(callee.permissions);
+      if (required === undefined) {
+        continue;
+      }
+      if (granted === undefined) {
+        violations.push(
+          `${file} job '${jobName}' calls ${calleeFile}, which declares permissions, but neither the job ` +
+            `nor the workflow declares any -- the grant depends on the repository default and cannot be verified here`
+        );
+        continue;
+      }
+
+      for (const scope of Object.keys(required)) {
+        if (levelOf(granted, scope) < levelOf(required, scope)) {
+          violations.push(
+            `${file} job '${jobName}' grants ${scope}: ${granted[scope] ?? 'none'} but ${calleeFile} requires ` +
+              `${scope}: ${required[scope]} -- the run will fail at startup with no jobs and no annotation`
+          );
+        }
+      }
+    }
+  }
+
+  if (violations.length > 0) {
+    for (const violation of violations) {
+      console.error(`::error::${violation}`);
+    }
+    console.error(`\n${violations.length} reusable-workflow permission violation(s) found.`);
+    process.exit(1);
+  }
+
+  console.log(`Checked ${files.length} workflow files; every reusable-workflow call is granted what it requires.`);
+};
+
+await main();

--- a/.github/scripts/check-workflow-permissions.test.mjs
+++ b/.github/scripts/check-workflow-permissions.test.mjs
@@ -1,0 +1,247 @@
+// This file is part of midnight-js.
+// Copyright (C) 2025-2026 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+import {
+  findViolations,
+  normalisePermissions,
+  readWorkflows,
+  requiredPermissions
+} from './check-workflow-permissions.mjs';
+
+const workflows = (files) => new Map(Object.entries(files).map(([name, document]) => [name, parse(document)]));
+
+const CALLEE_REQUIRING_ACTIONS_READ = `
+permissions:
+  actions: read
+  contents: read
+on:
+  workflow_call:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+`;
+
+describe('findViolations', () => {
+  it('reports a caller that grants less than the callee declares', () => {
+    const tree = workflows({
+      'callee.yml': CALLEE_REQUIRING_ACTIONS_READ,
+      'caller.yml': `
+permissions:
+  contents: read
+jobs:
+  build:
+    uses: ./.github/workflows/callee.yml
+`
+    });
+
+    const { violations } = findViolations(tree);
+
+    expect(violations).toEqual([
+      "caller.yml job 'build' grants actions: none but callee.yml requires actions: read -- " +
+        'the run will fail at startup with no jobs and no annotation'
+    ]);
+  });
+
+  it('counts a job-level block inside the callee as part of what the callee requires', () => {
+    const tree = workflows({
+      'callee.yml': `
+permissions:
+  contents: read
+on:
+  workflow_call:
+jobs:
+  scan:
+    permissions:
+      security-events: write
+    runs-on: ubuntu-latest
+`,
+      'caller.yml': `
+permissions:
+  contents: read
+jobs:
+  build:
+    uses: ./.github/workflows/callee.yml
+`
+    });
+
+    const { violations } = findViolations(tree);
+
+    expect(violations).toEqual([
+      "caller.yml job 'build' grants security-events: none but callee.yml requires security-events: write -- " +
+        'the run will fail at startup with no jobs and no annotation'
+    ]);
+  });
+
+  it('treats a job-level block on the caller as replacing the workflow-level grant', () => {
+    const tree = workflows({
+      'callee.yml': CALLEE_REQUIRING_ACTIONS_READ,
+      'caller.yml': `
+permissions:
+  actions: read
+  contents: read
+jobs:
+  build:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/callee.yml
+`
+    });
+
+    const { violations } = findViolations(tree);
+
+    expect(violations).toEqual([
+      "caller.yml job 'build' grants actions: none but callee.yml requires actions: read -- " +
+        'the run will fail at startup with no jobs and no annotation'
+    ]);
+  });
+
+  it('accepts a caller holding a higher level than the callee asks for', () => {
+    const tree = workflows({
+      'callee.yml': CALLEE_REQUIRING_ACTIONS_READ,
+      'caller.yml': `
+permissions:
+  actions: write
+  contents: write
+jobs:
+  build:
+    uses: ./.github/workflows/callee.yml
+`
+    });
+
+    expect(findViolations(tree).violations).toEqual([]);
+  });
+
+  it('does not let a read-all caller satisfy a write requirement', () => {
+    const tree = workflows({
+      'callee.yml': `
+permissions:
+  packages: write
+on:
+  workflow_call:
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+`,
+      'caller.yml': `
+permissions: read-all
+jobs:
+  build:
+    uses: ./.github/workflows/callee.yml
+`
+    });
+
+    const { violations } = findViolations(tree);
+
+    expect(violations).toEqual([
+      "caller.yml job 'build' grants packages: read but callee.yml requires packages: write -- " +
+        'the run will fail at startup with no jobs and no annotation'
+    ]);
+  });
+
+  it('reports a local callee that does not exist', () => {
+    const tree = workflows({
+      'caller.yml': `
+permissions:
+  contents: read
+jobs:
+  build:
+    uses: ./.github/workflows/missing.yml
+`
+    });
+
+    expect(findViolations(tree).violations).toEqual([
+      "caller.yml job 'build' calls ./.github/workflows/missing.yml, which does not exist"
+    ]);
+  });
+
+  it('reports a call it cannot verify rather than passing it', () => {
+    const tree = workflows({
+      'callee.yml': CALLEE_REQUIRING_ACTIONS_READ,
+      'caller.yml': `
+jobs:
+  build:
+    uses: ./.github/workflows/callee.yml
+`
+    });
+
+    expect(findViolations(tree).violations).toEqual([
+      "caller.yml job 'build' calls callee.yml, which declares permissions, but neither the job nor the " +
+        'workflow declares any -- the grant depends on the repository default and cannot be verified here'
+    ]);
+  });
+
+  it('surfaces calls into other repositories as unchecked instead of silently passing them', () => {
+    const tree = workflows({
+      'caller.yml': `
+permissions:
+  contents: read
+jobs:
+  label:
+    uses: midnightntwrk/workflows/.github/workflows/ai-assisted-label.yml@2a516da
+`
+    });
+
+    const { violations, externalCalls } = findViolations(tree);
+
+    expect(violations).toEqual([]);
+    expect(externalCalls).toEqual([
+      "caller.yml job 'label' -> midnightntwrk/workflows/.github/workflows/ai-assisted-label.yml@2a516da"
+    ]);
+  });
+});
+
+describe('requiredPermissions', () => {
+  it('takes the highest level a scope is asked for anywhere in the callee', () => {
+    const callee = parse(`
+permissions:
+  contents: read
+jobs:
+  one:
+    permissions:
+      contents: write
+  two:
+    permissions:
+      actions: read
+`);
+
+    expect(requiredPermissions(callee)).toEqual({ contents: 'write', actions: 'read' });
+  });
+
+  it('distinguishes a workflow that declares nothing from one that grants nothing', () => {
+    expect(requiredPermissions(parse('jobs:\n  one:\n    runs-on: ubuntu-latest\n'))).toBeUndefined();
+    expect(requiredPermissions(parse('permissions: {}\njobs:\n  one:\n    runs-on: ubuntu-latest\n'))).toEqual({});
+  });
+});
+
+describe('normalisePermissions', () => {
+  it('rejects a level GitHub does not recognise instead of reading it as none', () => {
+    expect(() => normalisePermissions({ contents: 'readonly' })).toThrow(
+      /Unrecognised permission level for 'contents'/
+    );
+  });
+
+  it('rejects a shorthand GitHub does not recognise', () => {
+    expect(() => normalisePermissions('all')).toThrow(/Unrecognised permissions value/);
+  });
+});
+
+describe('the workflows checked in to this repository', () => {
+  it('grant every local reusable-workflow call what it requires', async () => {
+    const { violations } = findViolations(await readWorkflows());
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/.github/scripts/vitest.config.mjs
+++ b/.github/scripts/vitest.config.mjs
@@ -1,0 +1,27 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) 2025-2026 Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// `.github/scripts` is not a workspace, so `turbo run test` never reaches it.
+// This config gives those scripts their own suite, run by `yarn test:workflow-scripts`.
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.mjs'],
+    reporters: ['default']
+  }
+});

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -52,6 +52,11 @@ jobs:
         if: ${{ inputs.yarn_lint_paths != '' }}
         run: yarn lint -- ${{ inputs.yarn_lint_paths }}
 
+      # A reusable workflow asking for more than its caller grants aborts the run at
+      # startup with no jobs and no annotation, so nothing downstream can catch it.
+      - name: Check reusable-workflow permissions
+        run: node .github/scripts/check-workflow-permissions.mjs
+
       - name: Check dependency constraints
         run: yarn constraints
 

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -52,11 +52,6 @@ jobs:
         if: ${{ inputs.yarn_lint_paths != '' }}
         run: yarn lint -- ${{ inputs.yarn_lint_paths }}
 
-      # A reusable workflow asking for more than its caller grants aborts the run at
-      # startup with no jobs and no annotation, so nothing downstream can catch it.
-      - name: Check reusable-workflow permissions
-        run: node .github/scripts/check-workflow-permissions.mjs
-
       - name: Check dependency constraints
         run: yarn constraints
 
@@ -68,6 +63,12 @@ jobs:
       # testkit workspaces are typechecked in their own leg.
       - name: Typecheck tests
         run: yarn typecheck:tests:core
+
+      # `.github/scripts` is not a workspace, so `turbo run test` never reaches it.
+      # The gate these cover runs in `workflow-permissions.yml`, which deliberately
+      # skips the workspace install and so cannot run vitest itself.
+      - name: Test workflow scripts
+        run: yarn test:workflow-scripts
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci-midnight-js.yml
+++ b/.github/workflows/ci-midnight-js.yml
@@ -34,7 +34,9 @@ jobs:
     uses: ./.github/workflows/ci-base.yml
     with:
       yarn_filter: --filter="./packages/*"
-      yarn_lint_paths: ./packages
+      # `.github/scripts` rides along here because this is the only leg that lints;
+      # the workflow-permissions gate lives there and had no lint of its own.
+      yarn_lint_paths: ./packages .github/scripts
     secrets: inherit
 
   cd-prerelease:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
           filters: |
             shared:
               - '.github/workflows/**'
+              - '.github/actions/**'
+              - '.github/scripts/**'
               - 'yarn.lock'
               - 'package.json'
             midnight-js:

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -18,8 +18,8 @@ on:
 permissions:
   # Required by `ci-testkit-js-build.yml`. A reusable workflow cannot be granted more
   # than its caller holds, and asking for more aborts the whole run at startup with
-  # zero jobs -- which on a schedule is silent. `.github/scripts/check-workflow-permissions.mjs`
-  # holds this now.
+  # zero jobs -- which on a schedule is silent. `workflow-permissions.yml` holds
+  # this now, on every PR.
   actions: read
   contents: read
   issues: read

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -16,6 +16,11 @@ on:
   workflow_dispatch:
 
 permissions:
+  # Required by `ci-testkit-js-build.yml`. A reusable workflow cannot be granted more
+  # than its caller holds, and asking for more aborts the whole run at startup with
+  # zero jobs -- which on a schedule is silent. `.github/scripts/check-workflow-permissions.mjs`
+  # holds this now.
+  actions: read
   contents: read
   issues: read
   id-token: write

--- a/.github/workflows/workflow-permissions.yml
+++ b/.github/workflows/workflow-permissions.yml
@@ -1,0 +1,66 @@
+name: Workflow Permissions
+
+# This gate must NOT live inside the call chain it validates.
+#
+# A reusable workflow that asks for more than its caller grants does not fail a
+# job -- GitHub refuses to start the whole run, producing zero jobs and no
+# annotation. A gate hosted inside `ci.yml -> ci-midnight-js.yml -> ci-base.yml`
+# would therefore be deleted by the very fault it exists to report: the run that
+# was supposed to carry the diagnosis is the run that never starts.
+#
+# So this workflow calls no reusable workflow, and installs no workspace. The
+# workspace install needs a GitHub Packages token, and a gate that depends on a
+# secret stops working exactly where an unprivileged run needs it most. It stays
+# able to speak when every other run has been refused.
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: workflow-permissions-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check:
+    name: Check reusable-workflow permissions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+
+      # `yaml` is public and dependency-free, so it needs no registry auth. The
+      # range is read out of package.json rather than repeated here, so the gate
+      # and the workspace cannot drift apart; removing the devDependency fails
+      # this step loudly instead of silently resolving something else.
+      #
+      # Installed under a prefix OUTSIDE the checkout, then linked in: `npm install`
+      # run at the root of a Yarn workspace tries to resolve the whole monorepo and
+      # dies on peer conflicts. Node's ESM resolver ignores NODE_PATH, so the link
+      # is what makes `import { parse } from 'yaml'` resolve.
+      - name: Install the YAML parser
+        env:
+          PARSER_DIR: ${{ runner.temp }}/yaml-parser
+        run: |
+          set -euo pipefail
+          range="$(node -p "require('./package.json').devDependencies.yaml ?? ''")"
+          if [ -z "$range" ]; then
+            echo "::error::root package.json no longer declares a 'yaml' devDependency"
+            exit 1
+          fi
+          mkdir -p "$PARSER_DIR" node_modules
+          npm install --prefix "$PARSER_DIR" --no-save --no-package-lock --no-audit --no-fund "yaml@${range}"
+          ln -s "$PARSER_DIR/node_modules/yaml" node_modules/yaml
+
+      - name: Check reusable-workflow permissions
+        run: node .github/scripts/check-workflow-permissions.mjs

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -92,7 +92,6 @@ export default tseslint.config(
       '**/*.json',
       'packages/compact/src/run-compactc.cjs',
       'scripts/**',
-      '.github/scripts/**',
       'yarn.config.cjs',
       '.versionrc.js',
     ]
@@ -100,6 +99,21 @@ export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended,
   ...tseslint.configs.stylistic,
+  {
+    // `.github/scripts` holds plain Node ESM entry points that CI runs straight
+    // off disk. They were ignored outright, which left the workflow-permissions
+    // gate -- a script whose whole job is to catch a silent CI fault -- with no
+    // lint of its own. Linting them only needs the Node globals declared; the
+    // typed rules below are all scoped to `packages/` and never match here.
+    files: ['.github/scripts/**/*.mjs'],
+    languageOptions: {
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+        URL: 'readonly'
+      }
+    }
+  },
   {
     files: ['packages/**/*.ts', 'packages/**/*.tsx', 'packages/**/*.mts', 'testkit-js/**/*.ts'],
     plugins: {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "turbo run test",
     "test:unit": "turbo run test --filter='!@midnight-ntwrk/testkit-*'",
     "it": "turbo run it",
+    "test:workflow-scripts": "vitest run --config .github/scripts/vitest.config.mjs",
     "e2e": "turbo run e2e",
     "e2e-single": "turbo run e2e-single",
     "check": "turbo run check && yarn lint && yarn constraints",
@@ -72,7 +73,7 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.63.0",
     "vitest": "^4.1.7",
-    "yaml": "2.9.0"
+    "yaml": "^2.9.0"
   },
   "lint-staged": {
     "*.ts": "eslint --cache"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "typedoc-plugin-markdown": "4.12.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.63.0",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.7",
+    "yaml": "2.9.0"
   },
   "lint-staged": {
     "*.ts": "eslint --cache"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,6 +2052,7 @@ __metadata:
     typescript: "npm:^6.0.3"
     typescript-eslint: "npm:^8.63.0"
     vitest: "npm:^4.1.7"
+    yaml: "npm:2.9.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,7 +2052,7 @@ __metadata:
     typescript: "npm:^6.0.3"
     typescript-eslint: "npm:^8.63.0"
     vitest: "npm:^4.1.7"
-    yaml: "npm:2.9.0"
+    yaml: "npm:^2.9.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- `nightly-e2e.yml` has been failing with `startup_failure` and **zero jobs** every night since at least 2026-08-26 (14 consecutive runs checked). Root cause: it calls `ci-testkit-js-build.yml`, which requests `actions: read`, and it was the only caller that did not grant it. A reusable workflow cannot be granted more than its caller holds, so GitHub refuses to start the run at all — no jobs, no annotation, nothing in the API to read. `ci.yml` and `ci-testkit-js.yml` both grant it; nightly did not.
- Adds `.github/scripts/check-workflow-permissions.mjs`, which reads the caller/callee relationship statically and names the missing scope.
- Adds `.github/workflows/workflow-permissions.yml`, which runs that gate — see below for why it is a standalone workflow rather than a step in `ci-base.yml`.
- Declares `yaml` as a root devDependency. It was already resolvable transitively at 2.9.0, and `resolutions` already carries a `>=2.8.3` **floor** (not a pin), but a script that imports it directly should not rely on hoisting.

### Why the gate is its own workflow

The first version of this PR ran the gate as a step in `ci-base.yml`, which is reached through `ci.yml` → `ci-midnight-js.yml` → `ci-base.yml` — the very chain it validates. That does not work. A `startup_failure` produces **zero** jobs, so a permission fault anywhere in that chain deletes the step meant to diagnose it: the run that was supposed to carry the message is the run that never starts.

`workflow-permissions.yml` therefore calls no reusable workflow and performs no workspace install. The workspace install needs a GitHub Packages token, and a gate that depends on a secret stops working exactly where an unprivileged run needs it most; instead the step installs the single public, dependency-free `yaml` package under a prefix outside the checkout (an `npm install` at the root of a Yarn workspace tries to resolve the whole monorepo and dies on peer conflicts) and links it in. The whole job runs in seconds.

**This new workflow is not yet a required check** — worth adding in branch protection, otherwise it can go red without blocking.

### What the gate checks

A callee's requirement is the per-scope maximum across its workflow-level `permissions:` block **and every job-level block**. Reading only the workflow-level block is a false negative: a callee whose top level looks modest can still over-ask one job down. Taking the maximum also makes the check sound across a chain — when A calls B and B calls C, C's demands surface in B's requirement, so the A→B pair catches a shortfall only C would have exposed at run time.

Reusable workflows in other repositories (five of them here) cannot be read from this repo, so they are reported as **unchecked** rather than folded into a pass.

### Scope note

This is a real bug worth fixing, but it is **not** a blocker for the fork-crossing e2e work. e2e already runs on every PR through `ci.yml` → `ci-testkit-js.yml` → `ci-testkit-js-e2e.yml`, pinned to the `devnet` image set. Nightly's only added value is rotating the five `testkit-js/env/*.env` sets, and none of those is a fork-capable topology, so it was never going to supply the environment that work needs.

### What the first successful nightly will show

Two matrix entries are expected to go red, by design rather than by regression: `mainnet.env` and `preprod.env` pin node **0.22.x**, and `protocolVersionToLedger` deliberately does not map node 0.x (#1218, `2d349f1b`, spec OQ1 as shipped). Anything reading the head version fails there on purpose. Flagging it here so it is not diagnosed from scratch at 02:00.

## Test plan

- [x] Tests written first (TDD), verified they fail before fix
- [x] All existing tests pass (no regressions)
- [x] Lint clean, build succeeds

The gate was run **before** the fix and reported exactly the diagnosed bug, independently of how the diagnosis was reached:

```
::error::nightly-e2e.yml job 'build' grants actions: none but ci-testkit-js-build.yml
requires actions: read -- the run will fail at startup with no jobs and no annotation
```

After the fix: `Checked 21 workflow files; every local reusable-workflow call is granted what it requires.`

The script now has a vitest suite (13 tests, `yarn test:workflow-scripts`, run in `ci-base.yml`). Reverting the job-level-permissions fix fails exactly the two tests that cover it and no others. Four sabotage runs against the final code:

| Sabotage | Result |
|---|---|
| nightly loses `actions: read` | the original diagnosis, verbatim |
| job-level over-ask inside `ci-testkit-js-e2e.yml` | caught, naming **both** callers — this passed silently before |
| `checks: readonly` typo in `ci.yml` | `::error::` annotation, not a stack trace |
| `ci.yml` drops `checks: write` | both affected jobs reported |

The last case is the one that motivated moving the gate out of `ci-base.yml`: it is only reportable from a workflow that survives the fault.

Also verified: the gate runs correctly from any working directory, and the install step works against a clean checkout with no `node_modules`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
