### PR TITLE
test(testkit-js): capture the stack's container logs when a fork run fails

### DIFF
--- a/.github/workflows/ci-hardfork.yml
+++ b/.github/workflows/ci-hardfork.yml
@@ -185,11 +185,16 @@ jobs:
       # only when it failed. They are the only account of WHY the chain refused a
       # submission: the framework's seam error redacts the provider's message by
       # design, and the provider's own error carries no reason.
+      # `stack-logs`, NOT `.logs`. A leading dot makes every path under it hidden,
+      # and `upload-artifact` skips hidden files unless told otherwise -- so the
+      # dotted name uploaded nothing while the driver reported the files written,
+      # which reads as a working capture and is not one. Measured: "No files were
+      # found with the provided path: consumer-e2e/.logs/".
       - name: Upload the stack's container logs
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4.6.2
         with:
           name: fork-stack-logs-${{ matrix.contract }}
-          path: consumer-e2e/.logs/
+          path: consumer-e2e/stack-logs/
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/ci-hardfork.yml
+++ b/.github/workflows/ci-hardfork.yml
@@ -170,3 +170,26 @@ jobs:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
           NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
           GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+
+      # AFTER the step above, `env:` block included, and that placement is the
+      # whole of this step's history. Inserting it between that step's `run:` and
+      # its `env:` re-parents the block onto THIS step -- which needs no
+      # credentials -- and leaves the scenario without `YARN_NPM_AUTH_TOKEN`. The
+      # persona install then resolves the `@midnight-ntwrk` scope anonymously
+      # against GitHub Packages and every shard fails alike on
+      # `YN0041: Invalid authentication (as an anonymous user)`. That took the
+      # lane from 6/7 to 0/7 once, and the diff read as innocent because the
+      # `env:` lines never appeared in it.
+      #
+      # The scenario writes these itself, before it tears the stack down, and
+      # only when it failed. They are the only account of WHY the chain refused a
+      # submission: the framework's seam error redacts the provider's message by
+      # design, and the provider's own error carries no reason.
+      - name: Upload the stack's container logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4.6.2
+        with:
+          name: fork-stack-logs-${{ matrix.contract }}
+          path: consumer-e2e/.logs/
+          if-no-files-found: warn
+          retention-days: 7

--- a/consumer-e2e/.gitignore
+++ b/consumer-e2e/.gitignore
@@ -1,2 +1,3 @@
 .tarballs/
 .retained/
+.logs/

--- a/consumer-e2e/.gitignore
+++ b/consumer-e2e/.gitignore
@@ -1,3 +1,3 @@
 .tarballs/
 .retained/
-.logs/
+stack-logs/

--- a/consumer-e2e/fork-matrix-smoke.mjs
+++ b/consumer-e2e/fork-matrix-smoke.mjs
@@ -318,7 +318,7 @@ const main = async () => {
     // node's log.
     if (outcome === undefined || outcome.code !== 0) {
       const captured = await environment
-        .captureContainerLogs(path.join(REPOSITORY_ROOT, 'consumer-e2e', '.logs'))
+        .captureContainerLogs(path.join(REPOSITORY_ROOT, 'consumer-e2e', 'stack-logs'))
         .catch((error) => {
           process.stdout.write(`Could not capture container logs: ${describeError(error)}\n`);
           return [];

--- a/consumer-e2e/fork-matrix-smoke.mjs
+++ b/consumer-e2e/fork-matrix-smoke.mjs
@@ -304,14 +304,29 @@ const main = async () => {
       }
     );
   } catch (error) {
-    // REPORTED BEFORE THE TEARDOWN IS ATTEMPTED. The teardown runs in the
-    // `finally` below, and a teardown that hangs or fails must not be able to
-    // take the diagnosis down with it -- which is exactly what happened to the
-    // persona install's own error.
+    // REPORTED BEFORE ANYTHING ELSE IS ATTEMPTED. The capture and the teardown
+    // both run below, and neither must be able to take the diagnosis down with
+    // it -- which is exactly what happened to the persona install's own error.
     process.stderr.write(`::error::the fork-crossing run failed while ${stage}\n`);
     process.stderr.write(`${describeError(error)}\n`);
     throw error;
   } finally {
+    // BEFORE the teardown, which removes the containers and their logs with
+    // them, and only when something went wrong: a green run's logs are large and
+    // answer nothing, and only a failure poses the question they answer -- a
+    // submission the chain refused reports no reason, and the reason is in the
+    // node's log.
+    if (outcome === undefined || outcome.code !== 0) {
+      const captured = await environment
+        .captureContainerLogs(path.join(REPOSITORY_ROOT, 'consumer-e2e', '.logs'))
+        .catch((error) => {
+          process.stdout.write(`Could not capture container logs: ${describeError(error)}\n`);
+          return [];
+        });
+      process.stdout.write(
+        captured.length === 0 ? 'No container logs captured.\n' : `Captured container logs: ${captured.join(', ')}\n`
+      );
+    }
     await shutdownWithin(environment);
   }
 

--- a/testkit-js/testkit-js/src/test-environment/test-environments/fork-test-environment.ts
+++ b/testkit-js/testkit-js/src/test-environment/test-environments/fork-test-environment.ts
@@ -15,6 +15,7 @@
 
 import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
@@ -78,6 +79,22 @@ const RUNTIME_APPLIED_TIMEOUT = 3 * MINUTE;
 const POST_FORK_FINALIZATION_TIMEOUT = 2 * MINUTE;
 const CHAIN_POLL_INTERVAL = 3_000;
 const STACK_SHUTDOWN_TIMEOUT = 30_000;
+
+/**
+ * The services {@link ForkTestEnvironment.captureContainerLogs} dumps.
+ *
+ * Both proof servers are included: which one served a call is decided by the head, and a rejection
+ * blamed on the chain has been a prover fault before.
+ */
+const LOGGED_SERVICES = ['node', 'indexer', 'proof-server', 'proof-server-v8'] as const;
+
+/**
+ * One service's log dump ceiling.
+ *
+ * A backstop rather than the mechanism: the command below terminates on its own, so reaching this
+ * means the docker CLI itself is wedged.
+ */
+const LOG_CAPTURE_TIMEOUT = 30_000;
 
 /** A single RPC round trip's ceiling, so a node that accepts a connection and never answers cannot outlive a poll deadline. */
 const RPC_TIMEOUT = 10_000;
@@ -534,6 +551,64 @@ export class ForkTestEnvironment extends TestEnvironment {
    *
    * @returns {Promise<void>} Resolves once the stack is down.
    */
+  /**
+   * Writes each stack container's logs into `directory`, one file per service, and answers with the
+   * paths written.
+   *
+   * For the failures the framework's own errors cannot explain. A submission the NODE rejects
+   * surfaces as `SubmissionError: Transaction submission error` with no reason on it, and the seam
+   * that wraps it redacts the provider's message deliberately -- so the only account of WHY the
+   * chain refused is in the node's log.
+   *
+   * `docker compose logs` WITHOUT `-f`, and that is the load-bearing detail. The obvious route --
+   * `getContainer(...).logs()` and drain the stream to `'end'` -- FOLLOWS a running container, so
+   * `'end'` never arrives; awaiting it leaves the process with a pending promise, and a pending
+   * promise under the driver's top-level `await` ends the run with `Detected unsettled top-level
+   * await` and exit 13, taking the failure report with it. That was measured twice, and bounding the
+   * drain with a timer only traded one hang for another. A command that terminates by itself removes
+   * the condition instead of racing it.
+   *
+   * Must be called BEFORE {@link shutdown}, which removes the containers and their logs with them.
+   * Never throws: it runs on a failure path, where losing the original error to a logging problem
+   * would be the worse outcome. A service whose log cannot be read is reported by its absence from
+   * the returned list.
+   *
+   * @param directory The directory the log files are written into; created if absent.
+   * @returns {Promise<string[]>} The paths written, one per service whose log could be read.
+   */
+  captureContainerLogs = async (directory: string): Promise<string[]> => {
+    if (this.dockerEnv === undefined) {
+      return [];
+    }
+    await mkdir(directory, { recursive: true });
+    const written: string[] = [];
+    for (const service of LOGGED_SERVICES) {
+      const destination = path.join(directory, `${service}.log`);
+      try {
+        const { stdout, stderr } = await execFileAsync(
+          'docker',
+          ['compose', '-f', this.composeFile, '-p', this.projectName, 'logs', '--no-color', service],
+          {
+            env: { ...process.env, ...this.composeEnvironment },
+            // Larger than `runToolkit`'s: a node that has been running through a fork enactment
+            // produces far more than one toolkit command does, and a truncated log is worth less
+            // than the round trip it costs to hold it.
+            maxBuffer: 64 * 1024 * 1024,
+            timeout: LOG_CAPTURE_TIMEOUT
+          }
+        );
+        // Both streams, in that order: compose writes the container's stdout and stderr to its own
+        // stdout, but its own diagnostics go to stderr, and a log that is missing because the
+        // service was never up is a fact worth keeping in the file.
+        await writeFile(destination, `${stdout}${stderr}`);
+        written.push(destination);
+      } catch (error) {
+        this.logger.warn(`Could not capture logs for '${service}': ${String(error)}`);
+      }
+    }
+    return written;
+  };
+
   shutdown = async (): Promise<void> => {
     this.logger.info('Shutting down fork test environment...');
     // Cleared before the await so a failing `down()` cannot leave this instance reporting URLs for

--- a/testkit-js/testkit-js/test/fork-test-environment.ut.test.ts
+++ b/testkit-js/testkit-js/test/fork-test-environment.ut.test.ts
@@ -13,6 +13,11 @@
  * limitations under the License.
  */
 
+import { randomUUID } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
 import pino from 'pino';
 
 import type { ProofServerContainer } from '../src/proof-server-container';
@@ -58,6 +63,17 @@ describe('[Unit tests] ForkTestEnvironment', () => {
       const environment = new ForkTestEnvironment(silentLogger);
 
       await expect(environment.shutdown()).resolves.toBeUndefined();
+    });
+
+    it('should capture no logs, and leave no directory behind, when there is no stack to read', async () => {
+      const environment = new ForkTestEnvironment(silentLogger);
+      const directory = path.join(tmpdir(), `fork-capture-${randomUUID()}`);
+
+      await expect(environment.captureContainerLogs(directory)).resolves.toEqual([]);
+      // The DIRECTORY matters, not just the empty list: creating it would leave the CI upload step
+      // warning about an empty artifact on every run that failed before the stack came up, which
+      // reads as "the logs were lost" rather than "there were none to take".
+      expect(existsSync(directory)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Third attempt at capturing the fork stack's container logs, and the first that **removes** both conditions that killed the other two rather than working around them.

### Why the logs are needed

A submission the node refuses surfaces as `SubmissionError: Transaction submission error` with no reason on it, and the seam that wraps it redacts the provider's message **by design** — `errors.ts:401` says so and points at the provider's own logs.

PR #1288's run then established that the seam message carries no diagnostic weight at all: an ordinary over-spend on a *write* circuit produced the byte-identical `submitTx rejected a retained-era transaction`. So the reason for the retained `getUnshieldedBalanceTest` refusal (open question 1) cannot come from the framework. It has to come from the node.

### What broke the first two attempts — both now measured

**The hang.** `getContainer(...).logs()` **follows** a running container, so `'end'` never arrives; awaiting it leaves a pending promise, and a pending promise under the driver's top-level `await` ends the run with `Detected unsettled top-level await` and exit 13, taking the failure report with it. `f1677a0d` bounded the drain with an unref'd timer, which traded one hang for another.

This uses `docker compose logs` **without `-f`**, which terminates by itself — the condition is gone rather than raced. `execFile`'s own `timeout` stays as a backstop for a wedged CLI.

**The 0/7.** `4a1b35d0` inserted the upload step **between** the scenario step's `run:` and its `env:` block, so YAML re-parented the block onto the upload — which needs no credentials — and the scenario lost `YARN_NPM_AUTH_TOKEN`. The persona install then resolved the `@midnight-ntwrk` scope anonymously against GitHub Packages, and every shard failed alike on `YN0041: Invalid authentication (as an anonymous user)`.

That is why the commit "touched nothing to do with credentials": it did not touch them, it **moved** them, and the `env:` lines never appear in such a diff. Parsing both versions shows it plainly:

```
broken (4a1b35d0)   scenario env=[]           upload env=["YARN_NPM_AUTH_TOKEN","NODE_AUTH_TOKEN","GITHUB_TOKEN"]
this branch         scenario env=[3 tokens]   upload env=[]
```

The upload step now sits after the block, with a comment recording why the placement is load-bearing.

### The capture itself

One file per service, **both** proof servers included — which one served a call is decided by the head, and a rejection blamed on the chain has been a prover fault before. Never throws: it runs on a failure path where losing the original error to a logging problem is the worse outcome, so a service whose log cannot be read is reported by its absence from the returned list.

It creates **no directory** when there is no stack to read.

## Test plan

- [x] Tests written first for the guard, verified RED before the fix — moving the guard after the `mkdir` fails the test (`expected true to be false`)
- [x] `testkit-js` unit tests pass: 135 passed, 34 skipped
- [x] Lint clean, build succeeds
- [x] Workflow parsed, not eyeballed — `env:` ownership asserted programmatically against both the broken and the fixed version

The unit test pins the **directory**, not only the empty list: creating it would leave the upload step warning about an empty artifact on every run that failed before the stack came up, which reads as *"the logs were lost"* rather than *"there were none to take"*.

### Pre-existing failures, not this branch

`test/testing-api.it.test.ts` fails 8 tests locally — they need a docker stack that is not running. The identical 8 fail on the base branch `fix/1006-fork-driver-loses-its-error`. Verified rather than assumed.

## What this does NOT do, and what step 3 needs

**The capture fires only when the run fails, and the lane is currently green.** The `unshielded` entry no longer calls the retained `getUnshieldedBalanceTest` — #1281 removed that assertion — so nothing in the matrix reproduces the refusal, and merging this alone will not produce a single node log.

Diagnosing open question 1 therefore needs a further, deliberate step: reinstate the retained `getUnshieldedBalanceTest` call so the refusal happens, with the capture unconditional and the upload on `if: always()`, run the lane once, read the node's reason, and keep only the finding. That is a throwaway diagnostic branch, not a merge candidate, and it is deliberately not folded in here — this PR is the infrastructure and stands on its own.

## Notes for review

- Stacked on #1290, which is the prerequisite: without it a capture that misbehaves would again exit 13 in silence and report nothing.
