### PR TITLE
feat(midnight-js): add a require-if-present ZK artifact integrity mode

### DIFF
--- a/docs/releases/v5.0.0/api-changes.md
+++ b/docs/releases/v5.0.0/api-changes.md
@@ -190,7 +190,7 @@ Internally the provider was split into 7 layered files (#960): `config.ts`, `tra
 export const isValidSigningKey: (value: unknown) => boolean;
 
 // ZK artifact integrity manifest (#1015) — consumed by both ZK config providers
-export type ZkArtifactIntegrityMode = 'require' | 'warn' | 'off';
+export type ZkArtifactIntegrityMode = 'require' | 'require-if-present' | 'warn' | 'off';
 export interface ZkConfigIntegrityOptions {
   readonly verify?: ZkArtifactIntegrityMode;   // default 'require' (fail-closed)
   readonly expectedManifestHash?: string;      // SHA-256 hex of the manifest bytes, pinned at build time

--- a/docs/releases/v5.0.0/breaking-changes.md
+++ b/docs/releases/v5.0.0/breaking-changes.md
@@ -105,11 +105,13 @@ Opt down or pin explicitly through the constructor option bag (`ZkConfigIntegrit
 
 ```ts
 new NodeZkConfigProvider(baseDir, {
-  verify: 'warn',                 // 'require' (default) | 'warn' | 'off'
+  verify: 'require-if-present',    // 'require' (default) | 'require-if-present' | 'warn' | 'off'
   onWarn: (msg) => logger.warn(msg),
   expectedManifestHash: MANIFEST_SHA256, // pin to resist a coordinated artifact+manifest swap
 });
 ```
+
+`compactc` only began emitting the manifest in 0.33, so artifacts compiled by an earlier toolchain cannot satisfy `require` however intact they are. `require-if-present` is the mode for them: a wholly absent manifest warns, but a manifest that does exist must cover the artifact, so a missing entry throws. That makes it strictly stronger than `warn`, which tolerates a missing entry in a manifest that is present, and it starts verifying in full the moment the artifacts are recompiled on 0.33 or later.
 
 A digest mismatch always throws (except in `'off'` mode). Only `expectedManifestHash` (SHA-256 of the manifest bytes, pinned at build time) defends against an adversary who can rewrite both the artifacts and their co-located manifest.
 

--- a/docs/releases/v5.0.0/migration-guide.md
+++ b/docs/releases/v5.0.0/migration-guide.md
@@ -180,7 +180,8 @@ If you need on-chain contract events, the `PublicDataProvider` now exposes them 
 
 - **Preferred:** recompile with `compactc 0.33.0-rc.1` so the `contract-manifest.json` is emitted alongside the artifacts, and ship the whole `compiler/` directory with your artifacts.
 - **Harden further:** pin `expectedManifestHash` (SHA-256 of the manifest bytes) at build time to resist a coordinated swap of both the artifacts and their co-located manifest.
-- **Temporary escape hatch:** set `verify: 'warn'` (or `'off'`) while you regenerate artifacts — but a digest mismatch still throws except in `'off'` mode.
+- **If you cannot recompile yet:** set `verify: 'require-if-present'`. `compactc` only began emitting the manifest in 0.33, so artifacts from an earlier toolchain can never satisfy `require`. This mode tolerates a wholly absent manifest (it warns) but still requires a manifest that *does* exist to cover the artifact, and it begins verifying in full as soon as you recompile — no further code change.
+- **Last resort:** `verify: 'warn'` (or `'off'`) while you regenerate artifacts. Unlike `require-if-present`, `warn` also lets through an artifact missing from a manifest that is present. A digest mismatch still throws except in `'off'` mode.
 
 ```diff
 - new NodeZkConfigProvider(baseDir);

--- a/docs/releases/v5.0.0/new-features.md
+++ b/docs/releases/v5.0.0/new-features.md
@@ -238,7 +238,7 @@ const provider = new NodeZkConfigProvider(baseDir);
 
 // Explicit control via ZkConfigIntegrityOptions:
 const lenient = new NodeZkConfigProvider(baseDir, {
-  verify: 'warn',                        // 'require' (default) | 'warn' | 'off'
+  verify: 'require-if-present',          // 'require' (default) | 'require-if-present' | 'warn' | 'off'
   onWarn: (msg) => logger.warn(msg),     // default: console.warn
   expectedManifestHash: MANIFEST_SHA256, // pin to resist a coordinated artifact+manifest swap
 });

--- a/docs/releases/v5.0.0/release-notes.md
+++ b/docs/releases/v5.0.0/release-notes.md
@@ -42,7 +42,7 @@ The testkit wallet stack moved to the 2.0.0 major beta line (`@midnightntwrk/wal
 
 ### ZK artifacts verified against the `compactc` integrity manifest (#1015)
 
-`FetchZkConfigProvider` and `NodeZkConfigProvider` now verify every ZK artifact they load against the `compactc`-emitted `contract-manifest.json` (in the `compiler/` directory). Verification is **fail-closed by default** (`verify: 'require'`): a missing manifest or a digest mismatch throws `ZkArtifactIntegrityError`. Opt down to `'warn'` or `'off'`, and pin `expectedManifestHash` (SHA-256 of the manifest bytes) to defend against a coordinated swap of both the artifacts and their co-located manifest. This is a breaking change for any deployment whose local artifacts are stale, partial, or missing the manifest. See [breaking-changes.md](./breaking-changes.md).
+`FetchZkConfigProvider` and `NodeZkConfigProvider` now verify every ZK artifact they load against the `compactc`-emitted `contract-manifest.json` (in the `compiler/` directory). Verification is **fail-closed by default** (`verify: 'require'`): a missing manifest or a digest mismatch throws `ZkArtifactIntegrityError`. Artifacts compiled before `compactc` 0.33 carry no manifest at all and cannot satisfy `require`; `'require-if-present'` is the mode for them — it tolerates a wholly absent manifest but still requires a manifest that does exist to cover the artifact. Opt further down to `'warn'` or `'off'`, and pin `expectedManifestHash` (SHA-256 of the manifest bytes) to defend against a coordinated swap of both the artifacts and their co-located manifest. This is a breaking change for any deployment whose local artifacts are stale, partial, or missing the manifest. See [breaking-changes.md](./breaking-changes.md).
 
 ## New Features
 
@@ -91,7 +91,7 @@ The indexer provider negotiates the `graphql-transport-ws+deflate` WebSocket sub
 
 ### ZK artifact integrity manifest module (#1015)
 
-A new `zk-artifact-manifest` module in `@midnight-ntwrk/midnight-js-utils` parses the `compactc` `contract-manifest.json`, exposing `ZkArtifactManifest`, `ZkConfigIntegrityOptions` (`verify`, `expectedManifestHash`, `onWarn`), `ZkArtifactIntegrityMode` (`'require' | 'warn' | 'off'`), and `ZkArtifactIntegrityError`. Both ZK config providers consume it (see Breaking Changes).
+A new `zk-artifact-manifest` module in `@midnight-ntwrk/midnight-js-utils` parses the `compactc` `contract-manifest.json`, exposing `ZkArtifactManifest`, `ZkConfigIntegrityOptions` (`verify`, `expectedManifestHash`, `onWarn`), `ZkArtifactIntegrityMode` (`'require' | 'require-if-present' | 'warn' | 'off'`), and `ZkArtifactIntegrityError`. Both ZK config providers consume it (see Breaking Changes).
 
 ### Disposable `IndexerPublicDataProvider` with structured config (#961)
 

--- a/packages/fetch-zk-config-provider/src/test/fetch-zk-config-provider.test.ts
+++ b/packages/fetch-zk-config-provider/src/test/fetch-zk-config-provider.test.ts
@@ -360,6 +360,42 @@ describe('Fetch ZK config Provider', () => {
       }
     });
 
+    it('warns and resolves when the manifest is absent in require-if-present mode', async () => {
+      const onWarn = vi.fn();
+      const { url, close } = startServer((app) => {
+        app.get('/keys/set_topic.prover', async (_, res) => res.send(await proverFixture()));
+      });
+      try {
+        const key = await new FetchZkConfigProvider(url, { verify: 'require-if-present', onWarn }).getProverKey(
+          'set_topic'
+        );
+        expect(key.length).toBeGreaterThan(0);
+        expect(onWarn).toHaveBeenCalledOnce();
+        expect(onWarn.mock.calls[0][0]).toMatch(/^midnight-js:.*set_topic\.prover/);
+      } finally {
+        close();
+      }
+    });
+
+    it('rejects in require-if-present mode when the served manifest has no entry for the artifact', async () => {
+      const onWarn = vi.fn();
+      const prover = await proverFixture();
+      const { url, close } = startServer((app) => {
+        app.get('/keys/set_topic.prover', (_, res) => res.send(prover));
+        app.get('/compiler/contract-manifest.json', (_, res) =>
+          res.type('application/json').send(manifestFor('keys', 'other.prover', prover))
+        );
+      });
+      try {
+        await expect(
+          new FetchZkConfigProvider(url, { verify: 'require-if-present', onWarn }).getProverKey('set_topic')
+        ).rejects.toThrow(ZkArtifactIntegrityError);
+        expect(onWarn).not.toHaveBeenCalled();
+      } finally {
+        close();
+      }
+    });
+
     it('rejects when the manifest is absent under the default (require)', async () => {
       const app = express();
       app.get('/keys/set_topic.prover', async (_, res) => res.send(await proverFixture()));

--- a/packages/node-zk-config-provider/src/test/node-zk-provider.test.ts
+++ b/packages/node-zk-config-provider/src/test/node-zk-provider.test.ts
@@ -240,6 +240,39 @@ describe('Node ZK config Provider', () => {
       );
     });
 
+    it('warns and resolves when the manifest is absent in require-if-present mode', async () => {
+      const onWarn = vi.fn();
+      const key = await new NodeZkConfigProvider(resourceDir, { verify: 'require-if-present', onWarn }).getProverKey(
+        'set_topic'
+      );
+      expect(key.length).toBeGreaterThan(0);
+      expect(onWarn).toHaveBeenCalledOnce();
+      expect(onWarn.mock.calls[0][0]).toMatch(/^midnight-js:.*set_topic\.prover/);
+    });
+
+    it('rejects in require-if-present mode when a present manifest has no entry for the artifact', async () => {
+      const onWarn = vi.fn();
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'node-zk-partial-rip-'));
+      await fs.mkdir(path.join(dir, 'keys'));
+      await fs.mkdir(path.join(dir, 'compiler'));
+      await fs.writeFile(
+        path.join(dir, 'keys', 'set_topic.prover'),
+        await fs.readFile(`${resourceDir}/keys/set_topic.prover`)
+      );
+      await fs.writeFile(
+        path.join(dir, 'compiler', 'contract-manifest.json'),
+        JSON.stringify({
+          'manifest-version': '1',
+          keys: { type: 'directory', 'other.prover': { type: 'file', size: 1, hash: 'f'.repeat(64) } }
+        })
+      );
+
+      await expect(
+        new NodeZkConfigProvider(dir, { verify: 'require-if-present', onWarn }).getProverKey('set_topic')
+      ).rejects.toThrow(ZkArtifactIntegrityError);
+      expect(onWarn).not.toHaveBeenCalled();
+    });
+
     it('warns and resolves when the manifest is absent in warn mode', async () => {
       const onWarn = vi.fn();
       const key = await new NodeZkConfigProvider(resourceDir, { verify: 'warn', onWarn }).getProverKey('set_topic');

--- a/packages/utils/src/test/zk-artifact-manifest.test.ts
+++ b/packages/utils/src/test/zk-artifact-manifest.test.ts
@@ -160,7 +160,7 @@ describe('verifyZkArtifactIntegrity', () => {
     expect(onWarn.mock.calls[0][0]).toMatch(/^midnight-js:/);
   });
 
-  it('warns when the manifest is present but the entry is missing (treated as absent)', () => {
+  it('warns when the manifest is present but the entry is missing', () => {
     const onWarn = vi.fn();
     verifyZkArtifactIntegrity({ manifest, relativePath: 'keys/missing.prover', bytes: BYTES, mode: 'warn', onWarn });
     expect(onWarn).toHaveBeenCalledOnce();
@@ -186,7 +186,9 @@ describe('verifyZkArtifactIntegrity', () => {
   it('names the opt-out hatches when it throws for a missing manifest in require mode', () => {
     expect(() =>
       verifyZkArtifactIntegrity({ manifest: undefined, relativePath: 'keys/increment.prover', bytes: BYTES, mode: 'require' })
-    ).toThrow(/recompile with a manifest-emitting compactc.*verify: 'warn'.*verify: 'off'/is);
+    ).toThrow(
+      /recompile with a manifest-emitting compactc.*verify: 'require-if-present'.*verify: 'warn'.*verify: 'off'/is
+    );
   });
 
   it('rejects an artifact whose length differs from the manifest size before hashing', () => {
@@ -199,6 +201,69 @@ describe('verifyZkArtifactIntegrity', () => {
     expect(() =>
       verifyZkArtifactIntegrity({ manifest: wrongSize, relativePath: 'keys/increment.prover', bytes: BYTES, mode: 'require' })
     ).toThrow(new RegExp(`expected ${BYTES.length + 1} bytes, got ${BYTES.length}`));
+  });
+
+  describe('require-if-present mode', () => {
+    it('warns and returns when no manifest exists at all', () => {
+      const onWarn = vi.fn();
+
+      verifyZkArtifactIntegrity({
+        manifest: undefined,
+        relativePath: 'keys/increment.prover',
+        bytes: BYTES,
+        mode: 'require-if-present',
+        onWarn
+      });
+
+      expect(onWarn).toHaveBeenCalledOnce();
+      expect(onWarn.mock.calls[0][0]).toMatch(/^midnight-js:.*keys\/increment\.prover/);
+    });
+
+    it('throws when the manifest exists but has no entry for the artifact', () => {
+      const onWarn = vi.fn();
+
+      expect(() =>
+        verifyZkArtifactIntegrity({
+          manifest,
+          relativePath: 'keys/missing.prover',
+          bytes: BYTES,
+          mode: 'require-if-present',
+          onWarn
+        })
+      ).toThrow(ZkArtifactIntegrityError);
+      expect(onWarn).not.toHaveBeenCalled();
+    });
+
+    it('throws on a digest mismatch', () => {
+      const wrong = parseZkArtifactManifest(manifestJson(OTHER_HASH));
+
+      expect(() =>
+        verifyZkArtifactIntegrity({
+          manifest: wrong,
+          relativePath: 'keys/increment.prover',
+          bytes: BYTES,
+          mode: 'require-if-present'
+        })
+      ).toThrow(ZkArtifactIntegrityError);
+    });
+
+    it('rejects an artifact whose length differs from the manifest size before hashing', () => {
+      const wrongSize = parseZkArtifactManifest(
+        JSON.stringify({
+          'manifest-version': '1',
+          keys: { type: 'directory', 'increment.prover': { type: 'file', size: BYTES.length + 1, hash: BYTES_SHA256 } }
+        })
+      );
+
+      expect(() =>
+        verifyZkArtifactIntegrity({
+          manifest: wrongSize,
+          relativePath: 'keys/increment.prover',
+          bytes: BYTES,
+          mode: 'require-if-present'
+        })
+      ).toThrow(new RegExp(`expected ${BYTES.length + 1} bytes, got ${BYTES.length}`));
+    });
   });
 
   it('skips verification entirely in off mode (even on mismatch)', () => {

--- a/packages/utils/src/zk-artifact-manifest.ts
+++ b/packages/utils/src/zk-artifact-manifest.ts
@@ -24,14 +24,24 @@ export const ZK_MANIFEST_FILE_NAME = 'contract-manifest.json';
 const SUPPORTED_MANIFEST_VERSION = '1';
 const SHA256_HEX = /^[0-9a-f]{64}$/;
 
-/** How a provider reacts to a missing manifest. A digest mismatch always throws (except `off`). */
-export type ZkArtifactIntegrityMode = 'require' | 'warn' | 'off';
+/**
+ * How a provider reacts to a manifest that does not cover an artifact. A digest mismatch always
+ * throws (except `off`).
+ *
+ * - `require`: both a wholly absent manifest and a manifest without an entry for the artifact throw.
+ * - `require-if-present`: a wholly absent manifest warns; a manifest that exists must cover the
+ *   artifact, so a missing entry throws. `compactc` only began emitting the manifest in 0.33, so
+ *   this is the mode for artifacts compiled by a toolchain that never produced one.
+ * - `warn`: both cases warn.
+ * - `off`: no verification at all.
+ */
+export type ZkArtifactIntegrityMode = 'require' | 'require-if-present' | 'warn' | 'off';
 
 /** Integrity options shared by both ZK config providers' constructor option bags. */
 export interface ZkConfigIntegrityOptions {
   /**
    * Default `'require'` (fail-closed). Trust boundary: without {@link expectedManifestHash} the
-   * manifest is loaded from the same base location as the artifacts, so `require`/`warn` detect
+   * manifest is loaded from the same base location as the artifacts, so every verifying mode detects
    * corruption (partial deploy, truncation, a stale or wrong artifact set) but NOT an adversary who
    * can rewrite both the artifacts and the co-located manifest. Set {@link expectedManifestHash} to
    * defend against that coordinated substitution.
@@ -153,7 +163,9 @@ const defaultOnWarn = (message: string): void => {
 /**
  * Verifies one artifact's bytes against the manifest entry for `relativePath`.
  * - `off`: no-op.
- * - missing manifest/entry: `require` throws, `warn` warns and returns.
+ * - no manifest at all: `require` throws, every other mode warns and returns.
+ * - manifest present but no entry for the artifact: `require` and `require-if-present` throw,
+ *   `warn` warns and returns.
  * - length or digest mismatch: always throws (except `off`). Length is checked first as a cheap
  *   pre-hash guard so a truncated artifact fails with a clear "expected N bytes" error.
  */
@@ -168,22 +180,35 @@ export function verifyZkArtifactIntegrity(params: {
   if (mode === 'off') {
     return;
   }
-  const entry = manifest?.files.get(relativePath);
-  if (entry === undefined) {
-    const reason =
-      manifest === undefined
-        ? `no ZK artifact manifest (${ZK_MANIFEST_DIR}/${ZK_MANIFEST_FILE_NAME}) was found`
-        : `ZK artifact manifest has no entry for "${relativePath}"`;
+  if (manifest === undefined) {
     if (mode === 'require') {
       throw new ZkArtifactIntegrityError(
-        `${reason}; integrity verification is required. Recompile with a manifest-emitting compactc, ` +
-          `or construct the provider with { verify: 'warn' } or { verify: 'off' } to opt out.`
+        `no ZK artifact manifest (${ZK_MANIFEST_DIR}/${ZK_MANIFEST_FILE_NAME}) was found; integrity ` +
+          `verification is required. Recompile with a manifest-emitting compactc, or construct the ` +
+          `provider with { verify: 'require-if-present' }, { verify: 'warn' } or { verify: 'off' } to ` +
+          `opt out.`
       );
     }
     (params.onWarn ?? defaultOnWarn)(
-      `midnight-js: ${reason}; skipping ZK artifact integrity verification for "${relativePath}"`
+      `midnight-js: no ZK artifact manifest (${ZK_MANIFEST_DIR}/${ZK_MANIFEST_FILE_NAME}) was found; ` +
+        `skipping ZK artifact integrity verification for "${relativePath}"`
     );
     return;
+  }
+  const entry = manifest.files.get(relativePath);
+  if (entry === undefined) {
+    if (mode === 'warn') {
+      (params.onWarn ?? defaultOnWarn)(
+        `midnight-js: ZK artifact manifest has no entry for "${relativePath}"; skipping ZK artifact ` +
+          `integrity verification for it`
+      );
+      return;
+    }
+    throw new ZkArtifactIntegrityError(
+      `ZK artifact manifest has no entry for "${relativePath}"; integrity verification is required. ` +
+        `The manifest does not certify this artifact, so the artifact set is stale or partial. ` +
+        `Construct the provider with { verify: 'warn' } or { verify: 'off' } to opt out.`
+    );
   }
   if (bytes.length !== entry.size) {
     throw new ZkArtifactIntegrityError(


### PR DESCRIPTION
## Summary

Closes #1268.

`compactc` only began emitting `compiler/contract-manifest.json` in 0.33. The ZK config providers default to `verify: 'require'`, which throws when that file is absent — so **for any artifact set compiled by an earlier toolchain the default is unsatisfiable however intact the artifacts are**, and that includes everything deployed pre-fork. The hard-fork AC0 harness already had to drop to `verify: 'warn'` for exactly this reason (`packaging/ac0-entry.mjs` on `test/1006-ac0-scenario`).

Before this change the only opt-outs were `warn` and `off`, both of which discard verification wholesale — including the checks that would still work if a manifest were present.

This adds a fourth `ZkArtifactIntegrityMode`, `'require-if-present'`:

| Case | `require` (default) | `require-if-present` | `warn` | `off` |
|---|---|---|---|---|
| no manifest at all | throw | warn | warn | pass |
| manifest present, no entry for the artifact | throw | **throw** | warn | pass |
| size or digest mismatch | throw | throw | throw | pass |
| `expectedManifestHash` set, manifest absent | throw | throw | throw | throw |

The new mode is strictly stronger than `warn`: `warn` also tolerates an artifact missing from a manifest that does exist, `require-if-present` does not. A consumer on pre-0.33 artifacts opts into it deliberately and gets full verification the moment they recompile on 0.33+, with no further code change.

**The default is unchanged and `require` still means exactly what it meant.** Weakening `require`'s semantics under its existing name was considered and rejected: a security audit reading either mode name should get what the name says. This is additive — `ZkArtifactIntegrityMode` is an input a consumer passes, never something they exhaustively switch on from us.

Two smaller consequences:

- `require`'s missing-manifest error now names `require-if-present` first, ahead of `warn`/`off`, so the proportionate hatch is the one a reader reaches for.
- The two failure reasons now carry distinct messages. "The manifest does not certify this artifact, so the artifact set is stale or partial" is a different problem from "no manifest was emitted", and only the latter is fixed by recompiling.

Follow-up, deliberately not here: `packaging/ac0-entry.mjs` should move from `warn` to `require-if-present` on the hard-fork branch that owns it.

## Test plan

- [x] Tests written first (TDD), verified they fail before the fix

  RED was demonstrated in `packages/utils`: 2 failed / 29 passed before the implementation — `require-if-present` did not throw on a manifest missing the entry, and `require`'s error did not name the new hatch. GREEN: 31/31.

  The other two new `require-if-present` unit tests (digest mismatch, size mismatch) passed before the fix as well, because the unimplemented mode fell through to the `warn` path, which already throws on a mismatch. They are kept as contract locks — the new mode must never skip digest verification — not as evidence of a red-to-green transition.

  The four provider-level tests are pass-through checks over the same semantics; they were not separately red, since a fresh worktree has no built `utils` dist to run them against.

- [x] All existing tests pass (no regressions) — full suite: 27/27 packages, `Cached: 0 cached, 27 total` (run with `--force`, so no task result was restored from cache)
- [x] Lint clean (`yarn lint`, plus `eslint` on the four changed source files), build succeeds

Docs updated in `docs/releases/v5.0.0/`: `migration-guide.md` gains the new mode as the path for artifacts compiled before 0.33, and `api-changes.md` / `breaking-changes.md` / `new-features.md` / `release-notes.md` carry the fourth mode. `README.md` is untouched — its two summary lines describe the fail-closed default, which has not changed.
