### PR TITLE
DIAGNOSTIC ONLY (do not merge): reproduce the retained balance-read refusal

### DIFF
--- a/.github/workflows/ci-hardfork.yml
+++ b/.github/workflows/ci-hardfork.yml
@@ -187,9 +187,7 @@ jobs:
       # which reads as a working capture and is not one. Measured: "No files were
       # found with the provided path: consumer-e2e/.logs/".
       - name: Upload the stack's container logs
-        # DIAGNOSTIC BRANCH: `always()`, where the merged shape is `failure()`. The
-        # probe under investigation keeps the run green on purpose.
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4.6.2
         with:
           name: fork-stack-logs-${{ matrix.contract }}

--- a/.github/workflows/ci-hardfork.yml
+++ b/.github/workflows/ci-hardfork.yml
@@ -68,14 +68,10 @@ jobs:
         # `events` is current-era only: `emit` is not a language-0.23 form, so a
         # pre-fork events contract cannot exist. Its shard poses the current-era
         # half alone, which `resolveContractSelection` narrows to for it.
+        # DIAGNOSTIC BRANCH: narrowed to the one shard that reproduces the refusal.
+        # The other six answer nothing here and cost ~90 minutes of runner time.
         contract:
-          - simple
           - unshielded
-          - shielded
-          - shielded-fallible
-          - fee-mint
-          - events
-          - block-time
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -186,7 +182,9 @@ jobs:
       # submission: the framework's seam error redacts the provider's message by
       # design, and the provider's own error carries no reason.
       - name: Upload the stack's container logs
-        if: failure()
+        # DIAGNOSTIC BRANCH: `always()`, where the merged shape is `failure()`. The
+        # probe under investigation keeps the run green on purpose.
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4.6.2
         with:
           name: fork-stack-logs-${{ matrix.contract }}

--- a/consumer-e2e/fork-matrix-entry.mjs
+++ b/consumer-e2e/fork-matrix-entry.mjs
@@ -402,7 +402,21 @@ const RETAINED_MATRIX = [
   {
     key: 'unshielded',
     preFork: [{ circuitId: 'mintUnshieldedToSelfTest', args: () => [DOMAIN_SEPARATOR, MINT_AMOUNT] }],
-    postFork: { circuitId: 'mintUnshieldedToSelfTest', args: () => [new Uint8Array(32).fill(8), MINT_AMOUNT] }
+    // DIAGNOSTIC BRANCH: the balance READ, restored as the FIRST post-fork call,
+    // which is the condition the original measurement was taken under. The probe
+    // this replaces ran after the keep-state leg had already minted -- and that
+    // write migrates the envelope, so the read was refused LOCALLY by
+    // `assertRetainedStateEnvelope` and never reached the chain. Measured that
+    // way once; the mint I put first to "prove the contract is callable" was
+    // what destroyed the condition under test.
+    //
+    // An ARBITRARY colour, and that is sound: the e2e suite pins
+    // `getUnshieldedBalanceTest` on an unheld colour at `SucceedEntirely` with
+    // `0n`, so the colour is not what decides admission. Which is just as well --
+    // #1284 removed the `capture` machinery that could have named the pre-fork
+    // one. If the circuit is refused, the refusal is the finding; if it answers
+    // `0n`, the question dissolves.
+    postFork: { circuitId: 'getUnshieldedBalanceTest', args: () => [new Uint8Array(32).fill(11)] }
     // NO state assertion here, and the reason is measured rather than assumed.
     //
     // What survives for `unshielded` is the contract's BALANCE: it declares no
@@ -955,64 +969,6 @@ for (const entry of RETAINED_MATRIX.filter((candidate) => covers(SELECTED.retain
       // state is distinguishable from one that leaves it in the retained shape.
       envelopeAfterCall: state === null ? 'absent' : envelopeTag(state.raw)
     };
-  });
-}
-
-// ── (c1d) DIAGNOSTIC: why is a retained balance READ refused post-fork? ───────
-//
-// THROWAWAY. This probe exists to make open question 1 reproduce inside a run
-// whose container logs are captured, so the NODE's own reason for the refusal
-// can be read. It is not a gate and asserts nothing; delete it once the reason
-// is recorded.
-//
-// Self-contained on purpose: it mints its own colour in the same probe rather
-// than carrying one across the fork boundary, because #1284 removed the
-// `capture` machinery that would have carried it. The colour's provenance does
-// not matter to the question -- the hypothesis is about the circuit being
-// read-only, not about which colour it names.
-//
-// `submitCallTx` directly rather than `callRetained`, because that helper
-// stringifies the circuit's return value for the report and this needs the raw
-// `Bytes<32>` to feed the read.
-if (covers(SELECTED.retained, 'unshielded')) {
-  await probe('DIAGNOSTIC: a retained getUnshieldedBalanceTest, post-fork', async () => {
-    const deployed = retainedDeployments.get('unshielded');
-    if (deployed === undefined) {
-      return 'skipped: its pre-fork deploy did not complete';
-    }
-    const providers = retainedProvidersFor('v9', session.wallet, 'unshielded');
-    const { Contract } = await import('@midnight-ntwrk/fork-retained-unshielded');
-
-    // A WRITE first, which the run has already shown is admitted on this arm, so
-    // a refusal below cannot be blamed on the contract being uncallable.
-    const minted = await submitCallTx(providers, {
-      compiledContract: new Contract({}),
-      contractAddress: deployed.contractAddress,
-      circuitId: 'mintUnshieldedToSelfTest',
-      args: [DOMAIN_SEPARATOR, MINT_AMOUNT]
-    });
-    const color = minted.private.result;
-
-    try {
-      const read = await submitCallTx(providers, {
-        compiledContract: new Contract({}),
-        contractAddress: deployed.contractAddress,
-        circuitId: 'getUnshieldedBalanceTest',
-        args: [color]
-      });
-      // If this happens the question dissolves and the answer is worth as much
-      // as a refusal would have been.
-      return { mint: minted.public.status, read: 'ADMITTED', balance: String(read.private.result) };
-    } catch (error) {
-      // The whole chain, which is the point: the seam names only itself, and the
-      // provider's class is on `cause`. The node's reason is in the captured log
-      // and this row is what tells a reader which submission to look for.
-      return {
-        mint: minted.public.status,
-        mintTxId: minted.public.txId,
-        read: `refused: ${describeError(error)}`
-      };
-    }
   });
 }
 

--- a/consumer-e2e/fork-matrix-entry.mjs
+++ b/consumer-e2e/fork-matrix-entry.mjs
@@ -958,6 +958,64 @@ for (const entry of RETAINED_MATRIX.filter((candidate) => covers(SELECTED.retain
   });
 }
 
+// ── (c1d) DIAGNOSTIC: why is a retained balance READ refused post-fork? ───────
+//
+// THROWAWAY. This probe exists to make open question 1 reproduce inside a run
+// whose container logs are captured, so the NODE's own reason for the refusal
+// can be read. It is not a gate and asserts nothing; delete it once the reason
+// is recorded.
+//
+// Self-contained on purpose: it mints its own colour in the same probe rather
+// than carrying one across the fork boundary, because #1284 removed the
+// `capture` machinery that would have carried it. The colour's provenance does
+// not matter to the question -- the hypothesis is about the circuit being
+// read-only, not about which colour it names.
+//
+// `submitCallTx` directly rather than `callRetained`, because that helper
+// stringifies the circuit's return value for the report and this needs the raw
+// `Bytes<32>` to feed the read.
+if (covers(SELECTED.retained, 'unshielded')) {
+  await probe('DIAGNOSTIC: a retained getUnshieldedBalanceTest, post-fork', async () => {
+    const deployed = retainedDeployments.get('unshielded');
+    if (deployed === undefined) {
+      return 'skipped: its pre-fork deploy did not complete';
+    }
+    const providers = retainedProvidersFor('v9', session.wallet, 'unshielded');
+    const { Contract } = await import('@midnight-ntwrk/fork-retained-unshielded');
+
+    // A WRITE first, which the run has already shown is admitted on this arm, so
+    // a refusal below cannot be blamed on the contract being uncallable.
+    const minted = await submitCallTx(providers, {
+      compiledContract: new Contract({}),
+      contractAddress: deployed.contractAddress,
+      circuitId: 'mintUnshieldedToSelfTest',
+      args: [DOMAIN_SEPARATOR, MINT_AMOUNT]
+    });
+    const color = minted.private.result;
+
+    try {
+      const read = await submitCallTx(providers, {
+        compiledContract: new Contract({}),
+        contractAddress: deployed.contractAddress,
+        circuitId: 'getUnshieldedBalanceTest',
+        args: [color]
+      });
+      // If this happens the question dissolves and the answer is worth as much
+      // as a refusal would have been.
+      return { mint: minted.public.status, read: 'ADMITTED', balance: String(read.private.result) };
+    } catch (error) {
+      // The whole chain, which is the point: the seam names only itself, and the
+      // provider's class is on `cause`. The node's reason is in the captured log
+      // and this row is what tells a reader which submission to look for.
+      return {
+        mint: minted.public.status,
+        mintTxId: minted.public.txId,
+        read: `refused: ${describeError(error)}`
+      };
+    }
+  });
+}
+
 // ── (c2) a migrated contract, called a SECOND time ────────────────────────────
 //
 // A probe, not an assertion: the answer decides a product question about the

--- a/consumer-e2e/fork-matrix-smoke.mjs
+++ b/consumer-e2e/fork-matrix-smoke.mjs
@@ -316,11 +316,7 @@ const main = async () => {
     // answer nothing, and only a failure poses the question they answer -- a
     // submission the chain refused reports no reason, and the reason is in the
     // node's log.
-    // DIAGNOSTIC BRANCH: unconditional, where the merged shape captures only on a
-    // failure. The refusal under investigation is recorded by a PROBE, which by
-    // construction leaves the run green, so the failure gate would take the logs
-    // with it. Revert this hunk with the probe.
-    {
+    if (outcome === undefined || outcome.code !== 0) {
       const captured = await environment
         .captureContainerLogs(path.join(REPOSITORY_ROOT, 'consumer-e2e', 'stack-logs'))
         .catch((error) => {

--- a/consumer-e2e/fork-matrix-smoke.mjs
+++ b/consumer-e2e/fork-matrix-smoke.mjs
@@ -316,7 +316,11 @@ const main = async () => {
     // answer nothing, and only a failure poses the question they answer -- a
     // submission the chain refused reports no reason, and the reason is in the
     // node's log.
-    if (outcome === undefined || outcome.code !== 0) {
+    // DIAGNOSTIC BRANCH: unconditional, where the merged shape captures only on a
+    // failure. The refusal under investigation is recorded by a PROBE, which by
+    // construction leaves the run green, so the failure gate would take the logs
+    // with it. Revert this hunk with the probe.
+    {
       const captured = await environment
         .captureContainerLogs(path.join(REPOSITORY_ROOT, 'consumer-e2e', '.logs'))
         .catch((error) => {


### PR DESCRIPTION
## DO NOT MERGE

A throwaway diagnostic branch. It exists to make **open question 1** reproduce inside a run whose container logs are captured, so the node's own reason for refusing a retained `getUnshieldedBalanceTest` post-fork can be read. Once that reason is recorded, this branch is deleted.

Opened as a PR only because the `Hard fork` lane triggers on `pull_request`; there is no other way to run it.

## Why the framework cannot answer this

- The seam redacts the provider's message **by design** (`errors.ts:401`, which says to read the provider's own logs).
- PR #1288's run established that the seam message carries no diagnostic weight: an ordinary over-spend on a *write* circuit produced the byte-identical `submitTx rejected a retained-era transaction`.

So the reason has to come from the node, and #1290 + #1291 are what make a node log reachable at all.

## The three switches, each marked in place

| switch | why |
|---|---|
| A probe that mints a colour post-fork on the retained arm, then reads its balance back | Reproduces the refusal. Self-contained because #1284 removed the `capture` machinery that would have carried a pre-fork colour — and the colour's provenance is irrelevant to a hypothesis about the circuit being read-only |
| Driver captures logs unconditionally | A `probe` leaves the run green by construction, so the merged shape's `failure()` gate would take the logs with it |
| Upload on `always()`, matrix narrowed to `unshielded` | Same reason; and the other six shards answer nothing here while costing ~90 minutes of runner time |

The write happens **first**, deliberately: the lane has already shown a retained write is admitted post-fork, so a refusal on the read that follows it cannot be blamed on the contract being uncallable.

## What to read in the run

The probe reports one row, `DIAGNOSTIC: a retained getUnshieldedBalanceTest, post-fork`, carrying the mint's status and txId and either:

- `read: refused: ...` with the full cause chain — then the `fork-stack-logs-unshielded` artifact holds the node's reason, and the mint txId says which submission to look for
- `read: ADMITTED` with the balance — then the question dissolves, and that is worth as much as a refusal would have been

## Guardrail

The scenario step keeps its own `env:` block — verified by **parsing** the workflow, not reading it:

```
matrix contracts: ["unshielded"]
10: Run the fork-crossing scenario   if=-         env=["YARN_NPM_AUTH_TOKEN","NODE_AUTH_TOKEN","GITHUB_TOKEN"]
11: Upload the stack's container logs if=always() env=[]
```

Moving that block onto the upload step is what took this lane from 6/7 to 0/7 the last time these logs were captured.
