### PR TITLE
refactor(midnight-js): bind the two era vocabularies with one pairing table

### DIFF
--- a/packages/contracts/docs/era-dispatch.md
+++ b/packages/contracts/docs/era-dispatch.md
@@ -197,42 +197,76 @@ the caller already holds; this decides only whether that pair may run, so it doe
 not restate the pair as a third value that could disagree with it.
 
 The rulings live in a DATA table, `ERA_PAIRING`, rather than in a chain of
-switches: one row per `PipelineEra`, one column per `LedgerVersion`, on a null
-prototype and frozen — the construction every era-keyed table in this tree uses
-(`packages/protocol/docs/shared-table-discipline.md`). Each cell holds one
-`EraPairing` verdict, `'run'`, `'call-only'` or `'artifact-newer-than-head'`,
-and `assertEraCompatible` turns that verdict and the operation kind into the
-refusal. `'call-only'` is where the deploy asymmetry above lives.
+switches: one row per `PipelineEra`, one column per `LedgerVersion`. Each cell
+holds one `EraPairing` verdict, `'run'`, `'call-only'` or
+`'artifact-newer-than-head'`, and `assertEraCompatible` turns that verdict and
+the operation kind into the refusal. `'call-only'` is where the deploy asymmetry
+above lives, and it refuses anything that is not positively a call — the one
+asymmetric cell in the fork window must not admit a `kind` nobody anticipated.
 
-### The table is where the two era vocabularies are bound
+### Where the build-time gate actually is
 
-`PipelineEra` and `LedgerVersion` name different facts and stay separate types.
-One says which era built the caller's artifact, the other which era the network
-head is on, and after the fork they DISAGREE: a retained-era call is recorded as
-a keep-state transaction tagged `'v9'` while `era` on its result says
-`'ledger8'`
+The table is built through two one-line constructors whose PARAMETER types are
+`EraPairingTable` and `EraRulings`. That is deliberate and it is the whole gate:
+a literal handed to one is checked against a total `Record`, so a missing cell,
+an excess cell and a verdict outside the set are all build failures — reported
+at the literal, where the mistake is.
+
+Annotating `ERA_PAIRING` itself cannot carry that. The table is re-homed onto a
+null prototype, and `Object.create(null) as T` asserts the rows into existence
+before the annotation is ever checked; an empty table would satisfy it. So the
+constructors are not ceremony to be simplified away — delete them and the gate
+goes with them, silently, while every test stays green.
+
+What the gate does and does not say: every pair of the two vocabularies has to
+be ruled, so a member added to either one is a build failure here. It does NOT
+bind the two sets to each other — a further artifact era can be added without a
+further head era, and the reverse. What cannot happen is either one arriving
+unruled.
+
+### Why the vocabularies stay separate
+
+`PipelineEra` and `LedgerVersion` name different facts. One says which era built
+the caller's artifact, the other which era the network head is on, and after the
+fork they DISAGREE: a retained-era call is recorded as a keep-state transaction
+tagged `'v9'` while `era` on its result says `'ledger8'`
 (`docs/adr/0011-tag-every-result-with-the-pipeline-that-produced-it.md`).
 Spelling both with one alphabet would put two identically-typed members holding
 different values on one result, and the disagreement the tag exists to express
 would read as a bug.
 
-What the two sets may not do is drift apart in size. `ERA_PAIRING`'s declared
-type, `Readonly<Record<PipelineEra, Readonly<Record<LedgerVersion, EraPairing>>>>`,
-is the one declaration that binds them: a member added to either set leaves the
-table short of a row or a column, and the build fails. A third era is a compile
-error here rather than a refusal discovered at the fork.
-`src/test/typecheck/era-pairing.test-d.ts` pins that the refusal is real — a
-`Partial<Record<...>>`, the shape `NODE_MAJOR_TO_LEDGER` legitimately uses and
-therefore the shape a later edit is most likely to copy, would accept an
-incomplete table and leave one pairing undecided.
+### Why the lookups are still checked at run time
 
-Both lookups are checked at run time as well, and neither check is redundant
-with the build-time gate: a head era arrives as an integer resolved at run time,
-and a pipeline era as whatever a JavaScript caller's artifact turned out to be,
-so either can reach the table before it has been extended for them. A missing
-cell refuses and names the era it could not place, rather than reaching a
-neighbour's ruling — which is also why the table is on a null prototype, where
-`constructor` and `toString` are absent instead of truthy.
+Both arguments are checked before and after the lookup, and neither check is
+redundant with the build-time gate.
+
+The `typeof` check is the load-bearing one. A member access coerces its key —
+`ToPropertyKey` runs `toString` — so an object with a `toString`, a `String`
+wrapper, or anything carrying `Symbol.toPrimitive` selects a REAL row and gets
+ruled on. The nested switches this table replaced compared with `===` and
+refused all of those. Reading a ruling for a key that merely stringifies to an
+era is the one way a table is weaker than the switch it replaces, and it is why
+the guard is not optional.
+
+The `undefined` check is the ordinary one, and the null prototype is what makes
+it sufficient: on a plain object literal `constructor`, `toString`, `valueOf`
+and `__proto__` all come back as truthy non-cells. Note what that would and
+would not cost. No prototype member is a valid verdict, so no such key reaches a
+wrong RULING; the refusal simply moves to the other axis and blames a value that
+was never at fault, or falls to the closing arm and reports a function where an
+era should be. The null prototype buys a correct diagnosis, not a correct
+verdict — which is why the test that pins it asserts which era gets blamed
+rather than asserting the prototype.
+
+Neither guard is a live boundary today: both call sites pass literals, and this
+module is not reachable from outside the package. They are here so a future call
+site threading a value through cannot quietly widen what the table admits.
+
+`packages/protocol/docs/shared-table-discipline.md` prescribes the null
+prototype and the freeze for a table indexed by a value, which this one is.
+Not every era-keyed table in the tree qualifies — `NODE_MAJOR_TO_LEDGER` is
+keyed by `number`, an open domain, so it is a `Partial` lookup and is neither
+frozen nor null-prototyped.
 
 ## Pairing the head against the fetched state
 

--- a/packages/contracts/docs/era-dispatch.md
+++ b/packages/contracts/docs/era-dispatch.md
@@ -196,9 +196,43 @@ The function returns nothing. Which pipeline runs is the `(pipeline, head)` pair
 the caller already holds; this decides only whether that pair may run, so it does
 not restate the pair as a third value that could disagree with it.
 
-Each `default` arm carries a compile-time exhaustiveness gate AND a runtime
-throw, and the runtime throw is not redundant with it: a new era reaches the
-switch from a real head integer before the switch is updated.
+The rulings live in a DATA table, `ERA_PAIRING`, rather than in a chain of
+switches: one row per `PipelineEra`, one column per `LedgerVersion`, on a null
+prototype and frozen — the construction every era-keyed table in this tree uses
+(`packages/protocol/docs/shared-table-discipline.md`). Each cell holds one
+`EraPairing` verdict, `'run'`, `'call-only'` or `'artifact-newer-than-head'`,
+and `assertEraCompatible` turns that verdict and the operation kind into the
+refusal. `'call-only'` is where the deploy asymmetry above lives.
+
+### The table is where the two era vocabularies are bound
+
+`PipelineEra` and `LedgerVersion` name different facts and stay separate types.
+One says which era built the caller's artifact, the other which era the network
+head is on, and after the fork they DISAGREE: a retained-era call is recorded as
+a keep-state transaction tagged `'v9'` while `era` on its result says
+`'ledger8'`
+(`docs/adr/0011-tag-every-result-with-the-pipeline-that-produced-it.md`).
+Spelling both with one alphabet would put two identically-typed members holding
+different values on one result, and the disagreement the tag exists to express
+would read as a bug.
+
+What the two sets may not do is drift apart in size. `ERA_PAIRING`'s declared
+type, `Readonly<Record<PipelineEra, Readonly<Record<LedgerVersion, EraPairing>>>>`,
+is the one declaration that binds them: a member added to either set leaves the
+table short of a row or a column, and the build fails. A third era is a compile
+error here rather than a refusal discovered at the fork.
+`src/test/typecheck/era-pairing.test-d.ts` pins that the refusal is real — a
+`Partial<Record<...>>`, the shape `NODE_MAJOR_TO_LEDGER` legitimately uses and
+therefore the shape a later edit is most likely to copy, would accept an
+incomplete table and leave one pairing undecided.
+
+Both lookups are checked at run time as well, and neither check is redundant
+with the build-time gate: a head era arrives as an integer resolved at run time,
+and a pipeline era as whatever a JavaScript caller's artifact turned out to be,
+so either can reach the table before it has been extended for them. A missing
+cell refuses and names the era it could not place, rather than reaching a
+neighbour's ruling — which is also why the table is on a null prototype, where
+`constructor` and `toString` are absent instead of truthy.
 
 ## Pairing the head against the fetched state
 

--- a/packages/contracts/src/internal/era.ts
+++ b/packages/contracts/src/internal/era.ts
@@ -401,10 +401,67 @@ export const resolveOperationEra = async (
 };
 
 /**
+ * How one `(artifact era, head era)` pair may run, before the operation kind is taken into
+ * account.
+ *
+ * A closed set rather than a boolean: the pair that admits calls and refuses deploys is a cell in
+ * its own right, and collapsing it into "allowed" would lose the one asymmetry the fork window
+ * has.
+ */
+export type EraPairing =
+  /** Both kinds run. */
+  | 'run'
+  /** Calls run -- as keep-state, when the head has moved past the artifact -- and deploys do not. */
+  | 'call-only'
+  /** Neither kind runs: the artifact is from an era the network head has not reached. */
+  | 'artifact-newer-than-head';
+
+/**
+ * The pairing table {@link assertEraCompatible} rules from: one row per {@link PipelineEra}, one
+ * column per `LedgerVersion`.
+ *
+ * This declaration is the one place the two era vocabularies are bound together. They stay
+ * separate types because they answer different questions -- which era built the caller's artifact,
+ * and which era the network head is on -- but they may not drift apart in size. A member added to
+ * either set leaves this table short of a row or a column and the annotation refuses it, so a
+ * further era is a BUILD failure here rather than a refusal at run time.
+ *
+ * @see {@link EraDispatch} for the table in full and why the deploy cell differs.
+ * @see `packages/protocol/docs/shared-table-discipline.md` for the construction every era-keyed
+ * table in this tree uses.
+ */
+export type EraPairingTable = Readonly<Record<PipelineEra, Readonly<Record<LedgerVersion, EraPairing>>>>;
+
+// Null prototype and frozen, for the reason `packages/protocol/docs/shared-table-discipline.md`
+// gives: both keys reach here from caller- or network-supplied values, and a plain object literal
+// resolves `constructor` and `toString` through `Object.prototype` to truthy non-cells.
+//
+// Exported so `src/test/typecheck/era-pairing.test-d.ts` can assert the DECLARED type. Dropping
+// the annotation for an inferred `as const` would leave every runtime test green while the
+// build-time gate this table exists for was gone.
+export const ERA_PAIRING: EraPairingTable = Object.freeze(
+  Object.assign(Object.create(null) as Record<PipelineEra, Readonly<Record<LedgerVersion, EraPairing>>>, {
+    ledger8: Object.freeze(
+      Object.assign(Object.create(null) as Record<LedgerVersion, EraPairing>, {
+        v8: 'run',
+        v9: 'call-only'
+      } satisfies Record<LedgerVersion, EraPairing>)
+    ),
+    ledger9: Object.freeze(
+      Object.assign(Object.create(null) as Record<LedgerVersion, EraPairing>, {
+        v8: 'artifact-newer-than-head',
+        v9: 'run'
+      } satisfies Record<LedgerVersion, EraPairing>)
+    )
+  } satisfies Record<PipelineEra, Readonly<Record<LedgerVersion, EraPairing>>>)
+);
+
+/**
  * Refuses an operation whose artifact era and network head era cannot be run together.
  *
- * Holds the whole dispatch table, and every cell is ruled rather than left to fall through. A
- * retained-era DEPLOY on a post-fork head is the one cell where calls and deploys differ.
+ * Rules every cell of {@link ERA_PAIRING} rather than letting one fall through. A retained-era
+ * DEPLOY on a post-fork head is the one cell where calls and deploys differ, and the `'call-only'`
+ * verdict is where that difference lives.
  *
  * Returns nothing. Which pipeline runs is the `(pipeline, head)` pair the caller already holds;
  * this decides only whether that pair may run, so it does not restate the pair as a third value
@@ -418,39 +475,37 @@ export const resolveOperationEra = async (
  * @throws EraArtifactMismatchError with reason `'current-era-artifact-on-pre-fork-head'` for a
  * current-era artifact on a pre-fork head.
  * @throws Ledger8DeployOnV9Error for a retained-era deploy on a post-fork head.
- * @throws UnknownLedgerVersionError if a ledger era is added without a cell here.
+ * @throws UnknownLedgerVersionError naming whichever of the two eras has no cell here, if one is
+ * added without extending the table.
  */
 export const assertEraCompatible = (pipeline: PipelineEra, head: LedgerVersion, kind: 'call' | 'deploy'): void => {
-  switch (pipeline) {
-    case 'ledger9':
-      switch (head) {
-        case 'v9':
-          return;
-        case 'v8':
-          throw new EraArtifactMismatchError('current-era-artifact-on-pre-fork-head');
-        default: {
-          // The runtime throw is not redundant with the compile-time gate: a new era reaches here
-          // from a real head integer before this switch is updated.
-          const unhandled: never = head;
-          throw new UnknownLedgerVersionError(String(unhandled));
-        }
+  // Looked up and checked, never indexed straight into the switch. The compile-time gate on
+  // ERA_PAIRING does not cover the value that arrives from a real head integer, or from a caller's
+  // artifact, before the table is extended -- and a missing cell has to refuse rather than reach a
+  // neighbour's ruling. The annotations widen both lookups so the checks are comparisons the
+  // compiler keeps rather than ones it reports as impossible.
+  const rulings: Readonly<Record<LedgerVersion, EraPairing>> | undefined = ERA_PAIRING[pipeline];
+  if (rulings === undefined) {
+    throw new UnknownLedgerVersionError(String(pipeline));
+  }
+  const verdict: EraPairing | undefined = rulings[head];
+  if (verdict === undefined) {
+    throw new UnknownLedgerVersionError(String(head));
+  }
+
+  switch (verdict) {
+    case 'run':
+      return;
+    case 'call-only':
+      if (kind === 'deploy') {
+        throw new Ledger8DeployOnV9Error();
       }
-    case 'ledger8':
-      switch (head) {
-        case 'v9':
-          if (kind === 'deploy') {
-            throw new Ledger8DeployOnV9Error();
-          }
-          return;
-        case 'v8':
-          return;
-        default: {
-          const unhandled: never = head;
-          throw new UnknownLedgerVersionError(String(unhandled));
-        }
-      }
+      return;
+    case 'artifact-newer-than-head':
+      throw new EraArtifactMismatchError('current-era-artifact-on-pre-fork-head');
     default: {
-      const unhandled: never = pipeline;
+      // A verdict added to EraPairing without an arm here stops this assignment type-checking.
+      const unhandled: never = verdict;
       throw new UnknownLedgerVersionError(String(unhandled));
     }
   }

--- a/packages/contracts/src/internal/era.ts
+++ b/packages/contracts/src/internal/era.ts
@@ -37,7 +37,8 @@ import {
   type EraSeam,
   HeadStateEraMismatchError,
   IndexerInconsistencyError,
-  Ledger8DeployOnV9Error} from '../errors';
+  Ledger8DeployOnV9Error,
+  type StaleHeadOperationKind} from '../errors';
 import type { Ledger8Contract } from '../ledger8-contract';
 import { type BreadcrumbSink, emitEncoding, emitHeadResolution } from './breadcrumbs';
 
@@ -416,45 +417,54 @@ export type EraPairing =
   /** Neither kind runs: the artifact is from an era the network head has not reached. */
   | 'artifact-newer-than-head';
 
+/** One artifact era's ruling against every era the network head can be on. */
+export type EraRulings = Readonly<Record<LedgerVersion, EraPairing>>;
+
 /**
  * The pairing table {@link assertEraCompatible} rules from: one row per {@link PipelineEra}, one
  * column per `LedgerVersion`.
  *
- * This declaration is the one place the two era vocabularies are bound together. They stay
- * separate types because they answer different questions -- which era built the caller's artifact,
- * and which era the network head is on -- but they may not drift apart in size. A member added to
- * either set leaves this table short of a row or a column and the annotation refuses it, so a
- * further era is a BUILD failure here rather than a refusal at run time.
+ * The two era vocabularies stay separate types because they answer different questions -- which
+ * era built the caller's artifact, and which era the network head is on. What this type adds is
+ * that every pair of them has to be ruled: a member added to either set leaves the table short of
+ * a row or a column, and that is a build failure.
+ *
+ * It does NOT bind the two sets to each other. A further artifact era can be added without a
+ * further head era, and vice versa; what cannot happen is either one arriving unruled.
  *
  * @see {@link EraDispatch} for the table in full and why the deploy cell differs.
- * @see `packages/protocol/docs/shared-table-discipline.md` for the construction every era-keyed
- * table in this tree uses.
  */
-export type EraPairingTable = Readonly<Record<PipelineEra, Readonly<Record<LedgerVersion, EraPairing>>>>;
+export type EraPairingTable = Readonly<Record<PipelineEra, EraRulings>>;
 
-// Null prototype and frozen, for the reason `packages/protocol/docs/shared-table-discipline.md`
-// gives: both keys reach here from caller- or network-supplied values, and a plain object literal
-// resolves `constructor` and `toString` through `Object.prototype` to truthy non-cells.
-//
-// Exported so `src/test/typecheck/era-pairing.test-d.ts` can assert the DECLARED type. Dropping
-// the annotation for an inferred `as const` would leave every runtime test green while the
-// build-time gate this table exists for was gone.
-export const ERA_PAIRING: EraPairingTable = Object.freeze(
-  Object.assign(Object.create(null) as Record<PipelineEra, Readonly<Record<LedgerVersion, EraPairing>>>, {
-    ledger8: Object.freeze(
-      Object.assign(Object.create(null) as Record<LedgerVersion, EraPairing>, {
-        v8: 'run',
-        v9: 'call-only'
-      } satisfies Record<LedgerVersion, EraPairing>)
-    ),
-    ledger9: Object.freeze(
-      Object.assign(Object.create(null) as Record<LedgerVersion, EraPairing>, {
-        v8: 'artifact-newer-than-head',
-        v9: 'run'
-      } satisfies Record<LedgerVersion, EraPairing>)
-    )
-  } satisfies Record<PipelineEra, Readonly<Record<LedgerVersion, EraPairing>>>)
-);
+/**
+ * Re-homes a table onto a null prototype and freezes it, the construction
+ * `packages/protocol/docs/shared-table-discipline.md` prescribes for a table indexed by a value.
+ *
+ * The lone cast is the point of the helper: `Object.create(null)` is `any`, and asserting it once
+ * here keeps the assertion out of the table literals, where it would launder a missing row past
+ * their declared types.
+ */
+const withNullPrototype = <T extends object>(source: T): Readonly<T> =>
+  Object.freeze(Object.assign(Object.create(null) as T, source));
+
+// The two constructors below exist for their PARAMETER types. A literal handed to one is checked
+// against a total `Record`, so a missing cell, an excess cell and a verdict outside the set are all
+// build failures -- at the literal, where the mistake is. Annotating `ERA_PAIRING` itself cannot do
+// that: by then `withNullPrototype` has already asserted the rows into existence, and the
+// annotation would accept an empty table. Do not "simplify" these away.
+const rulings = (byHead: EraRulings): EraRulings => withNullPrototype(byHead);
+const pairingTable = (byPipeline: EraPairingTable): EraPairingTable => withNullPrototype(byPipeline);
+
+/**
+ * Every `(artifact era, head era)` pair, ruled.
+ *
+ * Exported so the construction itself can be asserted -- frozen, null-prototyped, on both levels.
+ * Nothing outside this module reads it to dispatch.
+ */
+export const ERA_PAIRING: EraPairingTable = pairingTable({
+  ledger8: rulings({ v8: 'run', v9: 'call-only' }),
+  ledger9: rulings({ v8: 'artifact-newer-than-head', v9: 'run' })
+});
 
 /**
  * Refuses an operation whose artifact era and network head era cannot be run together.
@@ -467,44 +477,63 @@ export const ERA_PAIRING: EraPairingTable = Object.freeze(
  * this decides only whether that pair may run, so it does not restate the pair as a third value
  * that could disagree with it.
  *
- * @see {@link EraDispatch} for the table in full and why the deploy cell differs.
- *
  * @param pipeline The pipeline the artifact belongs to, from {@link pipelineEraOf}.
  * @param head The era the network head is on, from {@link resolveOperationEra}.
- * @param kind Whether this operation deploys a contract or calls one already deployed.
+ * @param kind Whether this operation deploys a contract or calls one already deployed. Anything
+ * that is not a call is treated as a deploy, which is the refusing side.
  * @throws EraArtifactMismatchError with reason `'current-era-artifact-on-pre-fork-head'` for a
  * current-era artifact on a pre-fork head.
  * @throws Ledger8DeployOnV9Error for a retained-era deploy on a post-fork head.
- * @throws UnknownLedgerVersionError naming whichever of the two eras has no cell here, if one is
- * added without extending the table.
+ * @throws UnknownLedgerVersionError carrying whichever argument has no cell here, if an era is
+ * added without extending the table -- and also from the closing arm, carrying a verdict rather
+ * than an era, if a verdict is ever added without one. The class does not distinguish the three;
+ * read `requestedVersion` for the value that was refused.
  */
-export const assertEraCompatible = (pipeline: PipelineEra, head: LedgerVersion, kind: 'call' | 'deploy'): void => {
-  // Looked up and checked, never indexed straight into the switch. The compile-time gate on
-  // ERA_PAIRING does not cover the value that arrives from a real head integer, or from a caller's
-  // artifact, before the table is extended -- and a missing cell has to refuse rather than reach a
-  // neighbour's ruling. The annotations widen both lookups so the checks are comparisons the
-  // compiler keeps rather than ones it reports as impossible.
-  const rulings: Readonly<Record<LedgerVersion, EraPairing>> | undefined = ERA_PAIRING[pipeline];
-  if (rulings === undefined) {
+export const assertEraCompatible = (
+  pipeline: PipelineEra,
+  head: LedgerVersion,
+  kind: StaleHeadOperationKind
+): void => {
+  // Defence in depth, not a live boundary: both call sites pass literals today
+  // (`internal/ledger8-entry.ts`) and this module is not reachable from outside the package. The
+  // guards are here so that a future call site threading a value through cannot quietly widen what
+  // the table admits.
+  //
+  // The `typeof` checks are load-bearing and are NOT redundant with the parameter types. A member
+  // access coerces its key -- `ToPropertyKey` runs `toString` -- so an object, a `String` wrapper
+  // or anything with `Symbol.toPrimitive` would select a real row and be RULED ON, where the
+  // `switch` this replaced compared with `===` and refused it.
+  if (typeof pipeline !== 'string') {
     throw new UnknownLedgerVersionError(String(pipeline));
   }
-  const verdict: EraPairing | undefined = rulings[head];
-  if (verdict === undefined) {
+  const pipelineRulings = ERA_PAIRING[pipeline];
+  if (pipelineRulings === undefined) {
+    throw new UnknownLedgerVersionError(pipeline);
+  }
+
+  if (typeof head !== 'string') {
     throw new UnknownLedgerVersionError(String(head));
+  }
+  const verdict = pipelineRulings[head];
+  if (verdict === undefined) {
+    throw new UnknownLedgerVersionError(head);
   }
 
   switch (verdict) {
     case 'run':
       return;
     case 'call-only':
-      if (kind === 'deploy') {
+      // Refuses on anything that is not a call, rather than refusing only on `'deploy'`. The two
+      // read the same for a typed caller and differ for every other value, and this is the one
+      // asymmetric cell in the fork window -- so the value nobody anticipated must land on the
+      // refusing side.
+      if (kind !== 'call') {
         throw new Ledger8DeployOnV9Error();
       }
       return;
     case 'artifact-newer-than-head':
       throw new EraArtifactMismatchError('current-era-artifact-on-pre-fork-head');
     default: {
-      // A verdict added to EraPairing without an arm here stops this assignment type-checking.
       const unhandled: never = verdict;
       throw new UnknownLedgerVersionError(String(unhandled));
     }

--- a/packages/contracts/src/test/era-dispatch.test.ts
+++ b/packages/contracts/src/test/era-dispatch.test.ts
@@ -29,6 +29,7 @@ import {
   Ledger8DeployOnV9Error} from '../errors';
 import {
   assertEraCompatible,
+  ERA_PAIRING,
   type PipelineEra,
   pipelineEraOf,
   resolveContractStateEra,
@@ -208,7 +209,9 @@ describe('pipelineEraOf: which execution pipeline an artifact belongs to', () =>
   });
 });
 
-type OperationKind = 'call' | 'deploy';
+// Read off the production signature rather than restated here. A test-local alias would make the
+// exhaustive map below a gate over itself, which is what left the kind axis unbound.
+type OperationKind = Parameters<typeof assertEraCompatible>[2];
 
 interface DispatchCell {
   readonly artifact: string;
@@ -277,12 +280,15 @@ const ALL_KINDS: Record<OperationKind, OperationKind> = {
   deploy: 'deploy'
 };
 
-// The values the run-time guards exist for: eras no member of either vocabulary spells, handed
-// over the way a JavaScript caller or a not-yet-mapped head integer would hand them over. Widened
-// to `string` and asserted back in one named place, so the negative tests below read as the calls
-// they are rather than as a cast each.
-const asPipelineEra = (value: string): PipelineEra => value as PipelineEra;
-const asHeadEra = (value: string): LedgerVersion => value as LedgerVersion;
+// The values the run-time guards exist for, asserted back in one named place so the negative tests
+// below read as the calls they are rather than as a cast each.
+//
+// `unknown`, not `string`. Typed as `string` these helpers could not express the case that matters
+// most -- a non-string key, which a member access coerces and a `switch` did not -- so every
+// negative test would have been confined to the inputs that were already safe.
+const asPipelineEra = (value: unknown): PipelineEra => value as PipelineEra;
+const asHeadEra = (value: unknown): LedgerVersion => value as LedgerVersion;
+const asOperationKind = (value: unknown): OperationKind => value as OperationKind;
 
 describe('the era dispatch table: artifact era x network head era x operation kind', () => {
   it.each(ACCEPTED_CELLS)('accepts a $artifact $kind on a $head head, routing it $route', ({ pipeline, head, kind }) => {
@@ -358,7 +364,11 @@ describe('the era dispatch table: artifact era x network head era x operation ki
   // The refusal is asserted on `requestedVersion`, never on the class alone. Every path out of
   // this function that is not a ruling throws the same class, so a class-only assertion passes
   // whichever axis was refused and whatever value it blamed -- including a value read off
-  // `Object.prototype`, which is exactly what these two tests exist to rule out.
+  // `Object.prototype`, which is exactly what these tests exist to rule out.
+  //
+  // That one class covers both axes is a known wart, not something asserted here as desirable:
+  // `UnknownLedgerVersionError`'s own message names `v8`/`v9`, which is the wrong vocabulary for a
+  // refused artifact era. These tests pin the VALUE blamed, and deliberately not the message.
   const refusedEra = (pipeline: PipelineEra, head: LedgerVersion): string => {
     try {
       assertEraCompatible(pipeline, head, 'call');
@@ -375,6 +385,55 @@ describe('the era dispatch table: artifact era x network head era x operation ki
     // turned out to be. Both reach this function before the table is extended for them.
     expect(refusedEra(asPipelineEra('ledger10'), 'v9')).toBe('ledger10');
     expect(refusedEra('ledger8', asHeadEra('v10'))).toBe('v10');
+  });
+
+  it('refuses a key that merely COERCES to an era, on either axis', () => {
+    // A member access runs `ToPropertyKey` on its key, so `{ toString: () => 'ledger9' }` selects a
+    // real row. The nested switches this table replaced compared with `===` and refused it. Without
+    // the `typeof` guards these six inputs are RULED ON, and four of them are ruled `'run'`.
+    const coercing: readonly unknown[] = [
+      { toString: () => 'ledger9' },
+      { [Symbol.toPrimitive]: () => 'ledger9' },
+      new String('ledger9'),
+      Object('ledger9')
+    ];
+
+    for (const coerces of coercing) {
+      expect(refusedEra(asPipelineEra(coerces), 'v9')).toBe(String(coerces));
+      expect(refusedEra('ledger9', asHeadEra(coerces))).toBe(String(coerces));
+    }
+  });
+
+  it('refuses the two era arguments transposed', () => {
+    // Both are era-shaped strings in adjacent positions, so this is the call a caller gets wrong.
+    expect(refusedEra(asPipelineEra('v9'), 'v9')).toBe('v9');
+    expect(refusedEra('ledger9', asHeadEra('ledger9'))).toBe('ledger9');
+  });
+
+  it('refuses a retained-era operation on a post-fork head unless it is positively a call', () => {
+    // The `'call-only'` cell is the one asymmetric ruling in the fork window, so it refuses
+    // anything that is not a call rather than admitting anything that is not a deploy. Asserting
+    // only the two declared literals would leave that direction untested -- and every value here
+    // was ADMITTED before.
+    const notCalls: readonly unknown[] = ['Deploy', 'DEPLOY', 'deploy ', '', undefined, null, 0, {}];
+
+    for (const notCall of notCalls) {
+      expect(() => assertEraCompatible('ledger8', 'v9', asOperationKind(notCall))).toThrow(Ledger8DeployOnV9Error);
+    }
+    expect(() => assertEraCompatible('ledger8', 'v9', 'call')).not.toThrow();
+  });
+
+  it('holds the table frozen and off the object prototype, at both levels', () => {
+    // The behavioural consequence of the null prototype is pinned by the test below; this pins the
+    // construction itself, because dropping either `Object.freeze` changes no behaviour any other
+    // test observes while leaving a process-wide singleton that a test double can rewrite.
+    expect(Object.isFrozen(ERA_PAIRING)).toBe(true);
+    expect(Object.getPrototypeOf(ERA_PAIRING)).toBeNull();
+
+    for (const row of Object.values(ERA_PAIRING)) {
+      expect(Object.isFrozen(row)).toBe(true);
+      expect(Object.getPrototypeOf(row)).toBeNull();
+    }
   });
 
   it('refuses a prototype-reachable key on either axis, blaming the key and not a prototype member', () => {

--- a/packages/contracts/src/test/era-dispatch.test.ts
+++ b/packages/contracts/src/test/era-dispatch.test.ts
@@ -17,7 +17,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import type { LedgerVersion } from '@midnight-ntwrk/midnight-js-protocol';
+import { type LedgerVersion, UnknownLedgerVersionError } from '@midnight-ntwrk/midnight-js-protocol';
 import type { RawContractState } from '@midnight-ntwrk/midnight-js-types';
 import { CONTRACTS_ERROR_CODES, hasErrorCode, TagParseError } from '@midnight-ntwrk/midnight-js-utils';
 import { beforeAll, describe, expect, it, type Mock, vi } from 'vitest';
@@ -259,6 +259,31 @@ const REFUSED_CELLS: readonly (DispatchCell & {
   }
 ];
 
+// Exhaustive maps over the three axes, in the `Record<K, K>` form this repo uses where a test has
+// to enumerate a closed set: a member added to any of the three types stops the literal below
+// compiling, which is what makes the completeness gate further down a real one.
+const ALL_PIPELINES: Record<PipelineEra, PipelineEra> = {
+  ledger8: 'ledger8',
+  ledger9: 'ledger9'
+};
+
+const ALL_HEADS: Record<LedgerVersion, LedgerVersion> = {
+  v8: 'v8',
+  v9: 'v9'
+};
+
+const ALL_KINDS: Record<OperationKind, OperationKind> = {
+  call: 'call',
+  deploy: 'deploy'
+};
+
+// The values the run-time guards exist for: eras no member of either vocabulary spells, handed
+// over the way a JavaScript caller or a not-yet-mapped head integer would hand them over. Widened
+// to `string` and asserted back in one named place, so the negative tests below read as the calls
+// they are rather than as a cast each.
+const asPipelineEra = (value: string): PipelineEra => value as PipelineEra;
+const asHeadEra = (value: string): LedgerVersion => value as LedgerVersion;
+
 describe('the era dispatch table: artifact era x network head era x operation kind', () => {
   it.each(ACCEPTED_CELLS)('accepts a $artifact $kind on a $head head, routing it $route', ({ pipeline, head, kind }) => {
     expect(() => assertEraCompatible(pipeline, head, kind)).not.toThrow();
@@ -281,10 +306,16 @@ describe('the era dispatch table: artifact era x network head era x operation ki
     // differently on `kind`, so the cross product has to include it -- omitting it left
     // `ledger9/v9/deploy`, the most common post-fork operation there is, untested while this gate
     // claimed completeness.
+    //
+    // The three enumerations are `Record<K, K>` maps, not `readonly K[]` arrays. An array only
+    // asserts that each element IS a member and never that all members are listed, so a third
+    // pipeline era or a third ledger version compiled and left this gate claiming completeness
+    // over a cross product two thirds the real size. `breadcrumbs.test.ts` had the same weakness
+    // and records the same reason.
     const covered = [...ACCEPTED_CELLS.map(cellKey), ...REFUSED_CELLS.map(cellKey)];
-    const pipelines: readonly PipelineEra[] = ['ledger8', 'ledger9'];
-    const heads: readonly LedgerVersion[] = ['v8', 'v9'];
-    const kinds: readonly OperationKind[] = ['call', 'deploy'];
+    const pipelines = Object.values(ALL_PIPELINES);
+    const heads = Object.values(ALL_HEADS);
+    const kinds = Object.values(ALL_KINDS);
     const wholeCrossProduct = pipelines.flatMap((pipeline) =>
       heads.flatMap((head) => kinds.map((kind) => cellKey({ artifact: '', pipeline, head, kind })))
     );
@@ -312,6 +343,49 @@ describe('the era dispatch table: artifact era x network head era x operation ki
       expect(error).toBeInstanceOf(Ledger8DeployOnV9Error);
       expect(hasErrorCode(error, CONTRACTS_ERROR_CODES.LEDGER8_DEPLOY_ON_V9)).toBe(true);
       expect((error as Ledger8DeployOnV9Error).message).toMatch(/runtime-deploy|0\.18 artifacts/);
+    }
+  });
+
+  it('keeps the three exhaustive maps self-consistent, so none of them drives the wrong values', () => {
+    // The maps are compile-time gates whose VALUES are what the cross product above is built from.
+    // A copy-paste slip -- a key mapped to a sibling's value -- would compile and would quietly
+    // cover one member twice while never covering another.
+    expect(Object.keys(ALL_PIPELINES)).toEqual(Object.values(ALL_PIPELINES));
+    expect(Object.keys(ALL_HEADS)).toEqual(Object.values(ALL_HEADS));
+    expect(Object.keys(ALL_KINDS)).toEqual(Object.values(ALL_KINDS));
+  });
+
+  // The refusal is asserted on `requestedVersion`, never on the class alone. Every path out of
+  // this function that is not a ruling throws the same class, so a class-only assertion passes
+  // whichever axis was refused and whatever value it blamed -- including a value read off
+  // `Object.prototype`, which is exactly what these two tests exist to rule out.
+  const refusedEra = (pipeline: PipelineEra, head: LedgerVersion): string => {
+    try {
+      assertEraCompatible(pipeline, head, 'call');
+      return expect.unreachable(`assertEraCompatible ruled on ${String(pipeline)}/${String(head)}`);
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnknownLedgerVersionError);
+      return (error as UnknownLedgerVersionError).requestedVersion;
+    }
+  };
+
+  it('refuses an era outside either vocabulary, naming the one it could not place', () => {
+    // The build-time gate on the pairing table cannot cover these: a head era arrives as an
+    // integer resolved at run time, and a pipeline era as whatever a JavaScript caller's artifact
+    // turned out to be. Both reach this function before the table is extended for them.
+    expect(refusedEra(asPipelineEra('ledger10'), 'v9')).toBe('ledger10');
+    expect(refusedEra('ledger8', asHeadEra('v10'))).toBe('v10');
+  });
+
+  it('refuses a prototype-reachable key on either axis, blaming the key and not a prototype member', () => {
+    // The difference between a table on a null prototype and one on a plain object literal. From a
+    // literal, `ERA_PAIRING.constructor` comes back as a truthy non-cell, so the refusal moves to
+    // the OTHER axis and blames a head era that was perfectly valid; on the head axis it blames
+    // `Object.prototype.constructor` rendered as a string. Both axes are checked, because both
+    // keys are supplied from outside this package.
+    for (const inherited of ['constructor', 'toString', 'hasOwnProperty', 'valueOf', '__proto__']) {
+      expect(refusedEra(asPipelineEra(inherited), 'v9')).toBe(inherited);
+      expect(refusedEra('ledger8', asHeadEra(inherited))).toBe(inherited);
     }
   });
 

--- a/packages/contracts/src/test/typecheck/era-pairing.test-d.ts
+++ b/packages/contracts/src/test/typecheck/era-pairing.test-d.ts
@@ -17,37 +17,25 @@ import type { LedgerVersion } from '@midnight-ntwrk/midnight-js-protocol';
 import { describe, expectTypeOf, it } from 'vitest';
 
 import type { PipelineEra } from '../../era';
-import { ERA_PAIRING, type EraPairing, type EraPairingTable } from '../../internal/era';
+import type { EraPairing, EraPairingTable, EraRulings } from '../../internal/era';
 
-// Compile-level tests, run by the typecheck pass this package enables in `vitest.config.ts` —
+// Compile-level tests, run by the typecheck pass this package enables in `vitest.config.ts` --
 // see the note at the top of `./overloads.test-d.ts` for how they are gated.
 //
-// What they pin is the ONE declaration that binds the two era vocabularies together: `PipelineEra`
-// keys the rows and `LedgerVersion` keys the columns, so neither set can gain a member without
-// this table gaining the cells for it. The runtime behaviour of every cell is asserted separately,
-// in `../era-dispatch.test.ts`.
+// These two types are the PARAMETER types of the constructors that build the pairing table, so a
+// literal rejected here is a literal the table cannot be built from. That is the whole gate: the
+// annotation on the table itself cannot carry it, because by then the null-prototype cast has
+// asserted the rows into existence and an empty table would satisfy it.
+//
+// Each case gets its own `it`, so a failure names the regression that caused it rather than
+// pointing at a block that covers four of them.
 
-describe('the era pairing table is declared total in BOTH era vocabularies', () => {
-  it('types the table as a row per pipeline era and a column per ledger version', () => {
-    expectTypeOf(ERA_PAIRING).toEqualTypeOf<EraPairingTable>();
-    expectTypeOf<EraPairingTable>().toEqualTypeOf<
-      Readonly<Record<PipelineEra, Readonly<Record<LedgerVersion, EraPairing>>>>
-    >();
+describe('a pairing table must rule every artifact era', () => {
+  it('is a total map from artifact era to rulings', () => {
+    expectTypeOf<EraPairingTable>().toEqualTypeOf<Readonly<Record<PipelineEra, EraRulings>>>();
   });
 
-  it('refuses a table whose row rules only some of the ledger versions', () => {
-    // A `Partial<Record<...>>` here — the shape `NODE_MAJOR_TO_LEDGER` legitimately uses, and so
-    // the shape a later edit is most likely to copy — would accept this and leave the pairing
-    // undecided for one head era at run time.
-    const missingColumn: EraPairingTable = {
-      ledger8: { v8: 'run', v9: 'call-only' },
-      // @ts-expect-error - this row rules no `v8` head
-      ledger9: { v9: 'run' }
-    };
-    void missingColumn;
-  });
-
-  it('refuses a table missing a whole pipeline era', () => {
+  it('refuses a table missing an artifact era', () => {
     // @ts-expect-error - no `ledger8` row
     const missingRow: EraPairingTable = {
       ledger9: { v8: 'artifact-newer-than-head', v9: 'run' }
@@ -55,14 +43,48 @@ describe('the era pairing table is declared total in BOTH era vocabularies', () 
     void missingRow;
   });
 
+  it('refuses a table carrying an artifact era the vocabulary does not spell', () => {
+    const excessRow: EraPairingTable = {
+      ledger8: { v8: 'run', v9: 'call-only' },
+      ledger9: { v8: 'artifact-newer-than-head', v9: 'run' },
+      // @ts-expect-error - `ledger10` is not a `PipelineEra`, so this cell could only ever be
+      // reached by a value the vocabulary has already refused
+      ledger10: { v8: 'run', v9: 'run' }
+    };
+    void excessRow;
+  });
+});
+
+describe('one row must rule every head era', () => {
+  it('is a total map from head era to verdict', () => {
+    expectTypeOf<EraRulings>().toEqualTypeOf<Readonly<Record<LedgerVersion, EraPairing>>>();
+  });
+
+  it('refuses a row that rules only some of the head eras', () => {
+    // `Partial<Record<...>>` here would accept this and leave the pairing undecided for one head
+    // era at run time. That shape is right for `NODE_MAJOR_TO_LEDGER`, whose keys are `number` --
+    // an open domain, where a total `Record` is not expressible. It is wrong for a closed union,
+    // and the two must not be conflated.
+    // @ts-expect-error - rules no `v8` head
+    const missingColumn: EraRulings = { v9: 'run' };
+    void missingColumn;
+  });
+
+  it('refuses a row carrying a head era the vocabulary does not spell', () => {
+    const excessColumn: EraRulings = {
+      v8: 'run',
+      v9: 'call-only',
+      // @ts-expect-error - `v10` is not a `LedgerVersion`
+      v10: 'run'
+    };
+    void excessColumn;
+  });
+
   it('refuses a ruling outside the closed verdict set', () => {
     // Without this the table would type-check with a verdict `assertEraCompatible` never reads,
-    // which is a cell that silently falls through to its unreachable arm.
-    const unknownVerdict: EraPairingTable = {
-      // @ts-expect-error - `'maybe'` is not an era pairing verdict
-      ledger8: { v8: 'run', v9: 'maybe' },
-      ledger9: { v8: 'artifact-newer-than-head', v9: 'run' }
-    };
+    // which is a cell that silently falls through to its unreachable closing arm.
+    // @ts-expect-error - `'maybe'` is not an era pairing verdict
+    const unknownVerdict: EraRulings = { v8: 'run', v9: 'maybe' };
     void unknownVerdict;
   });
 });

--- a/packages/contracts/src/test/typecheck/era-pairing.test-d.ts
+++ b/packages/contracts/src/test/typecheck/era-pairing.test-d.ts
@@ -1,0 +1,68 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LedgerVersion } from '@midnight-ntwrk/midnight-js-protocol';
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type { PipelineEra } from '../../era';
+import { ERA_PAIRING, type EraPairing, type EraPairingTable } from '../../internal/era';
+
+// Compile-level tests, run by the typecheck pass this package enables in `vitest.config.ts` —
+// see the note at the top of `./overloads.test-d.ts` for how they are gated.
+//
+// What they pin is the ONE declaration that binds the two era vocabularies together: `PipelineEra`
+// keys the rows and `LedgerVersion` keys the columns, so neither set can gain a member without
+// this table gaining the cells for it. The runtime behaviour of every cell is asserted separately,
+// in `../era-dispatch.test.ts`.
+
+describe('the era pairing table is declared total in BOTH era vocabularies', () => {
+  it('types the table as a row per pipeline era and a column per ledger version', () => {
+    expectTypeOf(ERA_PAIRING).toEqualTypeOf<EraPairingTable>();
+    expectTypeOf<EraPairingTable>().toEqualTypeOf<
+      Readonly<Record<PipelineEra, Readonly<Record<LedgerVersion, EraPairing>>>>
+    >();
+  });
+
+  it('refuses a table whose row rules only some of the ledger versions', () => {
+    // A `Partial<Record<...>>` here — the shape `NODE_MAJOR_TO_LEDGER` legitimately uses, and so
+    // the shape a later edit is most likely to copy — would accept this and leave the pairing
+    // undecided for one head era at run time.
+    const missingColumn: EraPairingTable = {
+      ledger8: { v8: 'run', v9: 'call-only' },
+      // @ts-expect-error - this row rules no `v8` head
+      ledger9: { v9: 'run' }
+    };
+    void missingColumn;
+  });
+
+  it('refuses a table missing a whole pipeline era', () => {
+    // @ts-expect-error - no `ledger8` row
+    const missingRow: EraPairingTable = {
+      ledger9: { v8: 'artifact-newer-than-head', v9: 'run' }
+    };
+    void missingRow;
+  });
+
+  it('refuses a ruling outside the closed verdict set', () => {
+    // Without this the table would type-check with a verdict `assertEraCompatible` never reads,
+    // which is a cell that silently falls through to its unreachable arm.
+    const unknownVerdict: EraPairingTable = {
+      // @ts-expect-error - `'maybe'` is not an era pairing verdict
+      ledger8: { v8: 'run', v9: 'maybe' },
+      ledger9: { v8: 'artifact-newer-than-head', v9: 'run' }
+    };
+    void unknownVerdict;
+  });
+});

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -61,7 +61,7 @@ export default defineConfig({
         // makes unreachable for a typed caller.
         'src/internal/ledger8-pipeline.ts': { lines: 100, functions: 100, branches: 100, statements: 100 },
         'src/internal/ledger8-entry.ts': { lines: 97, functions: 100, branches: 89, statements: 97 },
-        'src/internal/era.ts': { lines: 87, functions: 100, branches: 88, statements: 87 }
+        'src/internal/era.ts': { lines: 92, functions: 100, branches: 91, statements: 92 }
       }
     },
     reporters: [


### PR DESCRIPTION
## Summary

Follow-up to finding 1 of `docs/reviews/2026-09-11-pr-1218-architecture-review.md`. Targets `feat/1004-protocol-dual-ledger`, not `main`.

**The finding, restated after reading the code.** `PipelineEra` (`'ledger8' | 'ledger9'`, `packages/contracts`) and `LedgerVersion` (`'v8' | 'v9'`, `packages/protocol`) do **not** mean the same thing, so this PR does not alias one to the other. They answer different questions — which era built the caller's artifact, and which era the network head is on — and after the fork they deliberately **disagree**: a retained-era call is recorded as a keep-state transaction tagged `version: 'v9'` while `era` on its result says `'ledger8'` (ADR-0011). `Ledger8FinalizedCallTxData` carries both members, and `PipelineSelectionBreadcrumb` logs both side by side. Spelling them with one alphabet would put two identically-typed members holding different values on one object, and the disagreement the tag exists to express would read as a bug.

Two corrections to the review while I was in there:

- The "third dictionary" (`[v6]`/`[v8]` in `packages/utils/src/contract-state-envelope.ts`) is not an era vocabulary. It is a state-format tag, keyed **by** `LedgerVersion` and gated with `satisfies Record<LedgerVersion, string>` — already the pattern this PR follows, not a problem.
- The cartesian product in `assertEraCompatible` is a **separate** problem from the vocabulary. Aliasing the types would not have shrunk it by one cell.

**What was actually missing** is a declaration binding the two sets. `packages/types/src/versioned.ts` has four type assertions tying its discriminant to `LedgerVersion`; `packages/contracts/src/era.ts` had none, so a further era added to one set and not the other compiled clean.

**The change.** `assertEraCompatible` rules from `ERA_PAIRING`, a data table with one row per `PipelineEra` and one column per `LedgerVersion`, in place of the nested switches. Each cell holds one `EraPairing` verdict — `'run'`, `'call-only'`, `'artifact-newer-than-head'` — and `'call-only'` is where the retained-deploy asymmetry lives.

Every pair of the two vocabularies has to be ruled, so a member added to either one leaves the table short of a row or a column and the **build fails** — a third era is a compile error rather than a refusal discovered at the fork. It does **not** bind the two sets to each other in size: an artifact era can be added without a head era and the reverse. What cannot happen is either arriving unruled.

The table is built through two one-line constructors whose **parameter** types are `EraPairingTable` and `EraRulings`. That is where the gate lives, and it is not ceremony: the table is re-homed onto a null prototype, and `Object.create(null) as T` asserts the rows into existence before any annotation on `ERA_PAIRING` is checked — an empty table would satisfy it.

**Scope note.** The review proposed this as two changes, a `PIPELINE_ERA_BY_LEDGER_VERSION` bridge table (a) and a data-table dispatch (b). They collapse into one artifact: `ERA_PAIRING`'s key structure already gates both vocabularies, and a separate correspondence table would have had no caller anywhere in the tree — `resolveContractStateEra` and the era facade both work in `LedgerVersion` alone, and no code converts between the two. Shipping it would have added a fourth place to edit and dead code to reject.

## Behaviour against the base branch

All eight declared cells keep their verdicts and their error classes. There is **one deliberate change**: the `'call-only'` cell refused only the exact string `'deploy'`, so `'Deploy'`, `''`, `undefined`, `null`, `0` and `{}` all ran as calls — a retained-era deploy onto a post-fork head. It now refuses anything that is not positively a call.

## Review round (commit `c2223ad7`)

Five review agents ran over the first commit. Three findings were real:

- **A fail-open the table introduced.** A `switch` discriminates with `===`; a member access runs `ToPropertyKey`, which calls `toString`. So `{ toString: () => 'ledger9' }`, `new String('ledger9')` and `Symbol.toPrimitive` carriers selected a real row and were ruled on — four of them ruled `'run'`. Both lookups now check `typeof === 'string'` first. Measured against a transcription of the pre-PR switches, this was the only permissive divergence in the whole change.
- **The build-time gate was not where the annotation suggested.** `: EraPairingTable` on `ERA_PAIRING` accepted a table missing a row, missing a column, or entirely empty; the gate was the `satisfies` clauses alone, which read as redundant next to an explicit annotation and were one cleanup away from deletion. Rebuilt through the two constructors described above. Verified: deleting a row or a column from `ERA_PAIRING` is now a `tsc` error on the package build, not merely a test failure.
- **The kind axis was unbound.** `OperationKind` in the completeness gate was a test-local alias, so the exhaustive map over it gated only itself. It now reads off the production signature, and `assertEraCompatible` takes `StaleHeadOperationKind` — the type `errors.ts` already declares and whose docstring already claimed this function used it.

A batch of comment and doc corrections went with it, all cases of prose describing a mechanism the code does not have: the gate is the constructors and not the annotation; `x === undefined` is not a comparison TypeScript reports as impossible; a prototype-reachable key never reached a wrong verdict, only a misattributed refusal; `NODE_MAJOR_TO_LEDGER` is `Partial` because its keys are `number`, not as a style choice; and the null-prototype discipline is scoped to tables indexed by a value, which not every era-keyed table in this tree is.

## Test plan

- [x] Tests written first (TDD), verified they fail before the fix — the compile-level suite was red on 3 of 4 cases before `EraPairingTable` existed; each of the five review fixes was mutation-verified, reverting it turns exactly one test red.
- [x] All existing tests pass (no regressions) — 597 passed, 40 files, `--force` so nothing came from the turbo cache.
- [x] Lint clean, build succeeds — `yarn build` and `yarn lint` at the repo root, both clean.

What the tests pin:

- **`era-pairing.test-d.ts`** (compile-level, run by this package's vitest typecheck pass): missing row, missing column, excess row, excess column and a verdict outside the closed set — one case per `it`, so a failure names the regression.
- **Completeness gate**: it enumerated its axes as `readonly PipelineEra[]` / `readonly LedgerVersion[]`, which only asserts each element **is** a member and never that all members are listed — so a third era would have compiled and left the gate claiming completeness over a third of the real cross product. `breadcrumbs.test.ts` had the identical weakness and records the identical reason. Now `Record<K, K>` maps plus a self-consistency check.
- **Refusals** asserted on `requestedVersion`, not the error class alone: every non-ruling path throws the same class, so a class-only assertion passes whichever axis was refused and whatever value it blamed. Verified against a plain-object-literal mutant, which blames `'v9'` where the real table blames `'constructor'`.
- **New negative coverage**: coercing keys on both axes, transposed arguments, eight non-call `kind` values, and `Object.isFrozen` + null-prototype assertions on the table and both rows. Dropping either freeze previously left the whole suite green.
- **`vitest.config.ts`**: `src/internal/era.ts` coverage floor raised to 92/92/91 (from 87/87/88); the file now reaches 93.54 / 93.75 / 92.30.

## Known limitations, not addressed here

Found during review, all pre-existing on the base branch. Raising separately rather than widening this PR:

- `UnknownLedgerVersionError` covers both axes, and its message names `v8`/`v9` — the wrong vocabulary for a refused *artifact* era, and it points the reader at `protocolVersionToLedger`, which cannot produce one. The new tests pin the value blamed and deliberately not the message.
- `isLedger8Result` (`src/era-results.ts`) has no `never` exhaustiveness gate, so a third era compiles and throws at run time.
- `CurrentPipelineEra` is `Extract<PipelineEra, 'ledger9'>`, which still resolves to `'ledger9'` after a third era is added — every result construction site would keep tagging results `'ledger9'` with no diagnostic.
