### PR TITLE
fix(midnight-js): distinguish a keyless operation slot from a key mismatch

### DIFF
--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import type { ContractAddress, ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import type { AnyProvableCircuitId, FinalizedTxData, PrivateStateId } from '@midnight-ntwrk/midnight-js-types';
 
 interface EffectContractError {
@@ -92,30 +92,109 @@ export class CallTxFailedError extends TxFailedError {
 }
 
 /**
+ * The ways in which a circuit the client holds a verifier key for can fail to line up with the
+ * contract state deployed on chain. Each circuit falls into exactly one of these.
+ */
+export interface ContractTypeMismatch {
+  /**
+   * Circuits for which the deployed state registers no operation at all.
+   */
+  readonly missing: AnyProvableCircuitId[];
+  /**
+   * Circuits whose operation is registered on the deployed state but carries no verifier key.
+   */
+  readonly keyless: AnyProvableCircuitId[];
+  /**
+   * Circuits whose deployed verifier key differs from the one the client holds.
+   */
+  readonly mismatched: AnyProvableCircuitId[];
+}
+
+const MAX_STATE_DESCRIPTION_CHARS = 2_000;
+
+const describeContractState = (contractState: ContractState): string => {
+  try {
+    const description = contractState.toString(true);
+    return description.length > MAX_STATE_DESCRIPTION_CHARS
+      ? `${description.slice(0, MAX_STATE_DESCRIPTION_CHARS)}… (truncated from ${description.length} characters; the full state is on 'error.contractState')`
+      : description;
+  } catch (error) {
+    // Deliberately narrow: this runs inside the error constructor, so letting a failure escape
+    // would destroy the ContractTypeError and take 'circuitIds' with it. The state itself stays
+    // reachable on 'error.contractState' for a caller that wants to inspect it.
+    return `<the deployed state could not be rendered: ${error instanceof Error ? error.message : String(error)}>`;
+  }
+};
+
+const describeMismatch = (mismatch: ContractTypeMismatch, contractAddress?: ContractAddress): string => {
+  const subject = contractAddress === undefined ? 'The deployed contract' : `The contract at '${contractAddress}'`;
+  const lines = [`${subject} is not the expected contract type.`];
+  if (mismatch.missing.length > 0) {
+    lines.push(`  Not registered on the deployed state: ${mismatch.missing.join(', ')}`);
+  }
+  if (mismatch.keyless.length > 0) {
+    lines.push(
+      `  Registered on the deployed state but carrying no verifier key: ${mismatch.keyless.join(', ')}. ` +
+        'The deployed state is incomplete, so recompiling the local contract will not resolve this.'
+    );
+  }
+  if (mismatch.mismatched.length > 0) {
+    lines.push(
+      `  Deployed verifier key differs from the local one: ${mismatch.mismatched.join(', ')}. ` +
+        'The local artifacts were built from a different contract or a different version of it.'
+    );
+  }
+  return lines.join('\n');
+};
+
+/**
  * The error that is thrown when there is a contract type mismatch between a given contract type,
  * and the initial state that is deployed at a given contract address.
  *
  * @remarks
  * This error is typically thrown during calls to {@link findDeployedContract} where the supplied contract
  * address represents a different type of contract to the contract type given.
+ *
+ * The three conditions are reported separately because they call for different responses: a
+ * mismatched key means the local artifacts are wrong, while a keyless slot means the deployed state
+ * itself is incomplete and rebuilding locally cannot help.
  */
 export class ContractTypeError extends TypeError {
+  /**
+   * The circuits that the deployed state registers no operation for.
+   */
+  readonly missingCircuitIds: AnyProvableCircuitId[];
+  /**
+   * The circuits whose deployed operation carries no verifier key.
+   */
+  readonly keylessCircuitIds: AnyProvableCircuitId[];
+  /**
+   * The circuits whose deployed verifier key differs from the local one.
+   */
+  readonly mismatchedCircuitIds: AnyProvableCircuitId[];
+  /**
+   * Every circuit that failed to match, whatever the reason, grouped by condition: missing first,
+   * then keyless, then mismatched.
+   */
+  readonly circuitIds: AnyProvableCircuitId[];
+
   /**
    * Initializes a new {@link ContractTypeError}.
    *
    * @param contractState The initial deployed contract state.
-   * @param circuitIds The circuits that are undefined, or have a verifier key mismatch with the
-   *                   key present in `contractState`.
+   * @param mismatch The circuits that failed to match, grouped by the condition that applied.
+   * @param contractAddress The address the state was read from, when known.
    */
   constructor(
     readonly contractState: ContractState,
-    readonly circuitIds: AnyProvableCircuitId[]
+    mismatch: ContractTypeMismatch,
+    readonly contractAddress?: ContractAddress
   ) {
-    super(
-      `Following operations: ${circuitIds.join(
-        ', '
-      )}, are undefined or have mismatched verifier keys for contract state ${contractState.toString(false)}`
-    );
+    super(`${describeMismatch(mismatch, contractAddress)}\nDeployed state: ${describeContractState(contractState)}`);
+    this.missingCircuitIds = mismatch.missing;
+    this.keylessCircuitIds = mismatch.keyless;
+    this.mismatchedCircuitIds = mismatch.mismatched;
+    this.circuitIds = [...mismatch.missing, ...mismatch.keyless, ...mismatch.mismatched];
   }
 }
 

--- a/packages/contracts/src/find-deployed-contract.ts
+++ b/packages/contracts/src/find-deployed-contract.ts
@@ -112,24 +112,45 @@ export const verifierKeysEqual = (a: Uint8Array, b: Uint8Array): boolean =>
 /**
  * Checks that the given `contractState` contains the given `verifierKeys`.
  *
- * A circuit counts as mismatched when the state registers no operation for it, when the registered
+ * A circuit fails the check when the state registers no operation for it, when the registered
  * operation carries no verifier key at all, or when the deployed key differs from the local one.
+ * The three are reported separately on the thrown error, because only the last one means the local
+ * artifacts are at fault.
  *
  * @param verifierKeys The verifier keys the client has for the deployed contract we're checking.
  * @param contractState The (typically already deployed) contract state containing verifier keys.
+ * @param contractAddress The address `contractState` was read from, used to identify the contract
+ *                        in the thrown error.
  *
- * @throws ContractTypeError When one or more of the local and deployed verifier keys do not match.
+ * @throws ContractTypeError When any circuit is missing from `contractState`, has no deployed
+ *                           verifier key, or has a key differing from the local one.
  */
 export const verifyContractState = (
   verifierKeys: [AnyProvableCircuitId, VerifierKey][],
-  contractState: ContractState
+  contractState: ContractState,
+  contractAddress?: ContractAddress
 ): void => {
-  const mismatchedCircuitIds = verifierKeys.reduce((acc, [circuitId, localVk]) => {
-    const deployedVk = contractState.operation(circuitId)?.verifierKey;
-    return deployedVk === undefined || !verifierKeysEqual(localVk, deployedVk) ? [...acc, circuitId] : acc;
-  }, [] as string[]);
-  if (mismatchedCircuitIds.length > 0) {
-    throw new ContractTypeError(contractState, mismatchedCircuitIds);
+  const missing: AnyProvableCircuitId[] = [];
+  const keyless: AnyProvableCircuitId[] = [];
+  const mismatched: AnyProvableCircuitId[] = [];
+  for (const [circuitId, localVk] of verifierKeys) {
+    const operation = contractState.operation(circuitId);
+    if (operation === undefined) {
+      missing.push(circuitId);
+      continue;
+    }
+    // Widened on purpose. The runtime declares 'verifierKey' as a non-optional 'Uint8Array', but a
+    // registered operation can carry none, so the guard below is unreachable to the type checker
+    // and load-bearing at runtime.
+    const deployedVk: Uint8Array | undefined = operation.verifierKey;
+    if (deployedVk === undefined) {
+      keyless.push(circuitId);
+    } else if (!verifierKeysEqual(localVk, deployedVk)) {
+      mismatched.push(circuitId);
+    }
+  }
+  if (missing.length > 0 || keyless.length > 0 || mismatched.length > 0) {
+    throw new ContractTypeError(contractState, { missing, keyless, mismatched }, contractAddress);
   }
 };
 
@@ -248,7 +269,8 @@ export async function findDeployedContract<C extends Contract.Any>(
  * @throws Error No contract state could be found at `contractAddress`.
  * @throws TypeError Thrown if `contractAddress` is not correctly formatted as a contract address.
  * @throws ContractTypeError One or more circuits defined on `contract` are undefined on the contract
- *                           state found at `contractAddress`, or have mis-matched verifier keys.
+ *                           state found at `contractAddress`, carry no deployed verifier key, or
+ *                           have mis-matched verifier keys.
  * @throws IncompleteFindContractPrivateStateConfig If an `initialPrivateState` is given but no
  *                                                  `privateStateId` is given to store it under.
  */
@@ -271,7 +293,7 @@ export async function findDeployedContract<C extends Contract.Any>(
   const verifierKeys = await providers.zkConfigProvider.getVerifierKeys(
     ContractExecutable.make(compiledContract).getProvableCircuitIds()
   );
-  verifyContractState(verifierKeys, currentContractState);
+  verifyContractState(verifierKeys, currentContractState, contractAddress);
 
   const signingKey = await setOrGetInitialSigningKey(providers.privateStateProvider, options);
   const initialPrivateState = await setOrGetInitialPrivateState(providers.privateStateProvider, options);

--- a/packages/contracts/src/find-deployed-contract.ts
+++ b/packages/contracts/src/find-deployed-contract.ts
@@ -112,6 +112,9 @@ export const verifierKeysEqual = (a: Uint8Array, b: Uint8Array): boolean =>
 /**
  * Checks that the given `contractState` contains the given `verifierKeys`.
  *
+ * A circuit counts as mismatched when the state registers no operation for it, when the registered
+ * operation carries no verifier key at all, or when the deployed key differs from the local one.
+ *
  * @param verifierKeys The verifier keys the client has for the deployed contract we're checking.
  * @param contractState The (typically already deployed) contract state containing verifier keys.
  *
@@ -121,14 +124,10 @@ export const verifyContractState = (
   verifierKeys: [AnyProvableCircuitId, VerifierKey][],
   contractState: ContractState
 ): void => {
-  const mismatchedCircuitIds = verifierKeys.reduce(
-    (acc, [circuitId, localVk]) =>
-      !contractState.operation(circuitId) ||
-      !verifierKeysEqual(localVk, contractState.operation(circuitId)!.verifierKey)
-        ? [...acc, circuitId]
-        : acc,
-    [] as string[]
-  );
+  const mismatchedCircuitIds = verifierKeys.reduce((acc, [circuitId, localVk]) => {
+    const deployedVk = contractState.operation(circuitId)?.verifierKey;
+    return deployedVk === undefined || !verifierKeysEqual(localVk, deployedVk) ? [...acc, circuitId] : acc;
+  }, [] as string[]);
   if (mismatchedCircuitIds.length > 0) {
     throw new ContractTypeError(contractState, mismatchedCircuitIds);
   }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -43,6 +43,7 @@ export {
 export {
   CallTxFailedError,
   ContractTypeError,
+  ContractTypeMismatch,
   DeployTxFailedError,
   IncompleteCallTxPrivateStateConfig,
   IncompleteFindContractPrivateStateConfig,

--- a/packages/contracts/src/test/find-deployed-contract.test.ts
+++ b/packages/contracts/src/test/find-deployed-contract.test.ts
@@ -14,9 +14,11 @@
  */
 
 import { type Contract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
+import { ContractOperation } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import type * as midnightJsTypes from '@midnight-ntwrk/midnight-js-types';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ContractTypeError } from '../errors';
 import { findDeployedContract, type FoundContract } from '../find-deployed-contract';
 import {
   createMockCompiledContract,
@@ -198,5 +200,35 @@ describe('findDeployedContract', () => {
     expect(providers.publicDataProvider.queryDeployContractState).toHaveBeenCalledWith(contractAddress);
     expect(providers.publicDataProvider.queryContractState).not.toHaveBeenCalled();
     expect(providers.zkConfigProvider.getVerifierKeys).not.toHaveBeenCalled();
+  });
+
+  it('should throw when the deployed state registers no operation for a circuit', async () => {
+    vi.mocked(contractState.operation).mockReturnValue(undefined);
+
+    await expect(findDeployedContract(providers, { compiledContract, contractAddress })).rejects.toThrow(
+      ContractTypeError
+    );
+
+    expect(providers.privateStateProvider.setSigningKey).not.toHaveBeenCalled();
+    expect(providers.privateStateProvider.set).not.toHaveBeenCalled();
+  });
+
+  // A default-constructed operation is exactly the keyless shape: registered on the state, but
+  // carrying no verifier key.
+  it('should throw when the deployed operation carries no verifier key', async () => {
+    vi.mocked(contractState.operation).mockReturnValue(new ContractOperation());
+
+    let thrown: unknown;
+    try {
+      await findDeployedContract(providers, { compiledContract, contractAddress });
+    } catch (error) {
+      thrown = error;
+    }
+
+    assert(thrown instanceof ContractTypeError);
+    expect(thrown.keylessCircuitIds).toEqual(['testCircuit']);
+    expect(thrown.contractAddress).toBe(contractAddress);
+    expect(providers.privateStateProvider.setSigningKey).not.toHaveBeenCalled();
+    expect(providers.privateStateProvider.set).not.toHaveBeenCalled();
   });
 });

--- a/packages/contracts/src/test/utils/ledger-utils.test.ts
+++ b/packages/contracts/src/test/utils/ledger-utils.test.ts
@@ -74,9 +74,8 @@ const emptyTranscript: PartitionedTranscript = [undefined, undefined];
 /**
  * A real, serialized verifier key. `createUnprovenLedgerCallTx` hashes each operation's verifier
  * key into the call's key location (see `ZKConfigRegistry`), and the `ContractOperation.verifierKey`
- * setter validates the bytes against the `midnight:verifier-key[v6]:` header — so fixtures cannot
- * use arbitrary bytes. We reuse a committed compiled key; its contents are irrelevant to these
- * tests (only that it is a valid, present key).
+ * setter rejects untagged bytes — so fixtures cannot use arbitrary bytes. We reuse a committed
+ * compiled key; its contents are irrelevant to these tests (only that it is a valid, present key).
  */
 const DUMMY_VERIFIER_KEY = new Uint8Array(
   readFileSync(new URL('../resources/compiled/shielded-map/keys/deposit.verifier', import.meta.url))

--- a/packages/contracts/src/test/verify-contract-state.test.ts
+++ b/packages/contracts/src/test/verify-contract-state.test.ts
@@ -1,0 +1,110 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ProvableCircuitId } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
+import { ContractOperation, ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
+import { createVerifierKey, type VerifierKey } from '@midnight-ntwrk/midnight-js-types';
+import { readFileSync } from 'fs';
+import { describe, expect, it } from 'vitest';
+
+import { ContractTypeError } from '../errors';
+import { verifyContractState } from '../find-deployed-contract';
+
+const CIRCUIT_ID = ProvableCircuitId('deposit');
+
+/**
+ * A real, serialized verifier key: the `ContractOperation.verifierKey` setter validates the bytes
+ * against the `midnight:verifier-key[v6]:` header, so a deployed key cannot be fabricated.
+ */
+const DEPLOYED_KEY = new Uint8Array(
+  readFileSync(new URL('./resources/compiled/shielded-map/keys/deposit.verifier', import.meta.url))
+);
+
+const stateWithKeylessOperation = (): ContractState => {
+  const state = new ContractState();
+  state.setOperation(CIRCUIT_ID, new ContractOperation());
+  return state;
+};
+
+const stateWithDeployedKey = (): ContractState => {
+  const state = new ContractState();
+  const operation = new ContractOperation();
+  operation.verifierKey = DEPLOYED_KEY;
+  state.setOperation(CIRCUIT_ID, operation);
+  return state;
+};
+
+const localKey = (bytes: Uint8Array): [typeof CIRCUIT_ID, VerifierKey][] => [[CIRCUIT_ID, createVerifierKey(bytes)]];
+
+describe('verifyContractState', () => {
+  it('accepts a state whose deployed key equals the local key', () => {
+    const state = stateWithDeployedKey();
+
+    expect(() => verifyContractState(localKey(DEPLOYED_KEY), state)).not.toThrow();
+  });
+
+  it('rejects a state whose deployed key differs from the local key', () => {
+    const state = stateWithDeployedKey();
+
+    expect(() => verifyContractState(localKey(new Uint8Array([1, 2, 3])), state)).toThrow(ContractTypeError);
+  });
+
+  it('rejects a state that registers no operation for the circuit', () => {
+    const state = new ContractState();
+
+    expect(() => verifyContractState(localKey(DEPLOYED_KEY), state)).toThrow(ContractTypeError);
+  });
+
+  // A registered operation can resolve while carrying no verifier key at all — the shape a
+  // constructor-built state has before a deploy fills it in, and one that survives a
+  // serialize/deserialize round trip. Reading `.verifierKey` unguarded dereferences `undefined`.
+  it('rejects a state whose operation resolves but carries no verifier key', () => {
+    const state = stateWithKeylessOperation();
+    expect(state.operation(CIRCUIT_ID)).toBeDefined();
+    expect(state.operation(CIRCUIT_ID)?.verifierKey).toBeUndefined();
+
+    let thrown: unknown;
+    try {
+      verifyContractState(localKey(DEPLOYED_KEY), state);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ContractTypeError);
+    expect((thrown as ContractTypeError).circuitIds).toEqual([CIRCUIT_ID]);
+  });
+
+  it('reports every circuit that fails to match, not just the first', () => {
+    const other = ProvableCircuitId('withdraw');
+    const state = stateWithKeylessOperation();
+    state.setOperation(other, new ContractOperation());
+
+    let thrown: unknown;
+    try {
+      verifyContractState(
+        [
+          [CIRCUIT_ID, createVerifierKey(DEPLOYED_KEY)],
+          [other, createVerifierKey(DEPLOYED_KEY)]
+        ],
+        state
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ContractTypeError);
+    expect((thrown as ContractTypeError).circuitIds.sort()).toEqual([CIRCUIT_ID, other].sort());
+  });
+});

--- a/packages/contracts/src/test/verify-contract-state.test.ts
+++ b/packages/contracts/src/test/verify-contract-state.test.ts
@@ -13,98 +13,268 @@
  * limitations under the License.
  */
 
+import { readFileSync } from 'node:fs';
+
 import { ProvableCircuitId } from '@midnight-ntwrk/midnight-js-protocol/compact-js/effect/Contract';
 import { ContractOperation, ContractState } from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import { createVerifierKey, type VerifierKey } from '@midnight-ntwrk/midnight-js-types';
-import { readFileSync } from 'fs';
 import { describe, expect, it } from 'vitest';
 
 import { ContractTypeError } from '../errors';
 import { verifyContractState } from '../find-deployed-contract';
 
 const CIRCUIT_ID = ProvableCircuitId('deposit');
+const OTHER_CIRCUIT_ID = ProvableCircuitId('withdraw');
 
 /**
- * A real, serialized verifier key: the `ContractOperation.verifierKey` setter validates the bytes
- * against the `midnight:verifier-key[v6]:` header, so a deployed key cannot be fabricated.
+ * A real, serialized verifier key, read from the committed compiled fixture. The
+ * `ContractOperation.verifierKey` setter rejects untagged bytes, so a deployed key cannot be an
+ * arbitrary `Uint8Array`.
  */
 const DEPLOYED_KEY = new Uint8Array(
   readFileSync(new URL('./resources/compiled/shielded-map/keys/deposit.verifier', import.meta.url))
 );
 
-const stateWithKeylessOperation = (): ContractState => {
-  const state = new ContractState();
-  state.setOperation(CIRCUIT_ID, new ContractOperation());
-  return state;
-};
+const keylessOperation = (): ContractOperation => new ContractOperation();
 
-const stateWithDeployedKey = (): ContractState => {
-  const state = new ContractState();
+const keyedOperation = (key: Uint8Array = DEPLOYED_KEY): ContractOperation => {
   const operation = new ContractOperation();
-  operation.verifierKey = DEPLOYED_KEY;
-  state.setOperation(CIRCUIT_ID, operation);
+  operation.verifierKey = key;
+  return operation;
+};
+
+const stateWith = (operations: [string, ContractOperation][]): ContractState => {
+  const state = new ContractState();
+  operations.forEach(([circuitId, operation]) => state.setOperation(circuitId, operation));
   return state;
 };
 
-const localKey = (bytes: Uint8Array): [typeof CIRCUIT_ID, VerifierKey][] => [[CIRCUIT_ID, createVerifierKey(bytes)]];
+const localKeys = (...entries: [string, Uint8Array][]): [ProvableCircuitId, VerifierKey][] =>
+  entries.map(([circuitId, bytes]) => [ProvableCircuitId(circuitId), createVerifierKey(bytes)]);
+
+const expectThrows = <E extends Error>(fn: () => unknown, ctor: new (...args: never[]) => E): E => {
+  try {
+    fn();
+  } catch (error) {
+    if (error instanceof ctor) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error(`expected ${ctor.name} to be thrown, but nothing was thrown`);
+};
 
 describe('verifyContractState', () => {
-  it('accepts a state whose deployed key equals the local key', () => {
-    const state = stateWithDeployedKey();
+  describe('states it accepts', () => {
+    it('should accept a state whose deployed key equals the local key', () => {
+      const state = stateWith([[CIRCUIT_ID, keyedOperation()]]);
 
-    expect(() => verifyContractState(localKey(DEPLOYED_KEY), state)).not.toThrow();
+      expect(() => verifyContractState(localKeys([CIRCUIT_ID, DEPLOYED_KEY]), state)).not.toThrow();
+    });
+
+    it('should accept any state when the client holds no verifier keys', () => {
+      expect(() => verifyContractState([], new ContractState())).not.toThrow();
+    });
   });
 
-  it('rejects a state whose deployed key differs from the local key', () => {
-    const state = stateWithDeployedKey();
+  describe('states it rejects', () => {
+    it('should reject a state whose deployed key differs from the local key', () => {
+      const state = stateWith([[CIRCUIT_ID, keyedOperation()]]);
 
-    expect(() => verifyContractState(localKey(new Uint8Array([1, 2, 3])), state)).toThrow(ContractTypeError);
-  });
-
-  it('rejects a state that registers no operation for the circuit', () => {
-    const state = new ContractState();
-
-    expect(() => verifyContractState(localKey(DEPLOYED_KEY), state)).toThrow(ContractTypeError);
-  });
-
-  // A registered operation can resolve while carrying no verifier key at all — the shape a
-  // constructor-built state has before a deploy fills it in, and one that survives a
-  // serialize/deserialize round trip. Reading `.verifierKey` unguarded dereferences `undefined`.
-  it('rejects a state whose operation resolves but carries no verifier key', () => {
-    const state = stateWithKeylessOperation();
-    expect(state.operation(CIRCUIT_ID)).toBeDefined();
-    expect(state.operation(CIRCUIT_ID)?.verifierKey).toBeUndefined();
-
-    let thrown: unknown;
-    try {
-      verifyContractState(localKey(DEPLOYED_KEY), state);
-    } catch (error) {
-      thrown = error;
-    }
-
-    expect(thrown).toBeInstanceOf(ContractTypeError);
-    expect((thrown as ContractTypeError).circuitIds).toEqual([CIRCUIT_ID]);
-  });
-
-  it('reports every circuit that fails to match, not just the first', () => {
-    const other = ProvableCircuitId('withdraw');
-    const state = stateWithKeylessOperation();
-    state.setOperation(other, new ContractOperation());
-
-    let thrown: unknown;
-    try {
-      verifyContractState(
-        [
-          [CIRCUIT_ID, createVerifierKey(DEPLOYED_KEY)],
-          [other, createVerifierKey(DEPLOYED_KEY)]
-        ],
-        state
+      const error = expectThrows(
+        () => verifyContractState(localKeys([CIRCUIT_ID, new Uint8Array([1, 2, 3])]), state),
+        ContractTypeError
       );
-    } catch (error) {
-      thrown = error;
-    }
 
-    expect(thrown).toBeInstanceOf(ContractTypeError);
-    expect((thrown as ContractTypeError).circuitIds.sort()).toEqual([CIRCUIT_ID, other].sort());
+      expect(error.mismatchedCircuitIds).toEqual([CIRCUIT_ID]);
+    });
+
+    // The local and deployed keys have equal length here, so `verifierKeysEqual`'s length
+    // short-circuit cannot decide the comparison and the byte-wise check has to run.
+    it('should reject a deployed key of the same length carrying different bytes', () => {
+      const tampered = new Uint8Array(DEPLOYED_KEY);
+      tampered[tampered.length - 1] ^= 0xff;
+      const state = stateWith([[CIRCUIT_ID, keyedOperation()]]);
+
+      const error = expectThrows(
+        () => verifyContractState(localKeys([CIRCUIT_ID, tampered]), state),
+        ContractTypeError
+      );
+
+      expect(error.mismatchedCircuitIds).toEqual([CIRCUIT_ID]);
+    });
+
+    it('should reject a state that registers no operation for the circuit', () => {
+      const error = expectThrows(
+        () => verifyContractState(localKeys([CIRCUIT_ID, DEPLOYED_KEY]), new ContractState()),
+        ContractTypeError
+      );
+
+      expect(error.missingCircuitIds).toEqual([CIRCUIT_ID]);
+    });
+
+    it('should reject a state whose operation resolves but carries no verifier key', () => {
+      const state = stateWith([[CIRCUIT_ID, keylessOperation()]]);
+      expect(state.operation(CIRCUIT_ID)).toBeDefined();
+      expect(state.operation(CIRCUIT_ID)?.verifierKey).toBeUndefined();
+
+      const error = expectThrows(
+        () => verifyContractState(localKeys([CIRCUIT_ID, DEPLOYED_KEY]), state),
+        ContractTypeError
+      );
+
+      expect(error.keylessCircuitIds).toEqual([CIRCUIT_ID]);
+    });
+
+    it('should reject an operation left keyless by a serialize/deserialize round trip', () => {
+      const roundTripped = ContractState.deserialize(stateWith([[CIRCUIT_ID, keylessOperation()]]).serialize());
+      expect(roundTripped.operation(CIRCUIT_ID)).toBeDefined();
+      expect(roundTripped.operation(CIRCUIT_ID)?.verifierKey).toBeUndefined();
+
+      const error = expectThrows(
+        () => verifyContractState(localKeys([CIRCUIT_ID, DEPLOYED_KEY]), roundTripped),
+        ContractTypeError
+      );
+
+      expect(error.keylessCircuitIds).toEqual([CIRCUIT_ID]);
+    });
+  });
+
+  describe('which circuits it reports', () => {
+    it('should report only the circuits that fail, leaving matching ones out', () => {
+      const state = stateWith([
+        [CIRCUIT_ID, keyedOperation()],
+        [OTHER_CIRCUIT_ID, keylessOperation()]
+      ]);
+
+      const error = expectThrows(
+        () => verifyContractState(localKeys([CIRCUIT_ID, DEPLOYED_KEY], [OTHER_CIRCUIT_ID, DEPLOYED_KEY]), state),
+        ContractTypeError
+      );
+
+      expect(error.circuitIds).toEqual([OTHER_CIRCUIT_ID]);
+      expect(error.keylessCircuitIds).toEqual([OTHER_CIRCUIT_ID]);
+      expect(error.mismatchedCircuitIds).toEqual([]);
+    });
+
+    it('should report every failing circuit in the order the local keys were given', () => {
+      const state = stateWith([
+        [CIRCUIT_ID, keylessOperation()],
+        [OTHER_CIRCUIT_ID, keylessOperation()]
+      ]);
+
+      const error = expectThrows(
+        () => verifyContractState(localKeys([CIRCUIT_ID, DEPLOYED_KEY], [OTHER_CIRCUIT_ID, DEPLOYED_KEY]), state),
+        ContractTypeError
+      );
+
+      expect(error.circuitIds).toEqual([CIRCUIT_ID, OTHER_CIRCUIT_ID]);
+    });
+
+    it('should sort each failing circuit into the condition that actually applies', () => {
+      const absent = ProvableCircuitId('transfer');
+      const state = stateWith([
+        [CIRCUIT_ID, keylessOperation()],
+        [OTHER_CIRCUIT_ID, keyedOperation()]
+      ]);
+
+      const error = expectThrows(
+        () =>
+          verifyContractState(
+            localKeys(
+              [CIRCUIT_ID, DEPLOYED_KEY],
+              [OTHER_CIRCUIT_ID, new Uint8Array([1, 2, 3])],
+              [absent, DEPLOYED_KEY]
+            ),
+            state
+          ),
+        ContractTypeError
+      );
+
+      expect(error.keylessCircuitIds).toEqual([CIRCUIT_ID]);
+      expect(error.mismatchedCircuitIds).toEqual([OTHER_CIRCUIT_ID]);
+      expect(error.missingCircuitIds).toEqual([absent]);
+    });
+  });
+
+  describe('the message it produces', () => {
+    const keylessError = (): ContractTypeError =>
+      expectThrows(
+        () => verifyContractState(localKeys([CIRCUIT_ID, DEPLOYED_KEY]), stateWith([[CIRCUIT_ID, keylessOperation()]])),
+        ContractTypeError
+      );
+
+    const mismatchError = (): ContractTypeError =>
+      expectThrows(
+        () =>
+          verifyContractState(
+            localKeys([CIRCUIT_ID, new Uint8Array([1, 2, 3])]),
+            stateWith([[CIRCUIT_ID, keyedOperation()]])
+          ),
+        ContractTypeError
+      );
+
+    // The deployed state renders a keyless operation exactly like a keyed one, so a message built
+    // only from the state dump reads identically for both conditions and sends the user after the
+    // wrong remediation.
+    it('should describe a keyless slot differently from a key mismatch', () => {
+      expect(keylessError().message).not.toEqual(mismatchError().message);
+    });
+
+    it('should tell the user that recompiling cannot fix a keyless slot', () => {
+      const message = keylessError().message;
+
+      expect(message).toContain(CIRCUIT_ID);
+      expect(message).toContain('no verifier key');
+      expect(message).not.toContain('differs from the local one');
+    });
+
+    it('should name a key mismatch as a differing key', () => {
+      const message = mismatchError().message;
+
+      expect(message).toContain(CIRCUIT_ID);
+      expect(message).toContain('differs from the local one');
+      expect(message).not.toContain('no verifier key');
+    });
+
+    it('should include the contract address when one is given', () => {
+      const error = expectThrows(
+        () =>
+          verifyContractState(
+            localKeys([CIRCUIT_ID, DEPLOYED_KEY]),
+            stateWith([[CIRCUIT_ID, keylessOperation()]]),
+            '0200deadbeef'
+          ),
+        ContractTypeError
+      );
+
+      expect(error.message).toContain('0200deadbeef');
+    });
+
+    it('should keep the message bounded when the deployed state is large', () => {
+      const operations: [string, ContractOperation][] = Array.from({ length: 200 }, (_, index) => [
+        `circuit_${index}`,
+        keyedOperation()
+      ]);
+
+      const error = expectThrows(
+        () => verifyContractState(localKeys([CIRCUIT_ID, DEPLOYED_KEY]), stateWith(operations)),
+        ContractTypeError
+      );
+
+      expect(error.message.length).toBeLessThan(4_000);
+      expect(error.message).toContain(CIRCUIT_ID);
+    });
+
+    it('should still carry the full state on the error when the message is truncated', () => {
+      const state = stateWith([[CIRCUIT_ID, keylessOperation()]]);
+
+      const error = expectThrows(
+        () => verifyContractState(localKeys([CIRCUIT_ID, DEPLOYED_KEY]), state),
+        ContractTypeError
+      );
+
+      expect(error.contractState).toBe(state);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #1270 (part 1).

`verifyContractState` guarded the *operation* being absent but read the deployed key unguarded, so a registered-but-keyless operation made `verifierKeysEqual` dereference `undefined.length` and throw a raw `TypeError` instead of the documented `ContractTypeError`.

Guarding the read is only half the fix. Folding the keyless case into the existing message made it **indistinguishable from a genuine key mismatch** — verified by rendering both:

```
MESSAGES IDENTICAL: true
Following operations: deposit, are undefined or have mismatched verifier keys for contract state ContractState (null{
    deposit: <verifier key>,      <-- rendered even though verifierKey === undefined
}ContractState )
```

`ContractState.toString` prints the `<verifier key>` placeholder for a slot that holds no key, so the message asserted a key was present when none was and pointed the user at "mismatched keys" — a condition they self-service by recompiling and re-fetching artifacts, none of which touches the real cause. That turns a loud library crash into a routine-looking user error. If the #1270 fork scenario materialises and every pre-fork contract reports an empty newer key slot, the old code fails loudly on the first one; a merged bucket would reject all of them while blaming the user.

So the three conditions are now partitioned and reported separately:

```
The contract at '0200abc123' is not the expected contract type.
  Registered on the deployed state but carrying no verifier key: deposit. The deployed state is
  incomplete, so recompiling the local contract will not resolve this.
Deployed state: ContractState (null{deposit: <verifier key>}ContractState )
```

`ContractTypeError` gains `missingCircuitIds` / `keylessCircuitIds` / `mismatchedCircuitIds` and keeps `circuitIds` as the union, so `instanceof` checks and the existing e2e assertions are unaffected.

### Also in this PR

- **Contract address in the message** — the most actionable field for a `findDeployedContract` failure, previously absent. Added as an optional third parameter to `verifyContractState`, threaded from `findDeployedContract`.
- **Bounded state dump** — measured at 6,527 chars for a 200-operation state, pretty-printed with newlines that fragment line-oriented logs. Now compact, capped at 2,000 chars, and wrapped so a render failure cannot destroy the error and take `circuitIds` with it.
- **Corrected `@throws` tags** on both `verifyContractState` and `findDeployedContract`; they still described only the mismatch case, and those tags are what TypeDoc renders.
- **Dropped a false comment claim.** Two test files stated the `ContractOperation.verifierKey` setter "validates the bytes against the `midnight:verifier-key[v6]:` header". Probing the setter directly: it accepts `[v6]` **and** `[v7]`, rejects `[v5]`/`[v8]`/untagged. `[v6]` is a property of the fixture, not of the runtime rule, and the fixture is regenerated by `run-compactc` — a compactc bump would silently falsify it.

### Correction to the issue as filed

1. **The "related, lower severity" item is not a reachable defect and is deliberately not fixed here.** A zero-length verifier key cannot be constructed through the setter *or* the deserializer, so `createUnprovenLedgerCallTx`'s existing `assertDefined(op.verifierKey, ...)` covers the only reachable case. A length guard would be speculative code.

2. **The error-type framing was loose.** `ContractTypeError extends TypeError`, so a consumer catching `TypeError` broadly caught the raw dereference too. What failed was `instanceof ContractTypeError`, and the raw error carried no `circuitIds` and no `contractState`.

3. **An earlier revision of this PR justified the merged bucket by citing `ContractTypeError`'s existing doc** ("circuits that are undefined, or have a verifier key mismatch"). That does not survive a literal read — a keyless circuit is neither. It is a third state the two-way split never contemplated, which is why it is now reported as its own condition. #1270 left this choice to the owner; this is the call.

### Still open, not in this PR

- **Part 2 of #1270** — *which* version's key should be compared at all. Needs a version-aware read the flat `ContractOperation.verifierKey` getter does not offer, plus confirmation from the ledger side. #1270 stays open.
- **The same conflation in the governance VK paths**, filed separately. `submit-remove-vk-tx.ts:78` guards registration rather than keyed-ness, so a keyless slot passes and the code proves, balances, and submits a remove-VK transaction with no key to remove. `submit-insert-vk-tx.ts:83` is the mirror and blocks the very remediation this PR's error points at.

## Test plan

- [x] Tests written first (TDD), verified they fail before the fix

  `packages/contracts/src/test/verify-contract-state.test.ts` — RED `12 failed | 4 passed (16)`, GREEN `16 passed (16)`. Uses a **real** `compact-runtime` `ContractState` and a committed verifier key rather than a mock, so it asserts against actual ledger behaviour.

  New coverage beyond the original revision: the byte-wise key comparison (the old mismatch test used a 3-byte key against a 2 KB one, so `verifierKeysEqual`'s length short-circuit meant `toHex` never ran — an implementation reduced to a length check would have passed); an empty verifier-key list; a mixed state where only some circuits fail; the serialize/deserialize round trip that makes a keyless slot reachable from indexer-supplied state; the message text itself, including that keyless and mismatch messages differ; and message bounding.

  `find-deployed-contract.test.ts` — the `ContractTypeError` path through the public entry point had **no** coverage; the mocks made a mismatch impossible by construction. Both throw paths now assert the error and that no signing key or private state is persisted.

- [x] All existing tests pass — full suite `27/27 packages`, `Cached: 0 cached, 27 total` (run with `--force`)
- [x] Lint clean (`yarn lint`), `tsc --noEmit` clean, build succeeds (`16/16`, `0 cached`)
