### PR TITLE
fix(midnight-js): let a migrated contract be called more than once

### DIFF
--- a/consumer-e2e/fork-matrix-entry.mjs
+++ b/consumer-e2e/fork-matrix-entry.mjs
@@ -396,7 +396,8 @@ const RETAINED_MATRIX = [
       label: 'round',
       read: (ledgerState) => BigInt(ledgerState.round),
       preFork: 1n,
-      postFork: 2n
+      postFork: 2n,
+      secondCall: 3n
     }
   },
   {
@@ -463,11 +464,27 @@ const RETAINED_MATRIX = [
     // surviving pre-fork write leaves TWO entries and a silently reset state
     // leaves one. Asserted by size rather than by key, so the hash does not have
     // to be recomputed here -- the count is what distinguishes the two outcomes.
+    // A THIRD nonce for the second post-fork call, and the reason is the same one that made
+    // `counters` the right field to read: the key is `persistentHash([mintNonce, domainSep])`, so
+    // reusing the post-fork nonce would overwrite that call's own entry and leave the size at 2
+    // whether the second call wrote or did nothing at all. A distinct nonce makes the size the
+    // thing that answers.
+    secondCall: {
+      circuitId: 'heavyCheckpointMintAndSend',
+      args: (context) => [
+        DOMAIN_SEPARATOR,
+        MINT_AMOUNT,
+        new Uint8Array(32).fill(97),
+        { bytes: context.coinPublicKey },
+        MINT_AMOUNT
+      ]
+    },
     state: {
       label: 'counters.size',
       read: (ledgerState) => BigInt(ledgerState.counters.size()),
       preFork: 1n,
-      postFork: 2n
+      postFork: 2n,
+      secondCall: 3n
     }
   },
   {
@@ -498,11 +515,22 @@ const RETAINED_MATRIX = [
     // `persistentHash([mintNonce, domainSep])`, and the nonce already differs
     // across the boundary (123 before, 122 after), so a surviving pre-fork write
     // leaves two entries where a reset leaves one.
+    secondCall: {
+      circuitId: 'mintWithUnshieldedFee',
+      args: (context) => [
+        DOMAIN_SEPARATOR,
+        MINT_AMOUNT,
+        new Uint8Array(32).fill(121),
+        { bytes: context.coinPublicKey },
+        FEE_AMOUNT
+      ]
+    },
     state: {
       label: 'counters.size',
       read: (ledgerState) => BigInt(ledgerState.counters.size()),
       preFork: 1n,
-      postFork: 2n
+      postFork: 2n,
+      secondCall: 3n
     }
   },
   {
@@ -650,27 +678,33 @@ const callRetained = async (label, key, providers, contractAddress, call, contex
  * callable, which a framework that silently reset the contract's state -- or
  * resolved the address to a fresh one -- would pass just as happily.
  *
- * The field is supplied by the matrix entry rather than fixed here: `simple`
- * has `round: Counter` and `shielded-fallible` has `counters: Map`, and the two
- * cover different things -- state across a trivial circuit, and state across the
- * heaviest one in the set. Contracts declaring no ledger block at all
- * (`unshielded`, `shielded`, `block-time`) cannot be read THIS way: what
- * survives for them is the contract's BALANCE, which `decodeContractState`
- * deliberately omits.
+ * The field is supplied by the matrix entry rather than fixed here. THREE twins
+ * declare one, deliberately at different weights: `simple` has `round: Counter`
+ * across a `noop`, and `shielded-fallible` and `fee-mint` have `counters: Map`
+ * across the partitioned checkpointed mints -- state across a trivial circuit,
+ * and state across the heaviest ones in the set.
  *
- * `unshielded` asserts its surviving state the OTHER way, now that the retained
- * arm answers with `private.result`: a post-fork call to
- * `getUnshieldedBalanceTest`, naming the colour its pre-fork mint captured,
- * returns the surviving balance directly. So the two mechanisms cover different
- * contract shapes: this one reads a declared ledger field (`simple`,
- * `shielded-fallible`, `fee-mint`), that one asks a circuit (`unshielded`).
+ * Each of the three is read at THREE phases: `preFork`, `postFork`, and
+ * `secondCall`. The third is what establishes that a migrated contract is
+ * callable more than once, and it is asserted the same way the first two are --
+ * by the field having moved again, not by the call having been admitted.
  *
- * `shielded` and `block-time` still assert nothing about surviving state, and
- * neither mechanism reaches them: both declare no ledger block, and neither has
- * a circuit that reads earlier state back -- `mintShieldedTokens` returns a new
- * coin and `testBlockTimeGte` answers about the block, not the contract. Closing
- * those two needs a circuit that does not exist in the source yet, so it is a
- * fixture change rather than a harness one.
+ * The other three twins (`unshielded`, `shielded`, `block-time`) declare no
+ * ledger block, so `checkLedgerState` returns `undefined` for them and asserts
+ * nothing about surviving state at any phase. What survives for them is the
+ * contract's BALANCE, which `decodeContractState` deliberately omits, and
+ * neither mechanism in this harness reaches it:
+ *
+ * - `unshielded`'s balance is readable only through a circuit, and a post-fork
+ *   retained call to `getUnshieldedBalanceTest` is REFUSED BY THE CHAIN -- see
+ *   that twin's own entry, which records the measurement and the untried
+ *   write-based alternative. Do not read this as coverage it does not have.
+ * - `shielded` and `block-time` have no circuit that reads earlier state back:
+ *   `mintShieldedTokens` returns a new coin and `testBlockTimeGte` answers about
+ *   the block, not the contract.
+ *
+ * Closing those three needs a circuit that does not exist in the source yet, so
+ * it is a fixture change rather than a harness one.
  */
 const readRetainedLedger = async (key, providers, contractAddress, read) => {
   const [{ ledger }, runtime, { utils }] = await Promise.all([
@@ -991,58 +1025,65 @@ for (const entry of RETAINED_MATRIX.filter((candidate) => covers(SELECTED.retain
 
 // ── (c2) a migrated contract, called a SECOND time ────────────────────────────
 //
-// A probe, not an assertion: the answer decides a product question about the
-// fork window and is not something the framework has committed to.
+// A LEG, not a probe, and it was a probe until the framework committed to an
+// answer. The keep-state leg above establishes that the FIRST post-fork call
+// succeeds and migrates the state envelope from the retained schema to the
+// current one; this establishes that the contract is still callable after that,
+// which is what makes keep-state a supported path rather than a single shot.
 //
-// The keep-state leg above establishes that the FIRST post-fork call succeeds
-// and migrates the state envelope from the retained schema to the current one.
-// What nothing had asked until now is whether the contract is callable after
-// that. This asks it, once per contract, with the same artifacts the successful
-// call used.
+// WHY THE SECOND CALL WORKS AT ALL, since the two facts look contradictory.
+// Migration rewrites the ENVELOPE but keeps the RETAINED verifier keys:
+// `reexpressOperationsForCurrentEra` copies `entryPoint.verifierKey` unchanged
+// into a ledger-v9 `ContractState`. Measured on the committed goldens rather
+// than assumed -- a real migrated 8-to-9 state carries byte-identical
+// `midnight:verifier-key[v6]:` keys, and the current-era decoder reads them. So
+// the contract holds current-era state over retained keys, and the retained
+// artifacts a consumer already has are still the right ones for it.
 //
-// What makes the answer matter rather than merely interesting: migration keeps
-// the RETAINED verifier keys. `reexpressOperationsForCurrentEra` copies
-// `entryPoint.verifierKey` unchanged into a ledger-v9 `ContractState`, so after
-// the boundary the contract holds current-era state over old keys. If the
-// retained arm refuses on the envelope and the current-era arm cannot be handed
-// a retained contract at all -- the two eras' contract shapes are deliberately
-// not interchangeable -- then a pre-fork contract is callable exactly once after
-// the fork, and that is a fork-window limit a consumer has to be told about
-// rather than discover.
+// `readLedger8Snapshot` therefore picks its decoder off the envelope instead of
+// pinning the retained era, and the KEY check decides whether the caller's
+// artifacts fit. Pinning the decoder is what made a pre-fork contract callable
+// exactly once, and this leg is what would catch that regressing.
 for (const entry of RETAINED_MATRIX.filter((candidate) => covers(SELECTED.retained, candidate.key))) {
-  await probe(`a migrated ${entry.key}, called a second time`, async () => {
+  const name = `a migrated ${entry.key}, called a second time`;
+  await leg(name, async () => {
     const deployed = retainedDeployments.get(entry.key);
     if (deployed === undefined) {
       return 'skipped: its pre-fork deploy did not complete';
     }
     const providers = retainedProvidersFor('v9', session.wallet, entry.key);
 
-    // Recorded before the attempt, so a refusal can be read against what the
-    // chain actually held rather than against an assumption about it.
+    // Recorded before the attempt, so the outcome can be read against what the
+    // chain actually held rather than against an assumption about it. This is
+    // the leg's own evidence that the first call migrated the envelope: it
+    // should already read current-era here.
     const before = await providers.publicDataProvider.queryRawContractState(deployed.contractAddress);
     const envelopeBefore = before === null ? 'absent' : envelopeTag(before.raw);
 
-    // The first post-fork call's own circuit and arguments, stripped of
-    // `capture` and `expect`: this probe is about whether the call is ADMITTED,
-    // and an assertion on its return value would turn an answer into a failure.
-    const [{ circuitId, args }] = [entry.postFork].flat();
+    // `secondCall` where the twin declares one, and the post-fork call's own
+    // circuit otherwise. A twin needs its own third call only when reusing the
+    // post-fork arguments would write to the same place twice and leave the
+    // ledger unable to tell a second write from none -- see `shielded-fallible`.
+    const call = entry.secondCall ?? entry.postFork;
+    // Re-read rather than reused: the wallet was rebuilt at the `post-fork head
+    // era` gate, and a key read off the stopped one would be stale.
     const context = { ...(retainedCaptures.get(entry.key) ?? {}), ...(await walletContext(session.wallet)) };
 
-    try {
-      const outcome = await callRetained(
-        `a migrated ${entry.key}, called a second time`,
-        entry.key,
-        providers,
-        deployed.contractAddress,
-        { circuitId, args },
-        context
-      );
-      return { envelopeBefore, retainedArm: 'accepted', ...outcome };
-    } catch (error) {
-      // The refusal IS the finding, so it is returned rather than rethrown --
-      // `probe` would otherwise colour the run's exit code with an answer.
-      return { envelopeBefore, retainedArm: `refused: ${describeError(error)}` };
-    }
+    // NOT caught. A refusal here is a defect now, not a finding, so it must
+    // colour the run's exit code -- which is the whole difference between this
+    // and the probe it replaced.
+    const outcome = await callRetained(name, entry.key, providers, deployed.contractAddress, call, context);
+
+    const after = await providers.publicDataProvider.queryRawContractState(deployed.contractAddress);
+    return {
+      envelopeBefore,
+      envelopeAfter: after === null ? 'absent' : envelopeTag(after.raw),
+      ...outcome,
+      // Where the twin can prove it, that the call was ADMITTED is not enough:
+      // the ledger field has to have moved again. Three of the six can, and for
+      // the other three this leg asserts admission only.
+      ...((await checkLedgerState(name, entry, 'secondCall', providers, deployed.contractAddress)) ?? {})
+    };
   });
 }
 

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -158,10 +158,16 @@ export class EraArtifactMismatchError extends Error {
  * An error indicating that the contract at this address is held on chain in a CURRENT-era state,
  * while the artifacts handed to this operation came from the retained Compact toolchain.
  *
- * The retained era stays supported for a contract whose state the retained ledger wrote — that
- * state keeps its own envelope across the fork, and reading it is the whole of keep-state. A
- * current-era envelope means this contract has been deployed, or re-deployed, with current-toolchain
- * artifacts, so the retained ones no longer describe it.
+ * The retained era stays supported for a contract whose state the retained ledger wrote, and it
+ * stays supported after that state has been MIGRATED: a contract's first post-fork call rewrites
+ * its envelope to the current era, and the ledger carries the retained verifier keys across
+ * unchanged. So a current-era envelope on its own says nothing about which toolchain built the
+ * contract, and this error is not raised for one.
+ *
+ * What raises it is the pair: a current-era envelope AND a key these artifacts cannot match. A
+ * migrated pre-fork contract still declares the keys the retained toolchain produced, so it does not
+ * reach here; a contract deployed with current-toolchain artifacts declares keys no retained
+ * artifact can match, and that is the case named here.
  *
  * Distinct from the era disagreements either side of it: nothing here is stale or inconsistent, and
  * a retry cannot change it. What has to change is which artifacts the caller passes.
@@ -171,14 +177,21 @@ export class RetainedArtifactOnCurrentEraStateError extends Error {
 
   /**
    * @param contractAddress The contract whose on-chain state was read.
+   * @param options Carries the key-mismatch this refusal re-reports on `cause`, so the byte-level
+   * diagnosis is not lost behind the era-level one.
    */
-  constructor(readonly contractAddress: string) {
+  constructor(
+    readonly contractAddress: string,
+    options?: ErrorOptions
+  ) {
     super(
-      `The contract at '${contractAddress}' is held on chain in a current-era state, but this operation ` +
-        `was given artifacts produced by the retained Compact toolchain, which cannot read it. A contract ` +
-        `deployed before the fork keeps its retained-era state across it, so a current-era state means this ` +
-        `contract was deployed with current-toolchain artifacts. Re-run the operation with the artifacts the ` +
-        `current toolchain produced for it. Retrying with the same artifacts cannot succeed.`
+      `The contract at '${contractAddress}' is held on chain in a current-era state whose verifier key ` +
+        `for this circuit is not the one the supplied artifacts carry, so those artifacts do not describe ` +
+        `this contract. A contract deployed before the fork keeps its retained keys even after a post-fork ` +
+        `call migrates its state, so this is not that case: it is a contract built with current-toolchain ` +
+        `artifacts. Re-run the operation with the artifacts the current toolchain produced for it. Retrying ` +
+        `with the same artifacts cannot succeed.`,
+      options
     );
     this.name = 'RetainedArtifactOnCurrentEraStateError';
   }

--- a/packages/contracts/src/internal/era.ts
+++ b/packages/contracts/src/internal/era.ts
@@ -37,9 +37,7 @@ import {
   type EraSeam,
   HeadStateEraMismatchError,
   IndexerInconsistencyError,
-  Ledger8DeployOnV9Error,
-  RetainedArtifactOnCurrentEraStateError
-} from '../errors';
+  Ledger8DeployOnV9Error} from '../errors';
 import type { Ledger8Contract } from '../ledger8-contract';
 import { type BreadcrumbSink, emitEncoding, emitHeadResolution } from './breadcrumbs';
 
@@ -200,7 +198,7 @@ export interface HeadEraReading {
 }
 
 /**
- * The one read {@link resolveOperationEra} and {@link assertRetainedStateEnvelope} make on the
+ * The one read {@link resolveOperationEra} and {@link resolveContractStateEra} make on the
  * public data provider.
  *
  * Declared as a `Pick` of the real provider rather than as the whole interface: a full
@@ -427,8 +425,8 @@ export const assertEraCompatible = (pipeline: PipelineEra, head: LedgerVersion, 
 };
 
 /**
- * Refuses a retained-era operation whose fetched contract state is not one the retained ledger
- * wrote.
+ * Resolves WHICH era's decoder may be handed a fetched contract state, refusing only the
+ * combination that cannot describe one chain.
  *
  * THE RULE THIS ENFORCES: the envelope decides, the block bounds. The two signals are not
  * symmetric and must not be compared for equality.
@@ -463,24 +461,22 @@ export const assertEraCompatible = (pipeline: PipelineEra, head: LedgerVersion, 
  *
  * @param head The era the operation resolved from the network head.
  * @param state The raw contract state the operation fetched, envelope included.
- * @param contractAddress The contract the state was read for, named in the graduation error.
  * @param pdp The read surface, for the fresh head read the impossible case needs.
  * @param logger The optional logger the encoding and re-read breadcrumbs are written to.
+ * @returns The era whose decoder owns these bytes: `'v8'` for a retained envelope, `'v9'` for a
+ * current-era one.
  * @throws TagParseError if `state.raw` carries no supported contract-state envelope.
- * @throws RetainedArtifactOnCurrentEraStateError if the chain holds this contract in a current-era
- * state, which retained artifacts cannot read.
  * @throws Error, carrying the transport failure on `cause`, if the fresh head read rejects — so the
  * disagreement that was under investigation is not lost behind a bare transport error.
  * @throws HeadStateEraMismatchError if a fresh head read agrees with the state's era.
  * @throws IndexerInconsistencyError if a fresh head read still disagrees with it.
  */
-export const assertRetainedStateEnvelope = async (
+export const resolveContractStateEra = async (
   head: LedgerVersion,
   state: RawContractState,
-  contractAddress: string,
   pdp: HeadVersionSource,
   logger?: BreadcrumbSink
-): Promise<void> => {
+): Promise<LedgerVersion> => {
   // NOT breadcrumbed when this THROWS. `contractStateEnvelopeVersion` refuses
   // an envelope it cannot parse, and the encoding breadcrumb's only field is
   // the era the tag declared -- so on that path there is no era to report and
@@ -496,18 +492,25 @@ export const assertRetainedStateEnvelope = async (
   // read -- under EITHER head. Pre-fork this is a native call; post-fork it is
   // keep-state. Both are ordinary, and neither involves the head.
   if (stateEra === 'v8') {
-    return;
+    return stateEra;
   }
 
-  // From here the state carries a CURRENT-era envelope, which the retained
-  // pipeline cannot read whatever the head says.
+  // From here the state carries a CURRENT-era envelope.
   //
-  // Under a post-fork head that is not a disagreement at all: the chain simply
-  // holds this contract in a current-era state, so the caller brought the wrong
-  // artifacts. Reporting it as a head/state conflict would send a reader after
-  // the read surface for a fault that is entirely in the request.
+  // Under a post-fork head that is ORDINARY, and it is what makes keep-state
+  // more than a single call: the first post-fork call migrates the contract's
+  // envelope from retained to current-era, and the ledger carries the retained
+  // VERIFIER KEYS across unchanged. So the bytes are the current decoder's to
+  // read while the artifacts that fit the contract are still the retained ones.
+  //
+  // The envelope answers ONE question -- which decoder may read these bytes --
+  // and it is not the question of whether the caller's artifacts fit this
+  // contract. Refusing here answered the second question with the first, and
+  // cost every call after a contract's first post-fork one. The key check does
+  // answer it, against the keys this state actually declares; see
+  // `assertSnapshotVerifierKey`.
   if (head === 'v9') {
-    throw new RetainedArtifactOnCurrentEraStateError(contractAddress);
+    return stateEra;
   }
 
   // Under a PRE-fork head a current-era envelope is impossible: the envelope is

--- a/packages/contracts/src/internal/ledger8-entry.ts
+++ b/packages/contracts/src/internal/ledger8-entry.ts
@@ -766,13 +766,21 @@ export const findLedger8Contract = async (
   // and half against another.
   const snapshot = await readLedger8Snapshot(
     retainedEra,
+    // `resolved.era`, not a second `loadLedgerEra`: the facade bound to this head was acquired at
+    // the operation's start, and acquiring one is a lazy WASM load.
+    resolved.era,
     resolved.head,
     providers.publicDataProvider,
     request.contractAddress,
     providers.loggerProvider
   );
   for (const circuitId of request.circuitIds) {
-    assertSnapshotVerifierKey(snapshot, circuitId, await providers.zkConfigProvider.getVerifierKey(circuitId));
+    assertSnapshotVerifierKey(
+      snapshot,
+      circuitId,
+      await providers.zkConfigProvider.getVerifierKey(circuitId),
+      request.contractAddress
+    );
   }
 
   return { deployTxData: await providers.publicDataProvider.watchForDeployTxData(request.contractAddress) };

--- a/packages/contracts/src/internal/ledger8-pipeline.ts
+++ b/packages/contracts/src/internal/ledger8-pipeline.ts
@@ -46,7 +46,9 @@ import {
   Ledger8AmbiguousEntryPointError,
   Ledger8RecipientUnmappableError,
   Ledger8ShieldedSpendUnsupportedError,
-  LedgerParametersUnservedError
+  LedgerParametersUnservedError,
+  RetainedArtifactOnCurrentEraStateError,
+  VerifierKeyMismatchError
 } from '../errors';
 import type { Ledger8ContractCall } from '../ledger8-contract';
 import {
@@ -58,7 +60,7 @@ import {
   zswapStateToSegmentedOffer
 } from '../utils/zswap-utils';
 import type { BreadcrumbSink } from './breadcrumbs';
-import { assertRetainedStateEnvelope } from './era';
+import { resolveContractStateEra } from './era';
 import { assertVerifierKeyMatches } from './verifier-key';
 
 /**
@@ -231,6 +233,15 @@ export interface Ledger8Snapshot {
   readonly encoded: EncodedStateValue;
   /** The entry points the state declares, with the key registered against each. */
   readonly decoded: ContractStatePojo;
+  /**
+   * The era whose decoder read {@link Ledger8Snapshot.state}, decided by its envelope.
+   *
+   * `'v9'` means the contract has already been migrated by an earlier post-fork call, which is what
+   * lets the key check tell a migrated contract apart from one deployed with current-toolchain
+   * artifacts. Both carry a current-era envelope; only the second carries keys these artifacts
+   * cannot match.
+   */
+  readonly stateEra: LedgerVersion;
 }
 
 /**
@@ -259,6 +270,7 @@ export interface Ledger8Snapshot {
  */
 export const readLedger8Snapshot = async (
   retainedEra: LedgerEra,
+  headEra: LedgerEra,
   head: LedgerVersion,
   pdp: Ledger8PipelineReadSurface,
   contractAddress: string,
@@ -267,17 +279,23 @@ export const readLedger8Snapshot = async (
   const state = await pdp.queryRawContractState(contractAddress);
   assertDefined(state, `No contract deployed at contract address '${contractAddress}'`);
 
-  await assertRetainedStateEnvelope(head, state, contractAddress, pdp, logger);
+  const stateEra = await resolveContractStateEra(head, state, pdp, logger);
 
-  // Read with the RETAINED era, never with the head's. The check above has just
-  // established that the retained ledger wrote these bytes, and it is the only
-  // ledger that can read them -- post-fork included, because the fork does not
-  // rewrite a contract's stored state. Handing them to the head's era is what
-  // made keep-state impossible.
-  const encoded = retainedEra.extractState(state.raw);
-  const decoded = retainedEra.decodeContractState(state.raw);
+  // Read with the era the ENVELOPE names, never with the head's and never with
+  // a fixed one. A retained envelope is the retained ledger's to read -- pre-
+  // fork natively, post-fork as keep-state, because the fork does not rewrite a
+  // contract's stored state. A current-era envelope belongs to the head's era,
+  // and post-fork it is what a contract looks like once an earlier call has
+  // migrated it; its retained verifier keys survive that migration unchanged,
+  // so this pipeline is still the right one to run it.
+  //
+  // Pinning this to the retained era is what made a migrated contract callable
+  // exactly once.
+  const reader = stateEra === 'v8' ? retainedEra : headEra;
+  const encoded = reader.extractState(state.raw);
+  const decoded = reader.decodeContractState(state.raw);
 
-  return { state, encoded, decoded };
+  return { state, encoded, decoded, stateEra };
 };
 
 /**
@@ -295,21 +313,40 @@ export const readLedger8Snapshot = async (
  * @param snapshot The one snapshot this operation read.
  * @param circuitId The entry point to check.
  * @param localVerifierKey The key compiled beside the local artifact.
+ * @param contractAddress The contract being operated on, named in the era-level refusal.
  * @throws Ledger8AmbiguousEntryPointError if the state declares the name twice.
  * @throws BlankVerifierKeySlotError if the chain declares no key for it.
- * @throws VerifierKeyMismatchError if the two keys differ byte for byte.
+ * @throws RetainedArtifactOnCurrentEraStateError if the keys differ byte for byte AND the state
+ * carries a current-era envelope, which together mean the contract was built with current-toolchain
+ * artifacts — carrying the byte-level mismatch on `cause`.
+ * @throws VerifierKeyMismatchError if the two keys differ byte for byte on a retained-era state.
  * @see {@link VerificationPath} for what this check buys.
  */
 export const assertSnapshotVerifierKey = (
   snapshot: Ledger8Snapshot,
   circuitId: string,
-  localVerifierKey: Uint8Array
+  localVerifierKey: Uint8Array,
+  contractAddress: string
 ): void => {
   const matches = snapshot.decoded.entryPoints.filter((candidate) => candidate.circuitId === circuitId);
   if (matches.length > 1) {
     throw new Ledger8AmbiguousEntryPointError(circuitId, matches.length);
   }
-  assertVerifierKeyMatches(localVerifierKey, matches[0]?.verifierKey, circuitId);
+  try {
+    assertVerifierKeyMatches(localVerifierKey, matches[0]?.verifierKey, circuitId);
+  } catch (cause) {
+    // A key mismatch on a CURRENT-era state has one likely cause worth naming: the contract was
+    // deployed with current-toolchain artifacts, so no retained artifact can ever match it and a
+    // retry is pointless. On a retained-era state the same mismatch means something else entirely
+    // -- the wrong build of the right contract -- so the generic refusal is the accurate one there.
+    //
+    // Only the MISMATCH is re-reported. A blank slot is left alone: it says the chain declares no
+    // key for this circuit at all, which is not an era statement.
+    if (snapshot.stateEra === 'v9' && cause instanceof VerifierKeyMismatchError) {
+      throw new RetainedArtifactOnCurrentEraStateError(contractAddress, { cause });
+    }
+    throw cause;
+  }
 };
 
 /**
@@ -513,6 +550,7 @@ export const runLedger8CallPipeline = async <TState>(
 
   const snapshot = await readLedger8Snapshot(
     retainedEra,
+    era,
     head,
     publicDataProvider,
     contractAddress,
@@ -531,7 +569,7 @@ export const runLedger8CallPipeline = async <TState>(
   // BEFORE proving, and before the circuit runs: a proof generated against a
   // key the chain does not hold is rejected on submission, so checking here
   // turns a paid-for, late failure into a free, immediate one.
-  assertSnapshotVerifierKey(snapshot, circuitId, request.localVerifierKey);
+  assertSnapshotVerifierKey(snapshot, circuitId, request.localVerifierKey, contractAddress);
 
   const downConverted = engine.downConvertForExecution(snapshot.encoded);
   const transcript = engine.executeCircuit({

--- a/packages/contracts/src/test/breadcrumbs.test.ts
+++ b/packages/contracts/src/test/breadcrumbs.test.ts
@@ -57,7 +57,7 @@ import {
 } from '../errors';
 import type { DispatchBreadcrumb, HeadReadingProvenance } from '../internal/breadcrumbs';
 import { DISPATCH_BREADCRUMB_MESSAGE, emitEncoding, emitHeadResolution, emitPipelineSelection } from '../internal/breadcrumbs';
-import { assertRetainedStateEnvelope, type PipelineEra, resolveOperationEra } from '../internal/era';
+import { type PipelineEra, resolveContractStateEra, resolveOperationEra } from '../internal/era';
 import { acquireLedger8Runtime, findLedger8Contract } from '../internal/ledger8-entry';
 import { handleSubmitRejection } from '../internal/stale-head';
 import { resolveScopeEra } from '../internal/transaction';
@@ -500,7 +500,6 @@ describe('pipeline selection pairs the artifact pipeline with the head era', () 
   });
 });
 
-const ADDRESS = '0'.repeat(64);
 
 describe('the encoding breadcrumb dates the fetched state from its envelope tag', () => {
   const v8Envelope = readHexFixture('state-v8.hex');
@@ -509,7 +508,7 @@ describe('the encoding breadcrumb dates the fetched state from its envelope tag'
   it('reports the envelope era on an agreeing head, carrying none of the state bytes', async () => {
     const sink = createSink();
 
-    await assertRetainedStateEnvelope('v8', rawState(v8Envelope, V8_HEAD, 'v8'), ADDRESS, headSource(), sink);
+    await resolveContractStateEra('v8', rawState(v8Envelope, V8_HEAD, 'v8'), headSource(), sink);
 
     const [breadcrumb] = emitted(sink);
     expect(breadcrumb).toBeDefined();
@@ -532,7 +531,7 @@ describe('the encoding breadcrumb dates the fetched state from its envelope tag'
     // is what tells an operator which decoder the bytes went to.
     const sink = createSink();
 
-    await assertRetainedStateEnvelope('v9', rawState(v8Envelope, V9_HEAD, 'v9'), ADDRESS, headSource(), sink);
+    await resolveContractStateEra('v9', rawState(v8Envelope, V9_HEAD, 'v9'), headSource(), sink);
 
     expect(emitted(sink)[0]).toStrictEqual({
       decision: 'encoding',
@@ -549,7 +548,7 @@ describe('the encoding breadcrumb dates the fetched state from its envelope tag'
     const sink = createSink();
 
     await expect(
-      assertRetainedStateEnvelope('v8', rawState(v9Envelope, V8_HEAD, 'v8'), ADDRESS, headSource(V9_HEAD), sink)
+      resolveContractStateEra('v8', rawState(v9Envelope, V8_HEAD, 'v8'), headSource(V9_HEAD), sink)
     ).rejects.toThrow(HeadStateEraMismatchError);
 
     expect(emitted(sink)).toStrictEqual([
@@ -568,7 +567,7 @@ describe('the encoding breadcrumb dates the fetched state from its envelope tag'
     const sink = createSink();
 
     await expect(
-      assertRetainedStateEnvelope('v8', rawState(v9Envelope, V9_HEAD, 'v9'), ADDRESS, headSource(V8_HEAD), sink)
+      resolveContractStateEra('v8', rawState(v9Envelope, V9_HEAD, 'v9'), headSource(V8_HEAD), sink)
     ).rejects.toThrow(IndexerInconsistencyError);
 
     expect(emitted(sink)).toStrictEqual([
@@ -587,7 +586,7 @@ describe('the encoding breadcrumb dates the fetched state from its envelope tag'
     const sink = createSink();
     const pdp = headSource();
 
-    await assertRetainedStateEnvelope('v9', rawState(v8Envelope, V9_HEAD_MINOR_BUMP, 'v9'), ADDRESS, pdp, sink);
+    await resolveContractStateEra('v9', rawState(v8Envelope, V9_HEAD_MINOR_BUMP, 'v9'), pdp, sink);
 
     expect(pdp.queryLatestProtocolVersion).not.toHaveBeenCalled();
     expect(emitted(sink).map((breadcrumb) => breadcrumb.decision)).toEqual(['encoding']);
@@ -608,7 +607,7 @@ describe('no breadcrumb carries a payload, a key or decoded state', () => {
     // One breadcrumb of every kind, produced by real code paths rather than
     // hand-built, so this gate is over what actually ships.
     await acquireLedger8Runtime(headSource(V8_HEAD), 'call', { logger: sink, contractAddress: CONTRACT_ADDRESS });
-    await assertRetainedStateEnvelope('v8', rawState(v8Envelope, V8_HEAD, 'v8'), ADDRESS, headSource(), sink);
+    await resolveContractStateEra('v8', rawState(v8Envelope, V8_HEAD, 'v8'), headSource(), sink);
     breadcrumbs = emitted(sink);
   });
 
@@ -841,7 +840,7 @@ describe('a faulty logger cannot fail an operation that otherwise succeeds', () 
     const v9Envelope = readHexFixture('state-migrated-v9.hex');
 
     await expect(
-      assertRetainedStateEnvelope('v8', rawState(v9Envelope, V8_HEAD, 'v8'), ADDRESS, headSource(V9_HEAD), sink)
+      resolveContractStateEra('v8', rawState(v9Envelope, V8_HEAD, 'v8'), headSource(V9_HEAD), sink)
     ).rejects.toThrow(HeadStateEraMismatchError);
   });
 });

--- a/packages/contracts/src/test/era-dispatch.test.ts
+++ b/packages/contracts/src/test/era-dispatch.test.ts
@@ -26,13 +26,12 @@ import {
   EraArtifactMismatchError,
   HeadStateEraMismatchError,
   IndexerInconsistencyError,
-  Ledger8DeployOnV9Error,
-  RetainedArtifactOnCurrentEraStateError} from '../errors';
+  Ledger8DeployOnV9Error} from '../errors';
 import {
   assertEraCompatible,
-  assertRetainedStateEnvelope,
   type PipelineEra,
   pipelineEraOf,
+  resolveContractStateEra,
   resolveOperationEra
 } from '../internal/era';
 import { NEITHER_ERA_CONTRACT_MESSAGE } from '../ledger8-contract';
@@ -362,42 +361,40 @@ describe('resolveOperationEra: the head is read ONCE per operation and threaded 
   });
 });
 
-describe('assertRetainedStateEnvelope: the retained pipeline reads only what the retained ledger wrote', () => {
+describe("resolveContractStateEra: which era's decoder owns the bytes an operation fetched", () => {
   const v8Envelope = readHexFixture('state-v8.hex');
   const v9Envelope = readHexFixture('state-migrated-v9.hex');
   // A real v9 envelope whose BODY is corrupt (one payload byte XORed past the header). Any decode
   // of these bytes throws; this fixture is how the "tag check happens before any decode" claim is
   // made observable rather than asserted.
   const v9EnvelopeCorruptBody = readHexFixture('state-tampered-bytes.hex');
-  const ADDRESS = '0'.repeat(64);
 
-  // THE RULE: the envelope decides, the block bounds. A retained envelope is accepted under EITHER
-  // head, because the fork does not rewrite a contract's stored state -- so a contract deployed
-  // before it is served with retained bytes under a post-fork head, indefinitely. Only an envelope
-  // NEWER than the block dating it is impossible, and only that is investigated.
+  // THE RULE: the envelope decides, the block bounds. A retained envelope is answered for under
+  // EITHER head, because the fork does not rewrite a contract's stored state -- so a contract
+  // deployed before it is served with retained bytes under a post-fork head, indefinitely. Only an
+  // envelope NEWER than the block dating it is impossible, and only that is investigated.
+  //
+  // What this function does NOT decide is whether the caller's artifacts fit the contract. It names
+  // a decoder; `assertSnapshotVerifierKey` judges the artifacts.
   it.each([
     ['a pre-fork head, which is a native retained call', 'v8' as LedgerVersion, V8_HEAD],
     ['a post-fork head, which is keep-state', 'v9' as LedgerVersion, V9_HEAD]
-  ])('accepts a retained envelope under %s, without re-reading the head', async (_name, head, headInt) => {
+  ])('answers the retained era for a retained envelope under %s, without re-reading the head', async (_name, head, headInt) => {
     const pdp = headSource();
 
-    await expect(
-      assertRetainedStateEnvelope(head, rawState(v8Envelope, headInt, head), ADDRESS, pdp)
-    ).resolves.toBeUndefined();
+    await expect(resolveContractStateEra(head, rawState(v8Envelope, headInt, head), pdp)).resolves.toBe('v8');
 
     // No re-read at all: the head plays no part in accepting a retained envelope, so there is
     // nothing to disambiguate.
     expect(pdp.queryLatestProtocolVersion).not.toHaveBeenCalled();
   });
 
-  it('accepts a retained envelope whatever the head INTEGER is, since the head is not compared', async () => {
+  it('answers the retained era whatever the head INTEGER is, since the head is not compared', async () => {
     const pdp = headSource();
 
     // A same-era minor node bump, and a different era entirely, reach the same answer.
     for (const headInt of [V8_HEAD, 1_000_001, V9_HEAD, 2_001_000]) {
-      await expect(
-        assertRetainedStateEnvelope('v9', rawState(v8Envelope, headInt, 'v9'), ADDRESS, pdp)
-      ).resolves.toBeUndefined();
+      await expect(resolveContractStateEra('v9', rawState(v8Envelope, headInt, 'v9'), pdp)).resolves.toBe('v8');
     }
 
     expect(pdp.queryLatestProtocolVersion).not.toHaveBeenCalled();
@@ -406,31 +403,22 @@ describe('assertRetainedStateEnvelope: the retained pipeline reads only what the
   it('reads the envelope tag BEFORE any decode, so a corrupt body never reaches a decoder', async () => {
     const pdp = headSource();
 
-    // These bytes cannot be decoded by either era. The refusal names the era of the TAG, which is
-    // only possible if the tag was read and the body was not: a decode would have raised a decode
-    // failure instead.
-    await expect(
-      assertRetainedStateEnvelope('v9', rawState(v9EnvelopeCorruptBody, V9_HEAD, 'v9'), ADDRESS, pdp)
-    ).rejects.toThrow(RetainedArtifactOnCurrentEraStateError);
+    // These bytes cannot be decoded by either era. The answer still names the era of the TAG, which
+    // is only possible if the tag was read and the body was not: a decode would have raised a decode
+    // failure instead of returning.
+    await expect(resolveContractStateEra('v9', rawState(v9EnvelopeCorruptBody, V9_HEAD, 'v9'), pdp)).resolves.toBe(
+      'v9'
+    );
   });
 
-  it('refuses a current-era state under a post-fork head as an ARTIFACT problem, not a read-surface one', async () => {
-    // The contract has been deployed with current-toolchain artifacts, so the retained ones no
-    // longer describe it. Nothing is stale and nothing is inconsistent -- a retry cannot help, and
-    // blaming the indexer would send a reader after the wrong thing.
+  it('answers the CURRENT era for a migrated state under a post-fork head, rather than refusing it', async () => {
+    // The fixture is a real ledger-8-to-9 migrated state: current-era envelope, retained verifier
+    // keys. Refusing it here is what made a pre-fork contract callable exactly once after the fork.
+    // Whether the caller's artifacts fit it is a question about the KEYS, and it is asked elsewhere.
     const pdp = headSource();
 
-    try {
-      await assertRetainedStateEnvelope('v9', rawState(v9Envelope, V9_HEAD, 'v9'), ADDRESS, pdp);
-      expect.unreachable('a current-era state was accepted by the retained pipeline');
-    } catch (error) {
-      expect(error).toBeInstanceOf(RetainedArtifactOnCurrentEraStateError);
-      expect(hasErrorCode(error, CONTRACTS_ERROR_CODES.RETAINED_ARTIFACT_ON_CURRENT_ERA_STATE)).toBe(true);
-      expect((error as RetainedArtifactOnCurrentEraStateError).contractAddress).toBe(ADDRESS);
-      // Explicitly NOT retry advice, and explicitly not the indexer's fault.
-      expect((error as RetainedArtifactOnCurrentEraStateError).message).toMatch(/cannot succeed/i);
-      expect((error as RetainedArtifactOnCurrentEraStateError).message).not.toMatch(/indexer/i);
-    }
+    await expect(resolveContractStateEra('v9', rawState(v9Envelope, V9_HEAD, 'v9'), pdp)).resolves.toBe('v9');
+
     // No re-read: the head is not in question here.
     expect(pdp.queryLatestProtocolVersion).not.toHaveBeenCalled();
   });
@@ -442,7 +430,7 @@ describe('assertRetainedStateEnvelope: the retained pipeline reads only what the
     const pdp = headSource(V9_HEAD);
 
     try {
-      await assertRetainedStateEnvelope('v8', rawState(v9Envelope, V8_HEAD, 'v8'), ADDRESS, pdp);
+      await resolveContractStateEra('v8', rawState(v9Envelope, V8_HEAD, 'v8'), pdp);
       expect.unreachable('a stale pre-fork head was accepted against a current-era state');
     } catch (error) {
       expect(error).toBeInstanceOf(HeadStateEraMismatchError);
@@ -463,7 +451,7 @@ describe('assertRetainedStateEnvelope: the retained pipeline reads only what the
     const pdp = headSource(V8_HEAD);
 
     try {
-      await assertRetainedStateEnvelope('v8', rawState(v9Envelope, V8_HEAD, 'v8'), ADDRESS, pdp);
+      await resolveContractStateEra('v8', rawState(v9Envelope, V8_HEAD, 'v8'), pdp);
       expect.unreachable('an inconsistent indexer response was accepted');
     } catch (error) {
       expect(error).toBeInstanceOf(IndexerInconsistencyError);
@@ -482,7 +470,7 @@ describe('assertRetainedStateEnvelope: the retained pipeline reads only what the
     const pdp = rejectingHeadSource(transportFailure);
 
     try {
-      await assertRetainedStateEnvelope('v8', rawState(v9Envelope, V8_HEAD, 'v8'), ADDRESS, pdp);
+      await resolveContractStateEra('v8', rawState(v9Envelope, V8_HEAD, 'v8'), pdp);
       expect.unreachable('a failed fresh head read was treated as agreement');
     } catch (error) {
       expect(error).toBeInstanceOf(Error);
@@ -505,7 +493,7 @@ describe('assertRetainedStateEnvelope: the retained pipeline reads only what the
     const pdp = headSource();
 
     await expect(
-      assertRetainedStateEnvelope('v9', rawState(verifierKey, V9_HEAD, 'v9'), ADDRESS, pdp)
+      resolveContractStateEra('v9', rawState(verifierKey, V9_HEAD, 'v9'), pdp)
     ).rejects.toThrow(TagParseError);
   });
 });

--- a/packages/contracts/src/test/keep-state.test.ts
+++ b/packages/contracts/src/test/keep-state.test.ts
@@ -484,17 +484,51 @@ describe('the keep-state pipeline (previous-toolchain contract, post-fork head)'
     expect(providers.proofProvider.proveTx).not.toHaveBeenCalled();
   });
 
-  it('refuses a current-era state even when the record mislabels itself as retained', async () => {
+  it('reads a current-era envelope with the CURRENT decoder even when the record mislabels itself as retained', async () => {
     // The mirror, and the one a label-based route would get wrong in the
     // dangerous direction: the label AGREES with the retained pipeline while
     // the bytes are current-era. Routing on the label would hand current-era
-    // bytes to the retained decoder.
+    // bytes to the retained decoder, which refuses them on the envelope tag.
+    // The envelope decides which decoder may read the bytes; it does not decide
+    // whether the caller's artifacts fit the contract.
     const providers = postForkProviders(v6Envelope);
-    providers.publicDataProvider.queryRawContractState = vi.fn().mockResolvedValue({
-      version: 'v8',
-      protocolVersion: POST_FORK_PROTOCOL_VERSION,
-      raw: v9Envelope
-    });
+    providers.publicDataProvider.queryRawContractState = vi
+      .fn()
+      .mockResolvedValue({ ...rawState(v9Envelope, POST_FORK_PROTOCOL_VERSION), version: 'v8' });
+
+    await expect(submitCallTx(providers, callOptions())).resolves.toBeDefined();
+  });
+
+  it('calls a MIGRATED contract again, whose state is current-era but whose keys are still retained', async () => {
+    // The second post-fork call, which is the whole point of keep-state being
+    // more than one shot. The first call migrated the envelope from retained to
+    // current-era; the ledger copies the retained verifier keys across
+    // unchanged, so the caller's retained artifacts are still the right ones
+    // for this contract. Measured on the committed goldens: a real migrated
+    // 8-to-9 state carries the SAME `midnight:verifier-key[v6]:` bytes its
+    // pre-migration form did, and the current-era decoder reads them.
+    const providers = postForkProviders(v9Envelope);
+
+    const finalized = await submitCallTx(providers, callOptions());
+
+    expect(finalized.circuitId).toBe(CIRCUIT_ID);
+    // Proved and submitted, not merely accepted by the reader: the point is that the call
+    // COMPLETES, not that one check stopped refusing.
+    expect(providers.proofProvider.proveTx).toHaveBeenCalledTimes(1);
+    expect(providers.publicDataProvider.watchForTxData).toHaveBeenCalledWith('keep-state-tx-id');
+    // Read with the CURRENT decoder, which is the only way these bytes decode at all: the retained
+    // decoder refuses a `contract-state[v8]` envelope on the tag.
+    expect(providers.publicDataProvider.queryRawContractState).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a current-era state whose key is not the one the local artifact carries', async () => {
+    // The negative the envelope check used to stand in for, now asked of the
+    // signal that actually answers it. A contract deployed with current-toolchain
+    // artifacts holds a key these retained artifacts cannot match, and the
+    // refusal has to name that rather than the envelope -- which, after a
+    // migration, says nothing about which artifacts the contract was built from.
+    const providers = postForkProviders(v9Envelope);
+    providers.zkConfigProvider.getVerifierKey = vi.fn().mockResolvedValue(Uint8Array.from([0x01, 0x02, 0x03]));
 
     let caught: unknown;
     try {
@@ -503,10 +537,11 @@ describe('the keep-state pipeline (previous-toolchain contract, post-fork head)'
       caught = error;
     }
 
-    // Named for what it is -- the contract has current-era artifacts on chain --
-    // rather than blamed on the read surface, and refused before any decoder
-    // sees the bytes.
     expect(caught).toBeInstanceOf(RetainedArtifactOnCurrentEraStateError);
+    expect((caught as RetainedArtifactOnCurrentEraStateError).contractAddress).toBe(recording.contractAddress);
+    // Refused before anything is paid for: a proof against a key the chain does
+    // not hold is rejected on submission, which is the late failure this
+    // ordering exists to prevent.
     expect(providers.proofProvider.proveTx).not.toHaveBeenCalled();
   });
 

--- a/packages/contracts/src/test/v8-native.test.ts
+++ b/packages/contracts/src/test/v8-native.test.ts
@@ -780,7 +780,15 @@ describe('the retained-native pipeline (previous-toolchain contract, pre-fork he
       providers.publicDataProvider.queryRawContractState = vi
         .fn()
         .mockResolvedValue(rawState(envelope, PRE_FORK_PROTOCOL_VERSION));
-      return readLedger8Snapshot(retainedEra, 'v8', providers.publicDataProvider, recording.contractAddress);
+      // Both era arguments are the retained facade, which is what a PRE-fork head means: the head's
+      // era and the retained era are the same ledger there.
+      return readLedger8Snapshot(
+        retainedEra,
+        retainedEra,
+        'v8',
+        providers.publicDataProvider,
+        recording.contractAddress
+      );
     };
 
     it('passes against the real committed envelope, which declares the name once', async () => {
@@ -789,7 +797,7 @@ describe('the retained-native pipeline (previous-toolchain contract, pre-fork he
       // The POSITIVE half, so the refusal below cannot be satisfied by a check
       // that refuses everything.
       expect(snapshot.decoded.entryPoints.filter((entry) => entry.circuitId === CIRCUIT_ID)).toHaveLength(1);
-      expect(() => assertSnapshotVerifierKey(snapshot, CIRCUIT_ID, STAND_IN_VERIFIER_KEY)).not.toThrow();
+      expect(() => assertSnapshotVerifierKey(snapshot, CIRCUIT_ID, STAND_IN_VERIFIER_KEY, recording.contractAddress)).not.toThrow();
     });
 
     it('REFUSES a state declaring the same entry-point name twice, rather than checking the first', async () => {
@@ -807,7 +815,7 @@ describe('the retained-native pipeline (previous-toolchain contract, pre-fork he
 
       let caught: unknown;
       try {
-        assertSnapshotVerifierKey(ambiguous, CIRCUIT_ID, STAND_IN_VERIFIER_KEY);
+        assertSnapshotVerifierKey(ambiguous, CIRCUIT_ID, STAND_IN_VERIFIER_KEY, recording.contractAddress);
       } catch (error) {
         caught = error;
       }


### PR DESCRIPTION
## Summary

A pre-fork contract was callable **exactly once** after the fork. This makes it callable indefinitely.

The first post-fork call migrates the contract's state envelope from the retained schema to the current one. `readLedger8Snapshot` then handed those bytes to the **retained** decoder, which refuses them on the envelope tag, so every later call was turned away with `RetainedArtifactOnCurrentEraStateError`.

The envelope answers one question — which decoder may read these bytes — and it was being used to answer a second one: whether the caller's artifacts fit the contract. Migration keeps the retained verifier keys, so after it the two answers differ. The reader now picks its decoder off the envelope; `assertSnapshotVerifierKey` decides artifact fitness.

### What is measured, and what is not

**Measured**, on goldens already committed to this repo:

```
state-migrated-v9.hex   (a real ledger-8-to-9 migrated state)
  envelope  "midnight:contract-state[v8]:"        <- current era
  v9 decode OK: takeDown, post
    vk 2119B tag "midnight:verifier-key[v6]:"     <- RETAINED keys
  v8 decode REFUSED: expected header tag 'midnight:contract-state[v6]:'

vs state-v8-v6-envelope.hex (its pre-migration form)
  takeDown: identical bytes = true
  post:     identical bytes = true
```

So migration rewrites the envelope and leaves the keys untouched, and the current-era decoder reads them. `downConvertForExecution` already accepts a post-fork `EncodedStateValue` and has golden coverage for it, so the execution half needed no change.

**Now measured on chain**, by the `Hard fork` lane on this PR (run [34450042045](https://github.com/midnightntwrk/midnight-js/actions/runs/34450042045), 7/7 green). That the chain accepts a v9 transaction carrying a proof verified against a v3-slot key entered this branch as the owner's ruling; the lane has since confirmed it on all six retained twins:

| twin | envelope before the 2nd call | 2nd call | ledger field |
|---|---|---|---|
| `simple` | `contract-state[v8]` | `SucceedEntirely` (v9) | `round` 1 -> 2 -> **3** |
| `shielded-fallible` | `contract-state[v8]` | `SucceedEntirely` (v9) | `counters.size` 1 -> 2 -> **3** |
| `fee-mint` | `contract-state[v8]` | `SucceedEntirely` (v9) | `counters.size` 1 -> 2 -> **3** |
| `unshielded` | `contract-state[v8]` | `SucceedEntirely` (v9) | none declared |
| `shielded` | `contract-state[v8]` | `SucceedEntirely` (v9) | none declared |
| `block-time` | `contract-state[v8]` | `SucceedEntirely` (v9) | none declared |

`envelopeBefore` reading `contract-state[v8]` on every row is the leg's own evidence that the first post-fork call had already migrated the contract, so each of these is genuinely a call against a migrated state rather than a second call against a retained one. `failures: []` on all seven shards.

This answers open question 3 in `docs/qa/fork-crossing-next-steps.md` ("Is a pre-fork contract callable more than once after the fork?"). It is: **yes**, and the "one call per contract, then redeploy" option is off the table.

### Error semantics

`RetainedArtifactOnCurrentEraStateError` keeps its registered code and is no longer dead: it is raised where it is actually true — a current-era state whose key the local artifact cannot match — carrying the byte-level mismatch on `cause`. Its message previously claimed that a current-era state proves the contract was deployed with current-toolchain artifacts, which a migrated contract disproves; that sentence is gone.

`resolveContractStateEra` replaces `assertRetainedStateEnvelope` (internal, not exported from the barrel). The impossible case — an envelope newer than the block dating it — keeps its fresh-head re-read and both refusals unchanged.

### consumer-e2e

`a migrated <contract>, called a second time` existed as a **probe**, which by construction could not colour the run's exit code, and had never once executed: on the run where it was live, its contract never migrated because the first call failed for an unrelated reason.

It is now a **leg**. `simple`, `shielded-fallible` and `fee-mint` additionally assert a third ledger phase (`secondCall`), each with a distinct mint nonce — reusing the post-fork nonce would overwrite that call's own map entry and leave the size unchanged whether the second call wrote or did nothing.

`readRetainedLedger`'s docblock claimed `unshielded` asserts its surviving balance through `getUnshieldedBalanceTest`. It does not, and cannot — that call is refused by the chain, as the twin's own entry records 200 lines above. Corrected, since this change adds a phase to exactly that mechanism.

## Test plan

- [x] Tests written first (TDD), verified RED before the fix — all three failed at `era.ts:510`, the envelope refusal
- [x] All existing tests pass (no regressions) — contracts `551/551` (`546/546` before #1285 was merged in; the parent added five)
- [x] Lint clean, build succeeds

### The RED run

```
× reads a current-era envelope with the CURRENT decoder even when the record mislabels itself as retained
× calls a MIGRATED contract again, whose state is current-era but whose keys are still retained
× refuses a current-era state whose key is not the one the local artifact carries
  RetainedArtifactOnCurrentEraStateError: ... at era.ts:510
Tests  3 failed | 10 passed (13)
```

### Pre-existing failure, not this branch

The full parallel `vitest run` reports 9 failures in `node-zk-config-provider` and `fetch-zk-config-provider`. They pass in isolation, and the **identical 9** fail on the base branch `feat/1006-public-api-result-shape-bases` under the same full run (base `2306 passed | 9 failed`, here `2308 passed | 9 failed` — the delta is exactly the two tests added here). Verified rather than assumed.

## Notes for review

- Synced with #1285 on 2026-09-10. One conflict, in `consumer-e2e/fork-matrix-entry.mjs`: the parent's #1284 dropped `callRetained`'s `label` parameter and the `retainedCaptures` map, and this branch's second-call leg was written against both. Resolved by keeping this leg's semantics on the parent's narrower signature — the leg name is already recorded by `leg()`, and no `secondCall` in the matrix names a captured value.
- Stacked on #1285, deliberately: all four files this touches are materially changed there, and `downConvertForExecution`'s post-fork contract comes from that branch.
- The GitNexus index is stale for this branch (indexed at `e9362d5`, on `main`), so the mandated impact analysis was done by enumerating call sites with grep plus `tsc` and the suite, not from the graph. Both `readLedger8Snapshot` callers and all four `assertSnapshotVerifierKey` call sites are updated.