### PR TITLE
fix(midnight-js): stop the fork driver losing the error that killed it

### DIFF
--- a/consumer-e2e/fork-matrix-smoke.mjs
+++ b/consumer-e2e/fork-matrix-smoke.mjs
@@ -27,6 +27,7 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 import process from 'node:process';
+import { setTimeout as delay } from 'node:timers/promises';
 
 import {
   createLogger,
@@ -161,15 +162,94 @@ const runScenario = (cwd, linker, environment, contractDir, enactFork) =>
     });
   });
 
+/**
+ * An error with its cause chain, which is the only form worth printing here.
+ *
+ * A `execFileSync` failure says `Command failed with exit code 1` and puts the
+ * command on `cause`; a seam failure says a provider refused and puts the
+ * provider's own error there. Printing `error.message` alone loses the half that
+ * names what went wrong.
+ *
+ * Deliberately a second copy of the dApp's own helper rather than a shared
+ * import: `fork-matrix-entry.mjs` is an ENTRY POINT that runs a fork scenario on
+ * import, and it executes inside the installed persona, which cannot reach this
+ * repository's modules at all.
+ */
+const describeError = (error, depth = 0) => {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+  const head = `${error.name}: ${error.message}\n${error.stack ?? ''}`.trim();
+  if (error.cause === undefined || depth >= 4) {
+    return head;
+  }
+  return `${head}\nCaused by: ${describeError(error.cause, depth + 1)}`;
+};
+
+/**
+ * How long the teardown gets before the run gives up on it.
+ *
+ * Generous, because a stack that is slow to come down is not itself a failure --
+ * `down()` carries its own timeout and this is the backstop for the case where
+ * that one does not fire.
+ */
+const SHUTDOWN_DEADLINE_MS = 180_000;
+
+/**
+ * Runs the teardown under a deadline, and never rejects.
+ *
+ * THE POINT IS THE DEADLINE, not the tidiness. A teardown that never settles
+ * leaves `main` pending, and a pending `main` under a top-level `await` ends the
+ * process with a bare `Detected unsettled top-level await` and exit 13 -- no
+ * error, no stack, no indication of what actually failed. That is what a run
+ * whose persona install failed reported: the install's own error never reached
+ * the log at all.
+ */
+const shutdownWithin = async (environment) => {
+  const timedOut = await Promise.race([
+    environment
+      .shutdown()
+      .then(() => false)
+      .catch((error) => {
+        process.stderr.write(`::warning::the fork stack did not shut down cleanly: ${describeError(error)}\n`);
+        return false;
+      }),
+    // `ref: false`, which is what makes the loser of this race harmless: an
+    // unreferenced timer does not hold the event loop open, so when the teardown
+    // wins there is nothing left to cancel and nothing keeping the process
+    // alive. A referenced deadline would trade a hung shutdown for a process
+    // that will not exit -- the same defect, reached the other way round.
+    delay(SHUTDOWN_DEADLINE_MS, true, { ref: false })
+  ]);
+
+  if (timedOut) {
+    process.stderr.write(
+      `::warning::the fork stack did not shut down within ${SHUTDOWN_DEADLINE_MS}ms; ` +
+        'abandoning it so the run can report what it found\n'
+    );
+  }
+};
+
+/**
+ * Where the run had got to, for the failure report.
+ *
+ * A stage name rather than a line number: the reader of a failed CI job needs to
+ * know whether the stack, the twins, the persona install or the scenario itself
+ * is what went wrong, and those four have entirely different remedies.
+ */
+let stage = 'starting up';
+
 const main = async () => {
   const environment = new ForkTestEnvironment(logger);
   let outcome;
   try {
+    stage = 'standing up the fork stack';
     process.stdout.write('Standing up the fork stack...\n');
     const preFork = await environment.start();
 
     // Before the install, because the persona copies these directories into
     // itself: a twin built afterwards would not be in the tree that gets linked.
+    stage = 'building the retained-era contract twins';
     process.stdout.write(
       `Building the retained-era contract twins (compactc 0.31.1): ${SELECTION.retained.join(', ') || '(none)'}...\n`
     );
@@ -178,6 +258,7 @@ const main = async () => {
       built.length === 0 ? 'Retained twins already built.\n' : `Built retained twins: ${built.join(', ')}\n`
     );
 
+    stage = 'installing the dApp persona';
     process.stdout.write('Installing the dApp persona from packed tarballs...\n');
     const manifest = readManifest();
     stageTarballs(manifest);
@@ -187,6 +268,7 @@ const main = async () => {
     ]);
     linker.install(cwd);
 
+    stage = 'running the fork-crossing scenario';
     outcome = await runScenario(
       cwd,
       linker,
@@ -221,8 +303,16 @@ const main = async () => {
         }
       }
     );
+  } catch (error) {
+    // REPORTED BEFORE THE TEARDOWN IS ATTEMPTED. The teardown runs in the
+    // `finally` below, and a teardown that hangs or fails must not be able to
+    // take the diagnosis down with it -- which is exactly what happened to the
+    // persona install's own error.
+    process.stderr.write(`::error::the fork-crossing run failed while ${stage}\n`);
+    process.stderr.write(`${describeError(error)}\n`);
+    throw error;
   } finally {
-    await environment.shutdown().catch(() => undefined);
+    await shutdownWithin(environment);
   }
 
   process.stdout.write(`${JSON.stringify(outcome.result, null, 2)}\n`);
@@ -233,4 +323,15 @@ const main = async () => {
   process.stdout.write('Fork-crossing scenario passed.\n');
 };
 
-await main();
+// NOT a bare `await main()`. A rejection there is reported by the runtime as an
+// unhandled rejection, and a `main` left PENDING -- by a teardown that never
+// settles -- ends the process with `Detected unsettled top-level await` and exit
+// 13, which names neither the stage nor the failure. Both now end here, with the
+// cause already printed above and an exit code the lane can read.
+try {
+  await main();
+} catch {
+  // Already described by `main`'s own handler; re-printing it here would give a
+  // reader two copies of one failure and no second fact.
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Step 1 of unblocking open question 1. A fork-crossing run whose persona install failed reported this, in full:

```
Warning: Detected unsettled top-level await at .../fork-matrix-smoke.mjs:239
await main();
##[error]Process completed with exit code 13.
```

No error, no stack, no stage. The install's own failure — `execFileSync` throwing on a yarn exit — never reached the log. For a harness whose entire job is diagnosis, that is the worst failure mode available, and it is what `docs/qa/fork-crossing-next-steps.md` records as *"still exited 13 ... and still printed none of its three messages"*.

### Two shapes conspired

`main` reported nothing itself, so the only account of a failure was the rejection propagating out of it. And the `finally` awaited an unbounded `environment.shutdown()`, so a teardown that did not settle left `main` **pending** — and a pending promise under a bare top-level `await` ends the process with that warning and exit 13, without the rejection ever being reported.

Three changes, one per cause:

- **`main` describes its own failure before the teardown is attempted**, with the cause chain. A teardown that hangs can no longer take the diagnosis with it.
- **A stage name** is carried and named in that report. Whether the stack, the twins, the persona install or the scenario failed have entirely different remedies; exit 13 distinguished none of them.
- **The teardown runs under a deadline.** The timer is `ref: false`, so when the teardown wins the race there is nothing to cancel and nothing holding the process open — a referenced deadline would trade a hung shutdown for a run that will not exit.

`await main()` becomes an explicit try/catch with `process.exit(1)`, so a rejection and a pending `main` end the same way.

### What this does not claim

Which promise stayed pending in that CI run is **not** established here. A teardown that never settles is one sufficient mechanism and it reproduces the symptom exactly, but the run's log cannot tell it apart from the others. The fix does not depend on the answer — the error is printed before the teardown either way.

## Test plan

- [x] Both shapes reproduced locally against one failure, with a teardown that never settles
- [x] Happy path verified to still exit 0 immediately
- [x] Lint clean, `node --check`, build succeeds

```
old shape:  Warning: Detected unsettled top-level await ...
            exit=13                        <- the error is gone

new shape:  ::error::the fork-crossing run failed while installing the dApp persona
            Error: Command failed: yarn install
            Caused by: Error: YN0041: Invalid authentication
            ::warning::the fork stack did not shut down within 800ms
            exit=1
```

Happy path: `exit=0` in 0.03s — not one deadline later, which is what the unreferenced timer buys.

No unit tests: this changes only `consumer-e2e/fork-matrix-smoke.mjs`, a `.mjs` driver that no unit suite imports. The `Hard fork` lane exercises it on every run of this PR.

## Context: this unblocks the node-log capture

`docs/qa/fork-crossing-next-steps.md` open question 1 — why the chain refuses a retained `getUnshieldedBalanceTest` post-fork — cannot be answered from the framework. The seam redacts the provider's message **by design** (`errors.ts:401`: *"read the provider's own logs for the unredacted detail"*), and PR #1288's run has since confirmed the seam message is generic: an ordinary over-spend on a WRITE circuit produced the byte-identical `submitTx rejected a retained-era transaction`. So the reason has to come from the node's log.

Capturing those logs was attempted twice (`4a1b35d0`, `f1677a0d`) and reverted both times, because the lane went 6/7 → **0/7**. That cause is now established too, and it is unrelated to the capture itself: the upload step was inserted **between** the scenario step's `run:` and its `env:` block, so the `env:` re-parented onto the upload and the scenario lost `YARN_NPM_AUTH_TOKEN`. The install then ran anonymous against the `@midnight-ntwrk` GitHub Packages scope — `YN0041: Invalid authentication (as an anonymous user)` — on every shard at once. The failing run's own log shows the credentials sitting on the upload step.

That is a one-line placement fix when the capture is retried, and it is deliberately **not** in this PR: this one is the prerequisite, so that the retry reports what it finds instead of exiting 13 in silence.
