### PR TITLE
fix(midnight-js)!: establish the artifact era from its declared runtime version

### DIFF
--- a/docs/adr/0012-read-the-artifact-era-from-what-the-artifact-declares.md
+++ b/docs/adr/0012-read-the-artifact-era-from-what-the-artifact-declares.md
@@ -31,27 +31,36 @@ this framework never sees.
 The era is a consensus-level fact. It was being inferred from a detail of
 generated JavaScript that a build step is free to rewrite.
 
-Two declared facts were available and unused:
+Two build-stable facts were available and unused:
 
-- the current toolchain's `CompiledContract` container assigns itself an own
-  `tag`, which survives the object spread its own combinators perform, and which
-  no build step rewrites;
-- `compactc` records `runtime-version` in `compiler/contract-info.json` beside
-  the keys, for BOTH toolchains — including the retained one, which emits no
-  integrity manifest (`contract-manifest.json` arrived in compactc 0.33).
+- a current-era contract arrives wrapped in a `CompiledContract` container
+  carrying an own `tag`. The tag's VALUE is chosen by the caller
+  (`CompiledContract.make(tag, ctor)`) and says nothing about an era — what is
+  usable is that no other shape has this one, and that an own property survives
+  both a bundler and the object spread the container's own combinators perform;
+- `compactc` records `runtime-version` on disk: in `compiler/contract-manifest.json`
+  from 0.33 onward, and in `compiler/contract-info.json` for every version
+  including the retained toolchain (0.31), which emits no manifest at all.
 
 ## Decision
 
 We will establish an artifact's era only from what the artifact declares, never
 from the shape of the code the compiler generated.
 
-- A current-era container is placed by its own `tag`. The artifact bundle is
-  NOT read for it.
+- A current-era container is placed by recognising the container — an own string
+  `tag` with no circuit collections. The artifact bundle is NOT read for it.
 - A retained-era candidate is placed by the `runtime-version` its bundle
   declares, read through a new `ZKConfigProvider.getArtifactRuntimeVersion()`
   and mapped by one frozen `major.minor` table in
   `packages/contracts/src/internal/era.ts`, guarded by a compile-time gate that
   every pipeline era is reachable from some declared version.
+- That version is taken from the INTEGRITY MANIFEST when the bundle has one,
+  because `expectedManifestHash` pins the manifest to a digest the application
+  controls and nothing else in the bundle can be anchored that way. The value
+  decides which ledger executes the call, so whoever serves the artifacts must
+  not be the one who decides it. `contract-info.json` is the fallback for
+  pre-0.33 bundles, and where a manifest exists it vouches for that file too, so
+  the fallback passes the same integrity gate as every key and ZKIR.
 - `constructor.name` may only REFUSE, and may never route. An `AsyncFunction`
   reading is proof of the current era that a build step can erase but never
   fabricate, so it stays as a refusal; a plain-function reading proves nothing
@@ -71,9 +80,14 @@ from the shape of the code the compiler generated.
   round trip, and its dispatch is unchanged.
 - **Positive:** the era comes from the same bundle the proof will be built from,
   rather than from an object handed in beside it.
-- **Negative:** retained-era callers must serve `compiler/contract-info.json`
-  from the same location as `keys/` and `zkir/`. A bundle that ships only keys
-  and ZKIR is refused on that arm.
+- **Negative:** retained-era callers must serve `compiler/` from the same
+  location as `keys/` and `zkir/`. A bundle that ships only keys and ZKIR is
+  refused on that arm.
+- **Negative:** a retained bundle has no manifest, so under the default
+  `verify: 'require'` its unvouched-for description is refused. Such callers must
+  construct the provider with `verify: 'require-if-present'` — the mode the
+  integrity work already defines for pre-0.33 artifacts, and which their key and
+  ZKIR reads need anyway.
 - **Negative:** `ZKConfigProvider` grows a member. It is concrete rather than
   abstract, with a default that throws, so a provider written outside this
   framework keeps compiling and keeps working for current-era artifacts; it

--- a/docs/adr/0012-read-the-artifact-era-from-what-the-artifact-declares.md
+++ b/docs/adr/0012-read-the-artifact-era-from-what-the-artifact-declares.md
@@ -1,0 +1,105 @@
+# 0012. Read an artifact's ledger era from what the artifact declares
+
+- Status: Accepted
+- Date: 2026-09-11
+- Deciders: Szymon Paluchowski
+- Related: #1218 (the dual-ledger dispatch this hardens), #1004
+
+## Context
+
+Across the ledger hard fork the contract entry points accept artifacts from two
+Compact toolchains through one API, and each operation must decide which
+pipeline runs. That decision was made from the shape of the caller's contract
+object, in `pipelineEraOf`:
+
+| shape | verdict |
+| ----- | ------- |
+| own `tag`, no `impureCircuits` | current era |
+| own `impureCircuits`, `initialState.constructor.name === 'Function'` | retained era |
+| own `impureCircuits`, `initialState.constructor.name === 'AsyncFunction'` | refused |
+| anything else | refused |
+
+The second and third rows are not stable facts about the artifacts. The current
+toolchain emits `async initialState`; a consumer's build targeting below ES2017
+— TypeScript, esbuild, older Babel presets — rewrites that into a plain
+function, and `constructor.name` then reads `'Function'` on it. A current-era
+contract passed raw therefore stopped being refused and was routed into the
+RETAINED pipeline instead. Every other branch of that function fails closed;
+this one failed open, and it failed open silently, on a consumer build setting
+this framework never sees.
+
+The era is a consensus-level fact. It was being inferred from a detail of
+generated JavaScript that a build step is free to rewrite.
+
+Two declared facts were available and unused:
+
+- the current toolchain's `CompiledContract` container assigns itself an own
+  `tag`, which survives the object spread its own combinators perform, and which
+  no build step rewrites;
+- `compactc` records `runtime-version` in `compiler/contract-info.json` beside
+  the keys, for BOTH toolchains — including the retained one, which emits no
+  integrity manifest (`contract-manifest.json` arrived in compactc 0.33).
+
+## Decision
+
+We will establish an artifact's era only from what the artifact declares, never
+from the shape of the code the compiler generated.
+
+- A current-era container is placed by its own `tag`. The artifact bundle is
+  NOT read for it.
+- A retained-era candidate is placed by the `runtime-version` its bundle
+  declares, read through a new `ZKConfigProvider.getArtifactRuntimeVersion()`
+  and mapped by one frozen `major.minor` table in
+  `packages/contracts/src/internal/era.ts`, guarded by a compile-time gate that
+  every pipeline era is reachable from some declared version.
+- `constructor.name` may only REFUSE, and may never route. An `AsyncFunction`
+  reading is proof of the current era that a build step can erase but never
+  fabricate, so it stays as a refusal; a plain-function reading proves nothing
+  and only earns the artifact the right to have its bundle consulted.
+- An artifact set that declares nothing, or declares a toolchain this framework
+  cannot place, is refused — `artifact-era-undeclared` and
+  `unknown-artifact-runtime-version`. Neither resolves to a default, because
+  every default would be a guess about which ledger executes the call.
+
+## Consequences
+
+- **Positive:** the fail-open closes. A transpiled current-era contract is now
+  refused by the same declaration that places a real retained one. The hole the
+  shape check could not close either — a `class` used as `initialState`, whose
+  own constructor IS `Function` — closes with it.
+- **Positive:** the current era pays nothing. It ships no new file, makes no new
+  round trip, and its dispatch is unchanged.
+- **Positive:** the era comes from the same bundle the proof will be built from,
+  rather than from an object handed in beside it.
+- **Negative:** retained-era callers must serve `compiler/contract-info.json`
+  from the same location as `keys/` and `zkir/`. A bundle that ships only keys
+  and ZKIR is refused on that arm.
+- **Negative:** `ZKConfigProvider` grows a member. It is concrete rather than
+  abstract, with a default that throws, so a provider written outside this
+  framework keeps compiling and keeps working for current-era artifacts; it
+  fails, loudly and by name, only if handed retained-era ones. A provider mocked
+  as an object literal in a consumer's tests does have to add the member.
+- **Follow-ups:** when the fork window closes and the retained arm is removed,
+  `getArtifactRuntimeVersion`, the version table and the two new refusal reasons
+  go with it, in one step.
+
+## Alternatives considered
+
+- **Keep sniffing, detect transpiled `async` better** — inspect
+  `Symbol.toStringTag`, or match `__awaiter`/`regeneratorRuntime` in
+  `Function.prototype.toString()`. Rejected: it chases each transpiler's output
+  and stays a guess about generated code, which is the class of defect being
+  removed, not an instance of it.
+- **A framework-owned container for the retained era**, so the caller declares
+  the era the way the current toolchain's container does. Rejected for this
+  change: it works, but it puts the declaration on the CALLER rather than on the
+  artifact, and it makes the retained era visibly different to use — against the
+  single-API premise of #1218. Kept as the fallback if serving
+  `contract-info.json` turns out to be impractical for real deployments.
+- **Separate era-specific entry points** (`submitLedger8CallTx`, …), making the
+  era a compile-time fact. Rejected outright: it contradicts the goal of one
+  common API across this fork and the next.
+- **Cross-check the current era against `contract-info.json` too.** Rejected on
+  cost: it would make the file mandatory for every existing consumer, which is a
+  breaking change for artifacts that are already correctly placed by a
+  declaration they carry.

--- a/packages/contracts/docs/breadcrumbs.md
+++ b/packages/contracts/docs/breadcrumbs.md
@@ -85,9 +85,13 @@ name could disagree with the pair it was derived from, which is the same reason
 the era gate itself returns nothing.
 
 `source` has one value today, because a pipeline is selected in exactly one way:
-from the shape of the compiled contract the caller passed. It is carried anyway,
+from the `runtime-version` the artifact set declares. It is carried anyway,
 because a second selection input is exactly the change that would need to show
-up in a log.
+up in a log — and this field has already earned that keep once. It read
+`compiled-contract-shape` while the era was inferred from the generated code;
+when that inference was replaced (see [EraDispatch](./era-dispatch.md)), the
+field was the one place an operator could otherwise have gone on reading a
+retired answer.
 
 `contractAddress` is present exactly when the operation names one, and ABSENT
 otherwise rather than empty. A deploy has no address until its composition mints

--- a/packages/contracts/docs/era-dispatch.md
+++ b/packages/contracts/docs/era-dispatch.md
@@ -31,25 +31,45 @@ A pipeline era is not a statement about the network. It says only which era's
 artifact the caller handed over; whether that artifact can run at all is the
 pairing rule below.
 
-## Reading the artifact's era: only from what the artifact declares
+## Reading the artifact's era: never from the generated code
 
-The era is a consensus-level fact, so it is established only from something the
-artifact states about itself. It is never inferred from the shape of the code
-the compiler generated, because a consumer's build is free to rewrite that
-shape and this framework never sees the setting that did.
+The era is a consensus-level fact, so it is never inferred from the shape of the
+code the compiler generated: a consumer's build is free to rewrite that shape,
+and this framework never sees the setting that did.
 
-Each era carries its own declaration:
+The two eras are answered differently, and it is worth being exact about why:
 
-| era | declaration | where it comes from |
-| --- | ----------- | ------------------- |
-| current | own `tag` on the `CompiledContract` container | the container assigns it to itself |
-| retained | `runtime-version` | `compiler/contract-info.json`, emitted by `compactc` |
+| era | what answers it | why a build cannot change it |
+| --- | --------------- | ---------------------------- |
+| current | the `CompiledContract` container it arrives in, recognised by its own `tag` | the property is an OWN one, and only that container has this shape |
+| retained | the `runtime-version` its artifact set declares | it is data on disk, not code |
 
-Only the retained arm reads the bundle, through
-`ZKConfigProvider.getArtifactRuntimeVersion()`. The current era's declaration is
-on the object already in hand, so a current-era caller buys no round trip and
-needs no file it does not already ship. `resolveArtifactEra` in
+The current era's answer is a CONTAINER CHECK, not a statement by the compiler.
+The `tag`'s value is chosen by the caller — `CompiledContract.make(tag, ctor)` —
+and carries no era information. What places the object is that nothing else has
+this shape, and that the property survives both a bundler and the object spread
+the container's own combinators perform. The retained era has no such container,
+which is why it is the arm that has to ask the artifact set.
+
+So only the retained arm reads the bundle, through
+`ZKConfigProvider.getArtifactRuntimeVersion()`; a current-era caller buys no
+round trip and needs no file it does not already ship. `resolveArtifactEra` in
 `packages/contracts/src/internal/era.ts` holds both halves.
+
+### Which file the retained answer comes from
+
+The provider prefers the INTEGRITY MANIFEST (`compiler/contract-manifest.json`),
+which already records `runtime-version`. That file is the only one in a bundle
+an application can anchor to a digest it controls, via `expectedManifestHash`;
+everything else is served from the same place as the artifacts it describes.
+Since this value selects which ledger pipeline executes a call, whoever serves
+the artifacts must not be the one who decides it.
+
+`compiler/contract-info.json` is the fallback, because `compactc` only began
+emitting a manifest in 0.33 and the retained toolchain (0.31) never did. When a
+manifest IS present it vouches for that file too, so the fallback passes through
+the same integrity gate as every key and ZKIR — under the default `require` an
+unvouched-for description is refused rather than trusted.
 
 `@midnight-ntwrk/compact-js` also brands its `CompiledContract` with the
 registered symbol `Symbol.for('compact-js/CompiledContract')`, which looks like
@@ -76,12 +96,13 @@ properties and loses everything it only inherited.
 
 ### What the shape is still read for
 
-The shape decides which DECLARATION to consult, and which objects to refuse
-outright. It never decides an era.
+The shape decides an era for exactly one input — the current-era container,
+which carries its marker on the object itself. For everything else it decides
+only which declaration to consult, or refuses outright.
 
 | shape | own `tag` | own `impureCircuits` | `initialState` | verdict |
 | ----- | --------- | -------------------- | -------------- | ------- |
-| current-era container | string | absent | absent | `'ledger9'`, declared by the `tag` |
+| current-era container | string | absent | absent | `'ledger9'`, from the container itself |
 | retained-era candidate | absent | present | `Function` | ask the bundle |
 | raw current-era instance | absent | present | `AsyncFunction` | refused, by name |
 | anything else | — | — | — | refused as neither era |

--- a/packages/contracts/docs/era-dispatch.md
+++ b/packages/contracts/docs/era-dispatch.md
@@ -6,7 +6,7 @@ title: EraDispatch
 
 Across the ledger hard fork the same entry point can run one of three ways, and
 which one it takes is decided by two independent facts: the ERA THE ARTIFACT
-BELONGS TO, read off the caller's contract object, and the ERA THE NETWORK HEAD
+BELONGS TO, read from what the artifact DECLARES, and the ERA THE NETWORK HEAD
 IS ON, read from the public data provider. This document records how each is
 established, why neither may be guessed, and the rules that pair them.
 
@@ -31,11 +31,29 @@ A pipeline era is not a statement about the network. It says only which era's
 artifact the caller handed over; whether that artifact can run at all is the
 pairing rule below.
 
-## Reading the artifact's era: why the check is structural
+## Reading the artifact's era: only from what the artifact declares
 
-`@midnight-ntwrk/compact-js` brands its `CompiledContract` with the registered
-symbol `Symbol.for('compact-js/CompiledContract')`, which looks like the obvious
-discriminator and is not usable as one.
+The era is a consensus-level fact, so it is established only from something the
+artifact states about itself. It is never inferred from the shape of the code
+the compiler generated, because a consumer's build is free to rewrite that
+shape and this framework never sees the setting that did.
+
+Each era carries its own declaration:
+
+| era | declaration | where it comes from |
+| --- | ----------- | ------------------- |
+| current | own `tag` on the `CompiledContract` container | the container assigns it to itself |
+| retained | `runtime-version` | `compiler/contract-info.json`, emitted by `compactc` |
+
+Only the retained arm reads the bundle, through
+`ZKConfigProvider.getArtifactRuntimeVersion()`. The current era's declaration is
+on the object already in hand, so a current-era caller buys no round trip and
+needs no file it does not already ship. `resolveArtifactEra` in
+`packages/contracts/src/internal/era.ts` holds both halves.
+
+`@midnight-ntwrk/compact-js` also brands its `CompiledContract` with the
+registered symbol `Symbol.for('compact-js/CompiledContract')`, which looks like
+the obvious discriminator for the current era and is not usable as one.
 
 `CompiledContract.make` installs the brand on a PROTOTYPE
 (`Object.create(CompiledContractProto)`), and every combinator that makes a
@@ -52,70 +70,91 @@ The internal `TypeId` symbol that DOES survive is a bare `Symbol()`, whose value
 differs between two copies of the package, so it is not duplicate-install safe
 and is not used either.
 
-What is left is the properties a spread preserves, plus one it cannot:
+The `tag` survives precisely because it is an OWN property — the distinction the
+brand loss turns on: a value rebuilt by an object spread keeps its own
+properties and loses everything it only inherited.
+
+### What the shape is still read for
+
+The shape decides which DECLARATION to consult, and which objects to refuse
+outright. It never decides an era.
 
 | shape | own `tag` | own `impureCircuits` | `initialState` | verdict |
 | ----- | --------- | -------------------- | -------------- | ------- |
-| current-era container | string | absent | absent | `'ledger9'` |
-| retained-era instance | absent | present | `Function` | `'ledger8'` |
+| current-era container | string | absent | absent | `'ledger9'`, declared by the `tag` |
+| retained-era candidate | absent | present | `Function` | ask the bundle |
 | raw current-era instance | absent | present | `AsyncFunction` | refused, by name |
 | anything else | — | — | — | refused as neither era |
-
-The third row is the mistake a JavaScript caller actually makes — passing the
-generated contract where its container belongs — and it is why `impureCircuits`
-alone cannot decide the era. It is refused by name, never silently routed into
-the retained pipeline.
 
 Requiring the `tag` as well as the ABSENCE of `impureCircuits` is what stops an
 arbitrary object — `{}` included — from being routed into the current-era
 pipeline by default.
 
-### Which checks are own-property checks, and the one that deliberately is not
-
 `tag` and `impureCircuits` are checked with `Object.hasOwn`, because both are
 assigned as own properties — `tag` by the container's constructor,
-`impureCircuits` by the generated contract's — and an own check is what makes
-them immune to the spread hazard above. Own-versus-prototype is exactly the
-distinction the brand-loss hazard turns on: a value rebuilt by an object spread
-keeps its own properties and loses everything it only inherited.
+`impureCircuits` by the generated contract's.
 
 `initialState` is NOT an own property and must not be checked as one. It is a
 class method, so it lives on the generated contract's PROTOTYPE — measured:
 `Object.hasOwn(contract, 'initialState')` is `false` on both eras' real
 artifacts, while `'initialState' in contract` is `true`. Requiring it to be own
-would refuse every real contract.
+would refuse every real contract. That is not the same hazard as the brand: a
+class instance's prototype is fixed at construction and nothing here rebuilds
+it.
 
-That is not the same hazard as the brand: a class instance's prototype is fixed
-at construction and nothing here rebuilds it, whereas the brand was lost because
-a combinator rebuilt a container with a spread. So the era is decided by an own
-property (`impureCircuits`) and only then refined by a prototype lookup.
+### Why `constructor.name` may refuse and may not route
 
-### Recognising the retained era positively
+The two `constructor.name` values on the eras' generated code — `'Function'` and
+`'AsyncFunction'` — are asymmetric, and the asymmetry is the whole rule.
 
-The two `constructor.name` values that separate the eras' generated code —
-`'Function'` and `'AsyncFunction'` — are properties of the real generated
-artifacts rather than conventions.
-`packages/contracts/src/test/era-dispatch-ledger8.test.ts` and
-`packages/contracts/src/test/era-dispatch.test.ts` each assert them against a
-real compiled contract before anything relies on them.
+A build step can ERASE an `AsyncFunction`: targeting below ES2017 lowers `async`
+to a generator-driven plain function, and the name then reads `'Function'`. No
+build step can FABRICATE one. So:
 
-`'Function'` is matched POSITIVELY, and that direction is load-bearing. The
-retained era is the era whose codegen is synchronous, so it must be recognised
-by what it IS. Treating it as "anything that is not async" would route a
-generator, an async generator, or any future codegen shape into the retained
-pipeline by default — a fail-open in the one function whose whole job is to fail
-closed. Generator and async-generator functions report their own names and are
-refused.
+- `'AsyncFunction'` is conclusive proof of the current era and is allowed to
+  REFUSE a raw instance on its own, before the bundle is consulted;
+- `'Function'` proves nothing. It is what a real retained artifact reads AND
+  what a transpiled current-era contract reads, so it only earns the artifact
+  the right to have its bundle asked;
+- anything else — a generator, an async generator, a future codegen shape — is
+  refused rather than routed anywhere by default.
 
-The one shape this cannot separate is a `class` used as `initialState`: a
-class's own constructor is `Function`, so it reads as the retained era.
+This replaces a rule that matched `'Function'` POSITIVELY as the retained era.
+That rule was fail-closed against every shape it could name and fail-OPEN
+against the one it could not: a current-era contract whose `async` a consumer's
+bundler had erased was routed into the retained pipeline instead of being
+refused. The `class`-as-`initialState` hole closed with it, because a class's
+own constructor is `Function` and that reading no longer decides anything.
+`docs/adr/0012-read-the-artifact-era-from-what-the-artifact-declares.md` records
+the decision.
 
-### One predicate, in two forms
+### Placing a declared runtime version
 
-`pipelineEraOf` makes the decision; `isLedger8Request` is the same decision in
-the narrowing form each era-dispatching entry point needs, so an entry point's
-body can drop the retained-era arm from its parameter union without a cast. It
-is not a second predicate — the decision is made in exactly one place.
+`RUNTIME_VERSION_TO_ERA` maps `major.minor` to a pipeline era, frozen, in one
+place. A patch release never moves a toolchain across the fork, so the patch
+component is not read. A compile-time gate refuses to build if a pipeline era
+exists that no declared version reaches.
+
+Two refusals have no default between them, deliberately:
+
+- `artifact-era-undeclared` — the provider could not report a version. Its own
+  failure is kept on `cause`.
+- `unknown-artifact-runtime-version` — a toolchain this framework cannot place,
+  named in the message.
+
+A retained SHAPE whose bundle declares the CURRENT toolchain is reported as
+`unwrapped-current-era-contract`: it is a current-era contract passed raw, with
+its `async` erased by the caller's build. That is the case the old check let
+through.
+
+### One decision, in two forms
+
+`resolveArtifactEra` makes the decision; `isLedger8Request` is that same,
+already-resolved answer in the narrowing form each era-dispatching entry point
+needs, so an entry point's body can drop the retained-era arm from its parameter
+union without a cast. It is not a second decision — it takes the era as an
+argument and only gives it a type predicate, because a type predicate cannot be
+asynchronous and the decision now is.
 
 It replaces the provisional structural check that tested for `impureCircuits`
 alone and so answered `true` for a raw CURRENT-era contract instance, which
@@ -125,7 +164,7 @@ the shape of the family it was serving.
 
 The failure mode changed with it, deliberately. Where the provisional check
 returned `false` for an object belonging to neither era and let it fall into the
-current-era pipeline to fail somewhere unrelated, `pipelineEraOf` raises
+current-era pipeline to fail somewhere unrelated, `resolveArtifactEra` raises
 `EraArtifactMismatchError` with remediation text at the entry point.
 
 ## Reading the network's era: exactly one head read per operation

--- a/packages/contracts/docs/overload-typing.md
+++ b/packages/contracts/docs/overload-typing.md
@@ -197,13 +197,14 @@ verbatim, and pins that a neither-era object really is refused by
 `NeitherEraContractOptions` — the assignability fact the overloads rely on,
 whether or not any arm spells it out.
 
-## The runtime predicate lives elsewhere
+## The runtime decision lives elsewhere
 
 This file declares no era predicate. Telling the two eras apart at runtime is
 `resolveArtifactEra` in `packages/contracts/src/internal/era.ts`, and it is the only
-one — see [EraDispatch](./era-dispatch.md) for why it is a structural check, why
-it must not be "improved" to test the vendor's `CompiledContract` brand, and
-what it refuses.
+one — see [EraDispatch](./era-dispatch.md) for which answer each era carries, why
+the era may not be inferred from generated code at all, why the check that
+remains must not be "improved" to test the vendor's `CompiledContract` brand,
+and what it refuses.
 
 An earlier, provisional check tested for `impureCircuits` alone. It lived here,
 answered `true` for a raw current-era contract instance, and could not close that

--- a/packages/contracts/docs/overload-typing.md
+++ b/packages/contracts/docs/overload-typing.md
@@ -178,7 +178,7 @@ statement on the common path. An arm that is NOT last never renders at all, so p
 earlier would only distort `ReturnType` and `Parameters`.
 
 `NEITHER_ERA_CONTRACT_MESSAGE` is consumed by `EraArtifactMismatchError`, which
-`pipelineEraOf` raises when it is handed an object belonging to neither era. A
+`resolveArtifactEra` raises when it is handed an object belonging to neither era. A
 thrown error can carry full remediation text where a compiler diagnostic cannot,
 which is why the text is not wired into an overload arm.
 
@@ -200,14 +200,14 @@ whether or not any arm spells it out.
 ## The runtime predicate lives elsewhere
 
 This file declares no era predicate. Telling the two eras apart at runtime is
-`pipelineEraOf` in `packages/contracts/src/internal/era.ts`, and it is the only
+`resolveArtifactEra` in `packages/contracts/src/internal/era.ts`, and it is the only
 one — see [EraDispatch](./era-dispatch.md) for why it is a structural check, why
 it must not be "improved" to test the vendor's `CompiledContract` brand, and
 what it refuses.
 
 An earlier, provisional check tested for `impureCircuits` alone. It lived here,
 answered `true` for a raw current-era contract instance, and could not close that
-blind spot; `pipelineEraOf` replaced it.
+blind spot; `resolveArtifactEra` replaced it.
 
 ## Why a retained-era result is version-tagged
 

--- a/packages/contracts/src/deploy-contract.ts
+++ b/packages/contracts/src/deploy-contract.ts
@@ -27,7 +27,7 @@ import {
   createCircuitMaintenanceTxInterfaces,
   createContractMaintenanceTxInterface
 } from './governance/tx-interfaces';
-import { isLedger8Request } from './internal/era';
+import { isLedger8Request, resolveArtifactEra } from './internal/era';
 import {
   type AnyLedger8DeployContractOptions,
   type AnyLedger8DeployedContract,
@@ -176,16 +176,20 @@ export async function deployContract<C extends Contract.Any>(
  *
  * @throws DeployTxFailedError If the transaction is submitted successfully but produces an error
  *                             when executed by the node.
- * @throws EraArtifactMismatchError If `options.compiledContract` belongs to neither Compact era, or
- *                                  is a raw current-era contract instance passed instead of its
- *                                  `CompiledContract` container. Raised before any provider is
+ * @throws EraArtifactMismatchError If `options.compiledContract` belongs to neither Compact era, is
+ *                                  a raw current-era contract instance passed instead of its
+ *                                  `CompiledContract` container, or its artifacts declare no
+ *                                  toolchain this framework can place. Raised before anything is
+ *                                  built or submitted; the ZK config provider is asked for the
+ *                                  artifacts' declared runtime version, and no other provider is
  *                                  consulted.
  */
 export async function deployContract<C extends Contract.Any>(
   providers: ContractProviders<C>,
   options: DeployContractOptions<C> | AnyLedger8DeployContractOptions
 ): Promise<DeployedContract<C> | AnyLedger8DeployedContract> {
-  if (isLedger8Request<AnyLedger8DeployContractOptions>(options)) {
+  const artifactEra = await resolveArtifactEra(options.compiledContract, providers.zkConfigProvider);
+  if (isLedger8Request<AnyLedger8DeployContractOptions>(options, artifactEra)) {
     throw new Ledger8DeployUnmaintainableError();
   }
   const deployTxData = await submitDeployTx(providers, createDeployTxOptions(options));

--- a/packages/contracts/src/era.ts
+++ b/packages/contracts/src/era.ts
@@ -17,8 +17,9 @@
  * Which pipeline produced a result, published so a caller can tell without
  * inspecting the objects inside it.
  *
- * The vocabulary was already resolved internally, by `resolveArtifactEra`, from the
- * compiled artifact a caller supplied. This module is where it becomes
+ * The vocabulary was already resolved internally, by `resolveArtifactEra` --
+ * from the container a caller supplied for the current era, and from the
+ * artifact set its ZK config provider serves for the retained one. This module is where it becomes
  * nameable: `src/internal` is hidden from consumers, and a published member
  * whose type a consumer cannot name is a member they cannot write a signature
  * against.

--- a/packages/contracts/src/era.ts
+++ b/packages/contracts/src/era.ts
@@ -17,7 +17,7 @@
  * Which pipeline produced a result, published so a caller can tell without
  * inspecting the objects inside it.
  *
- * The vocabulary was already resolved internally, by `pipelineEraOf`, from the
+ * The vocabulary was already resolved internally, by `resolveArtifactEra`, from the
  * compiled artifact a caller supplied. This module is where it becomes
  * nameable: `src/internal` is hidden from consumers, and a published member
  * whose type a consumer cannot name is a member they cannot write a signature

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -116,9 +116,11 @@ export class EraInvariantViolationError extends Error {
 /**
  * Why an object was refused as belonging to the wrong era, or to neither.
  *
- * One error class over three reasons rather than three classes: a caller catches "I handed the
- * framework the wrong kind of contract" as one condition, and the reason is what tells it which
- * of the three mistakes it made.
+ * One error class over every reason rather than a class per reason: a caller catches "this operation
+ * cannot be placed on a ledger era" as one condition, and the reason is what tells it which mistake
+ * it made. Two of the reasons are about the CALLER's contract object and two are about the artifact
+ * set its ZK config provider serves, which is one condition from the caller's side: something in the
+ * bundle it passed does not belong to the era it is being run against.
  */
 export type EraArtifactMismatchReason =
   /** A raw current-era contract instance, passed where its `CompiledContract` container belongs. */
@@ -126,7 +128,11 @@ export type EraArtifactMismatchReason =
   /** An object matching no era's shape at all. */
   | 'unrecognised-contract-shape'
   /** A current-era artifact, on a network head that is still pre-fork. */
-  | 'current-era-artifact-on-pre-fork-head';
+  | 'current-era-artifact-on-pre-fork-head'
+  /** An artifact set that does not declare which `compact-runtime` produced it. */
+  | 'artifact-era-undeclared'
+  /** An artifact set declaring a `compact-runtime` this framework places on no ledger era. */
+  | 'unknown-artifact-runtime-version';
 
 const ERA_ARTIFACT_MISMATCH_MESSAGES: Readonly<Record<EraArtifactMismatchReason, string>> = Object.freeze({
   // Named as the mistake it is: the raw instance and the container both carry `impureCircuits`, so
@@ -145,8 +151,29 @@ const ERA_ARTIFACT_MISMATCH_MESSAGES: Readonly<Record<EraArtifactMismatchReason,
   'current-era-artifact-on-pre-fork-head':
     'This contract was produced by the current Compact toolchain, but the network head is still on the ' +
     'pre-fork ledger era, which cannot execute it. Run this operation against a contract produced by the ' +
-    'retained toolchain until the network head has crossed the fork.'
+    'retained toolchain until the network head has crossed the fork.',
+  // Named as a missing DECLARATION rather than a missing file: the fix is to serve what the compiler
+  // already emitted, not to produce something new.
+  'artifact-era-undeclared':
+    'The ZK config provider for this operation could not report which compact-runtime built these ' +
+    'artifacts, so the ledger era they belong to cannot be established. The compiler records it in ' +
+    'compiler/contract-info.json beside the keys; serve that file from the same location as the ' +
+    'artifacts. The era is never inferred from the generated code, because a build step can rewrite it.',
+  'unknown-artifact-runtime-version':
+    'These artifacts declare a compact-runtime this version of midnight-js places on no ledger era, so ' +
+    'no pipeline can be chosen for them. Upgrade midnight-js to one that knows this toolchain, or ' +
+    'rebuild the contract with a toolchain this version supports.'
 });
+
+/** Options for {@link EraArtifactMismatchError}. */
+export interface EraArtifactMismatchOptions extends ErrorOptions {
+  /**
+   * A sentence appended to the settled wording for this reason, naming the value that was actually
+   * seen. Kept OUT of the reason's own message so every instance of a reason reads identically up to
+   * the fact that varies.
+   */
+  readonly detail?: string;
+}
 
 /**
  * An error indicating that the contract handed to an entry point does not belong to the era the
@@ -161,11 +188,18 @@ export class EraArtifactMismatchError extends Error {
   readonly code = CONTRACTS_ERROR_CODES.ERA_ARTIFACT_MISMATCH;
 
   /**
-   * @param reason Which of the three era mismatches this is. Also the discriminant a caller
-   *               branches on, so it is retained on the error rather than only rendered.
+   * @param reason Which era mismatch this is. Also the discriminant a caller branches on, so it is
+   *               retained on the error rather than only rendered.
+   * @param options Carries the originating failure on `cause` -- a provider that could not serve the
+   *                artifact description reports WHY there -- and an optional `detail` naming the
+   *                value that was seen.
    */
-  constructor(readonly reason: EraArtifactMismatchReason) {
-    super(ERA_ARTIFACT_MISMATCH_MESSAGES[reason]);
+  constructor(
+    readonly reason: EraArtifactMismatchReason,
+    options?: EraArtifactMismatchOptions
+  ) {
+    const message = ERA_ARTIFACT_MISMATCH_MESSAGES[reason];
+    super(options?.detail === undefined ? message : `${message} ${options.detail}`, { cause: options?.cause });
     this.name = 'EraArtifactMismatchError';
   }
 }

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -131,6 +131,8 @@ export type EraArtifactMismatchReason =
   | 'current-era-artifact-on-pre-fork-head'
   /** An artifact set that does not declare which `compact-runtime` produced it. */
   | 'artifact-era-undeclared'
+  /** A ZK config provider that cannot report a declared runtime version at all. */
+  | 'provider-cannot-declare-era'
   /** An artifact set declaring a `compact-runtime` this framework places on no ledger era. */
   | 'unknown-artifact-runtime-version';
 
@@ -159,6 +161,14 @@ const ERA_ARTIFACT_MISMATCH_MESSAGES: Readonly<Record<EraArtifactMismatchReason,
     'artifacts, so the ledger era they belong to cannot be established. The compiler records it in ' +
     'compiler/contract-info.json beside the keys; serve that file from the same location as the ' +
     'artifacts. The era is never inferred from the generated code, because a build step can rewrite it.',
+  // Distinct from `artifact-era-undeclared`: nothing is wrong with the artifacts, and serving a
+  // file cannot fix it. What is missing is a capability of the provider itself.
+  'provider-cannot-declare-era':
+    'The ZK config provider supplied for this operation cannot report which compact-runtime built ' +
+    'its artifacts, so the ledger era they belong to cannot be established. The providers this ' +
+    'framework ships all report it; a provider written elsewhere must override ' +
+    'getArtifactRuntimeVersion() to read the runtime-version from the compiler output beside the ' +
+    'keys. See this refusal\'s cause for which provider could not answer.',
   'unknown-artifact-runtime-version':
     'These artifacts declare a compact-runtime this version of midnight-js places on no ledger era, so ' +
     'no pipeline can be chosen for them. Upgrade midnight-js to one that knows this toolchain, or ' +

--- a/packages/contracts/src/find-deployed-contract.ts
+++ b/packages/contracts/src/find-deployed-contract.ts
@@ -36,7 +36,7 @@ import {
   createCircuitMaintenanceTxInterfaces,
   createContractMaintenanceTxInterface
 } from './governance/tx-interfaces';
-import { isLedger8Request, requireV9Record } from './internal/era';
+import { isLedger8Request, requireV9Record, resolveArtifactEra } from './internal/era';
 import { findLedger8Contract } from './internal/ledger8-entry';
 import {
   type AnyLedger8FindDeployedContractOptions,
@@ -341,14 +341,18 @@ export async function findDeployedContract<C extends Contract.Any>(
  *                                                  `privateStateId` is given to store it under.
  * @throws EraArtifactMismatchError If `options.compiledContract` belongs to neither Compact era, or
  *                                  is a raw current-era contract instance passed instead of its
- *                                  `CompiledContract` container. Raised before any provider is
+ *                                  `CompiledContract` container, or its artifacts declare no
+ *                                  toolchain this framework can place. Raised before anything is
+ *                                  read from the chain; the ZK config provider is asked for the
+ *                                  artifacts' declared runtime version, and no other provider is
  *                                  consulted.
  */
 export async function findDeployedContract<C extends Contract.Any>(
   providers: ContractProviders<C>,
   options: FindDeployedContractOptions<C> | AnyLedger8FindDeployedContractOptions
 ): Promise<FoundContract<C> | AnyLedger8FoundContract> {
-  if (isLedger8Request<AnyLedger8FindDeployedContractOptions>(options)) {
+  const artifactEra = await resolveArtifactEra(options.compiledContract, providers.zkConfigProvider);
+  if (isLedger8Request<AnyLedger8FindDeployedContractOptions>(options, artifactEra)) {
     const found = await findLedger8Contract(providers, {
       contract: options.compiledContract,
       contractAddress: options.contractAddress,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -72,6 +72,7 @@ export {
   ContractTypeMismatch,
   DeployTxFailedError,
   EraArtifactMismatchError,
+  type EraArtifactMismatchOptions,
   type EraArtifactMismatchReason,
   EraInvariantViolationError,
   type EraSeam,

--- a/packages/contracts/src/internal/breadcrumbs.ts
+++ b/packages/contracts/src/internal/breadcrumbs.ts
@@ -90,9 +90,11 @@ export interface PipelineSelectionBreadcrumb {
   /** The era the network head is on. */
   readonly version: LedgerVersion;
   readonly protocolVersion: number;
-  /** One value today, carried anyway: a second selection input is exactly the
-   * change that would need to show up in a log. */
-  readonly source: 'compiled-contract-shape';
+  /** Which input the pipeline was selected from. One value today, carried anyway:
+   * a second selection input is exactly the change that would need to show up in
+   * a log -- and the move from the contract's shape to the artifacts' declared
+   * runtime version is exactly that change having happened once already. */
+  readonly source: 'artifact-runtime-version-declaration';
   readonly readingProvenance: HeadReadingProvenance;
   /** The pipeline the artifact belongs to. */
   readonly path: PipelineEra;
@@ -202,7 +204,7 @@ export const emitPipelineSelection = (
     decision: 'pipeline-selection',
     version: reading.head,
     protocolVersion: reading.headProtocolVersion,
-    source: 'compiled-contract-shape',
+    source: 'artifact-runtime-version-declaration',
     readingProvenance: 'operation-start',
     path,
     // Spread rather than assigned: an operation with no address must leave the field OUT, not

--- a/packages/contracts/src/internal/era.ts
+++ b/packages/contracts/src/internal/era.ts
@@ -21,6 +21,7 @@ import {
   UnknownLedgerVersionError
 } from '@midnight-ntwrk/midnight-js-protocol';
 import {
+  ArtifactRuntimeVersionUnavailableError,
   type FinalizedTxData,
   type PublicDataProvider,
   type RawContractState,
@@ -29,7 +30,7 @@ import {
   type VersionedTx,
   type ZKConfigProvider
 } from '@midnight-ntwrk/midnight-js-types';
-import { contractStateEnvelopeVersion } from '@midnight-ntwrk/midnight-js-utils';
+import { contractStateEnvelopeVersion, ZkArtifactContractInfoError } from '@midnight-ntwrk/midnight-js-utils';
 
 import { CURRENT_PIPELINE_ERA, type PipelineEra, RETAINED_PIPELINE_ERA } from '../era';
 import {
@@ -240,12 +241,12 @@ export interface HeadEraReading {
  */
 export type HeadVersionSource = Pick<PublicDataProvider, 'queryLatestProtocolVersion'>;
 
-// The `constructor.name` values that appear on the two eras' generated code. Both are used to
-// REFUSE and neither is used to accept: a build step targeting below ES2017 rewrites an
-// `AsyncFunction` into a plain one, so reading `PLAIN_FUNCTION` as proof of the retained era let a
-// transpiled current-era contract into the retained pipeline. `ASYNC_FUNCTION` survives no such
-// rewrite in the other direction -- a build step can erase it, never fabricate it -- which is what
-// makes it sound as a refusal and unsound as a route.
+// The `constructor.name` values that appear on the two eras' generated code. `ASYNC_FUNCTION`
+// REFUSES; `PLAIN_FUNCTION` admits a candidate and decides nothing. A build step targeting below
+// ES2017 rewrites an `AsyncFunction` into a plain one, so reading `PLAIN_FUNCTION` as proof of the
+// retained era let a transpiled current-era contract into the retained pipeline. The rewrite runs
+// in one direction only -- a build can erase `async`, never fabricate it -- which is what makes the
+// async reading sound as a refusal and the plain reading unsound as a route.
 const PLAIN_FUNCTION = 'Function';
 const ASYNC_FUNCTION = 'AsyncFunction';
 
@@ -255,6 +256,10 @@ const ASYNC_FUNCTION = 'AsyncFunction';
  *
  * Frozen, and the ONE place a toolchain version is turned into an era. Adding an era adds a row
  * here; the gate below refuses to compile if one is added without a row.
+ *
+ * The gate has to be a CONSTRAINT, not a bare conditional type: `type X = ... ? true : never` is a
+ * legal declaration that nothing reads, so it computes the answer and discards it. Passing the
+ * conditional through `Assert` makes the failing case violate a constraint, which is a build error.
  */
 const RUNTIME_VERSION_TO_ERA = Object.freeze({
   '0.16': RETAINED_PIPELINE_ERA,
@@ -265,7 +270,10 @@ const RUNTIME_VERSION_TO_ERA = Object.freeze({
 // Without it a third era could be added to `PipelineEra` with no toolchain mapped to it, and every
 // artifact built by that toolchain would be refused at run time instead of failing here.
 type MappedEra = (typeof RUNTIME_VERSION_TO_ERA)[keyof typeof RUNTIME_VERSION_TO_ERA];
-type _EveryEraHasARuntimeVersion = PipelineEra extends MappedEra ? true : never;
+type Assert<T extends true> = T;
+// The tuple wrapping keeps this a whole-union check rather than a distributive one, so a single
+// mapped era could never satisfy it on behalf of the rest.
+type _EveryEraHasARuntimeVersion = Assert<[PipelineEra] extends [MappedEra] ? true : false>;
 
 const RUNTIME_VERSION = /^(\d+\.\d+)\.\d+/;
 
@@ -330,11 +338,13 @@ const artifactShapeOf = (compiledContract: unknown): ArtifactShape => {
   }
 
   if (!hasOwnProperty(compiledContract, 'impureCircuits')) {
-    // The container carries a `tag` and none of the circuit collections. The `tag` is an OWN
-    // property the current toolchain's container assigns to itself, so it is a declaration that
-    // survives every build step -- which is why this arm needs no artifact read. Requiring it as
-    // well as the absence of `impureCircuits` is what stops an arbitrary object -- `{}` included --
-    // from being routed into the current-era pipeline by default.
+    // The container carries a `tag` and none of the circuit collections. The `tag`'s VALUE is
+    // chosen by the caller (`CompiledContract.make(tag, ctor)`) and says nothing about an era; what
+    // places this object is that only the current toolchain's container has this shape, and that
+    // the property is an OWN one, so it survives both the spread its own combinators perform and
+    // any build step -- which is why this arm needs no artifact read. Requiring the `tag` as well
+    // as the absence of `impureCircuits` is what stops an arbitrary object -- `{}` included -- from
+    // being routed into the current-era pipeline by default.
     if (hasOwnProperty(compiledContract, 'tag') && typeof compiledContract.tag === 'string') {
       return 'current-era-container';
     }
@@ -362,9 +372,10 @@ const artifactShapeOf = (compiledContract: unknown): ArtifactShape => {
 /**
  * Decides which pipeline a caller's contract belongs to, from what the artifact DECLARES.
  *
- * Two declarations answer it, one per era, and neither is a property of generated JavaScript that a
- * consumer's build can rewrite: the current era's container assigns itself an own `tag`, and the
- * retained era's artifact set carries the `runtime-version` its compiler recorded. The shape of the
+ * Two answers, one per era, and neither rests on a property of generated JavaScript that a
+ * consumer's build can rewrite. The current era arrives wrapped in a container whose own `tag`
+ * survives every build step, so recognising that container is enough. The retained era has no such
+ * container, so it is placed by the `runtime-version` its artifact set declares. The shape of the
  * generated code is consulted only to refuse.
  *
  * The artifact set is read ONLY for a retained candidate, so a current-era caller pays no round trip
@@ -392,7 +403,17 @@ export const resolveArtifactEra = async (
   try {
     runtimeVersion = await source.getArtifactRuntimeVersion();
   } catch (error) {
-    throw new EraArtifactMismatchError('artifact-era-undeclared', { cause: error });
+    // Only the two failures that are STATEMENTS about the era become era refusals. A transport
+    // fault, a permission fault or a bug in a caller's provider says nothing about which ledger
+    // executes this call, and relabelling it sends the caller to serve a file that is already
+    // there. `readHeadEra` states the same rule for the head read.
+    if (error instanceof ZkArtifactContractInfoError) {
+      throw new EraArtifactMismatchError('artifact-era-undeclared', { cause: error });
+    }
+    if (error instanceof ArtifactRuntimeVersionUnavailableError) {
+      throw new EraArtifactMismatchError('provider-cannot-declare-era', { cause: error });
+    }
+    throw error;
   }
 
   const era = eraOfRuntimeVersion(runtimeVersion);

--- a/packages/contracts/src/internal/era.ts
+++ b/packages/contracts/src/internal/era.ts
@@ -26,11 +26,12 @@ import {
   type RawContractState,
   UntaggedPayloadError,
   type VersionedFinalizedTxData,
-  type VersionedTx
+  type VersionedTx,
+  type ZKConfigProvider
 } from '@midnight-ntwrk/midnight-js-types';
 import { contractStateEnvelopeVersion } from '@midnight-ntwrk/midnight-js-utils';
 
-import type { PipelineEra } from '../era';
+import { CURRENT_PIPELINE_ERA, type PipelineEra, RETAINED_PIPELINE_ERA } from '../era';
 import {
   EraArtifactMismatchError,
   EraInvariantViolationError,
@@ -239,11 +240,34 @@ export interface HeadEraReading {
  */
 export type HeadVersionSource = Pick<PublicDataProvider, 'queryLatestProtocolVersion'>;
 
-// The `constructor.name` values that separate the two eras' generated code, asserted against real
-// compiled contracts by `src/test/era-dispatch-ledger8.test.ts` and `src/test/era-dispatch.test.ts`.
-// Match `PLAIN_FUNCTION` POSITIVELY -- never as "anything that is not async", which would fail open.
+// The `constructor.name` values that appear on the two eras' generated code. Both are used to
+// REFUSE and neither is used to accept: a build step targeting below ES2017 rewrites an
+// `AsyncFunction` into a plain one, so reading `PLAIN_FUNCTION` as proof of the retained era let a
+// transpiled current-era contract into the retained pipeline. `ASYNC_FUNCTION` survives no such
+// rewrite in the other direction -- a build step can erase it, never fabricate it -- which is what
+// makes it sound as a refusal and unsound as a route.
 const PLAIN_FUNCTION = 'Function';
 const ASYNC_FUNCTION = 'AsyncFunction';
+
+/**
+ * The `compact-runtime` versions this framework can place on the era timeline, keyed by
+ * `major.minor` because a patch release never moves a toolchain across the fork.
+ *
+ * Frozen, and the ONE place a toolchain version is turned into an era. Adding an era adds a row
+ * here; the gate below refuses to compile if one is added without a row.
+ */
+const RUNTIME_VERSION_TO_ERA = Object.freeze({
+  '0.16': RETAINED_PIPELINE_ERA,
+  '0.19': CURRENT_PIPELINE_ERA
+} as const);
+
+// Compile-time gate: every pipeline era must be reachable from some declared runtime version.
+// Without it a third era could be added to `PipelineEra` with no toolchain mapped to it, and every
+// artifact built by that toolchain would be refused at run time instead of failing here.
+type MappedEra = (typeof RUNTIME_VERSION_TO_ERA)[keyof typeof RUNTIME_VERSION_TO_ERA];
+type _EveryEraHasARuntimeVersion = PipelineEra extends MappedEra ? true : never;
+
+const RUNTIME_VERSION = /^(\d+\.\d+)\.\d+/;
 
 /**
  * Whether `value` carries `key` as its OWN property, narrowing `value` so the property can then be
@@ -257,8 +281,34 @@ const ASYNC_FUNCTION = 'AsyncFunction';
 const hasOwnProperty = <K extends string>(value: object, key: K): value is object & Record<K, unknown> =>
   Object.hasOwn(value, key);
 
+/** What the artifact's own shape can establish, which is never an era on its own. */
+type ArtifactShape = 'current-era-container' | 'retained-era-candidate';
+
 /**
- * Decides which pipeline a caller's contract belongs to, from the object itself.
+ * The one read {@link resolveArtifactEra} makes on the ZK config provider.
+ *
+ * Declared as a `Pick` of the real provider for the same reason {@link HeadVersionSource} is: a full
+ * `ZKConfigProvider` satisfies it, so nothing at a call site changes, while a test -- and a reader
+ * -- sees exactly which member is consulted.
+ */
+export type ArtifactRuntimeVersionSource = Pick<ZKConfigProvider<string>, 'getArtifactRuntimeVersion'>;
+
+/**
+ * Places a declared `compact-runtime` version on the era timeline.
+ *
+ * @param runtimeVersion The version string the compiler recorded, verbatim.
+ * @returns The pipeline era that toolchain builds for, or `undefined` if this framework knows no
+ * such toolchain -- which the caller reports rather than resolving to a default.
+ */
+const eraOfRuntimeVersion = (runtimeVersion: string): PipelineEra | undefined => {
+  const majorMinor = RUNTIME_VERSION.exec(runtimeVersion)?.[1];
+
+  return majorMinor === undefined ? undefined : RUNTIME_VERSION_TO_ERA[majorMinor as keyof typeof RUNTIME_VERSION_TO_ERA];
+};
+
+/**
+ * Reads what the caller's contract object can prove about itself, WITHOUT deciding an era for a
+ * retained candidate.
  *
  * A STRUCTURAL check, and it must not be "improved" to test the vendor's registered
  * `CompiledContract` brand: that brand sits on a prototype the container's own combinators drop,
@@ -267,24 +317,26 @@ const hasOwnProperty = <K extends string>(value: object, key: K): value is objec
  *
  * @param compiledContract The value a caller passed as its contract. `unknown`, because a
  * JavaScript caller can pass anything and the point of this function is to say what it passed.
- * @returns The pipeline that contract belongs to.
+ * @returns Which of the two recognised shapes it has.
  * @throws EraArtifactMismatchError with reason `'unwrapped-current-era-contract'` for a raw
- * current-era contract instance, and `'unrecognised-contract-shape'` for an object matching
- * neither era.
+ * current-era contract instance whose `async` survived the caller's build, and
+ * `'unrecognised-contract-shape'` for an object matching neither era.
  * @see {@link EraDispatch} for the shape table each branch below implements, the brand-loss
  * measurement, and why `initialState` is the one check that is not an own-property check.
  */
-export const pipelineEraOf = (compiledContract: unknown): PipelineEra => {
+const artifactShapeOf = (compiledContract: unknown): ArtifactShape => {
   if (typeof compiledContract !== 'object' || compiledContract === null) {
     throw new EraArtifactMismatchError('unrecognised-contract-shape');
   }
 
   if (!hasOwnProperty(compiledContract, 'impureCircuits')) {
-    // The container carries a `tag` and none of the circuit collections. Requiring the `tag` as
-    // well as the absence of `impureCircuits` is what stops an arbitrary object — `{}` included —
+    // The container carries a `tag` and none of the circuit collections. The `tag` is an OWN
+    // property the current toolchain's container assigns to itself, so it is a declaration that
+    // survives every build step -- which is why this arm needs no artifact read. Requiring it as
+    // well as the absence of `impureCircuits` is what stops an arbitrary object -- `{}` included --
     // from being routed into the current-era pipeline by default.
     if (hasOwnProperty(compiledContract, 'tag') && typeof compiledContract.tag === 'string') {
-      return 'ledger9';
+      return 'current-era-container';
     }
     throw new EraArtifactMismatchError('unrecognised-contract-shape');
   }
@@ -298,7 +350,7 @@ export const pipelineEraOf = (compiledContract: unknown): PipelineEra => {
 
   switch (initialState.constructor.name) {
     case PLAIN_FUNCTION:
-      return 'ledger8';
+      return 'retained-era-candidate';
     case ASYNC_FUNCTION:
       throw new EraArtifactMismatchError('unwrapped-current-era-contract');
     default:
@@ -308,26 +360,78 @@ export const pipelineEraOf = (compiledContract: unknown): PipelineEra => {
 };
 
 /**
- * {@link pipelineEraOf}, in the narrowing form each era-dispatching entry point needs.
+ * Decides which pipeline a caller's contract belongs to, from what the artifact DECLARES.
  *
- * Not a second predicate: the decision is made in exactly one place, and this only gives it a type
- * predicate so an entry point's body can drop the retained-era arm from its parameter union without
- * a cast.
+ * Two declarations answer it, one per era, and neither is a property of generated JavaScript that a
+ * consumer's build can rewrite: the current era's container assigns itself an own `tag`, and the
+ * retained era's artifact set carries the `runtime-version` its compiler recorded. The shape of the
+ * generated code is consulted only to refuse.
+ *
+ * The artifact set is read ONLY for a retained candidate, so a current-era caller pays no round trip
+ * for this and needs no file it does not already ship.
+ *
+ * @param compiledContract The value a caller passed as its contract.
+ * @param source The ZK config provider serving that contract's artifacts.
+ * @returns The pipeline that contract belongs to.
+ * @throws EraArtifactMismatchError with reason `'unrecognised-contract-shape'` or
+ * `'unwrapped-current-era-contract'` before the provider is consulted at all;
+ * `'artifact-era-undeclared'` when the provider cannot report a runtime version, carrying its
+ * failure on `cause`; and `'unknown-artifact-runtime-version'` for a toolchain this framework
+ * cannot place.
+ * @see {@link EraDispatch} for the table this implements and why the era may not be inferred.
+ */
+export const resolveArtifactEra = async (
+  compiledContract: unknown,
+  source: ArtifactRuntimeVersionSource
+): Promise<PipelineEra> => {
+  if (artifactShapeOf(compiledContract) === 'current-era-container') {
+    return CURRENT_PIPELINE_ERA;
+  }
+
+  let runtimeVersion: string;
+  try {
+    runtimeVersion = await source.getArtifactRuntimeVersion();
+  } catch (error) {
+    throw new EraArtifactMismatchError('artifact-era-undeclared', { cause: error });
+  }
+
+  const era = eraOfRuntimeVersion(runtimeVersion);
+  if (era === undefined) {
+    throw new EraArtifactMismatchError('unknown-artifact-runtime-version', {
+      detail: `The artifacts declare compact-runtime ${runtimeVersion}.`
+    });
+  }
+  // A retained SHAPE whose artifacts declare the current toolchain is the mistake this dispatch
+  // exists to catch: a current-era contract passed raw, with its `async` erased by the caller's
+  // build. It reads as retained and is not.
+  if (era === CURRENT_PIPELINE_ERA) {
+    throw new EraArtifactMismatchError('unwrapped-current-era-contract');
+  }
+
+  return era;
+};
+
+/**
+ * {@link resolveArtifactEra}'s answer, in the narrowing form each era-dispatching entry point needs.
+ *
+ * Not a second decision: the era is established in exactly one place, and this only gives that
+ * established value a type predicate so an entry point's body can drop the retained-era arm from its
+ * parameter union without a cast.
  *
  * Name the type parameter explicitly at each call site rather than letting it infer, so the
  * narrowing removes exactly the retained-era arm of that entry point's parameter union.
  *
- * @see {@link EraDispatch} for the provisional check this replaces and the failure mode that
- *      changed with it.
+ * @see {@link EraDispatch} for how `era` was established.
  *
- * @param options The options object an entry point received.
+ * @param _options The options object an entry point received. Read by the type system only -- the
+ *                 decision was made from the artifact's declaration, not from this object.
+ * @param era The era {@link resolveArtifactEra} resolved for that object's contract.
  * @returns Whether this is a retained-era request.
- * @throws EraArtifactMismatchError if the contract belongs to neither era, or is a raw current-era
- * contract passed instead of its container.
  */
 export const isLedger8Request = <L extends { readonly compiledContract: Ledger8Contract }>(
-  options: { readonly compiledContract: unknown } | L
-): options is L => pipelineEraOf(options.compiledContract) === 'ledger8';
+  _options: { readonly compiledContract: unknown } | L,
+  era: PipelineEra
+): _options is L => era === RETAINED_PIPELINE_ERA;
 
 /**
  * Makes the ONE head read and resolves it to an era, acquiring nothing.
@@ -412,7 +516,7 @@ export const resolveOperationEra = async (
  *
  * @see {@link EraDispatch} for the table in full and why the deploy cell differs.
  *
- * @param pipeline The pipeline the artifact belongs to, from {@link pipelineEraOf}.
+ * @param pipeline The pipeline the artifact belongs to, from {@link resolveArtifactEra}.
  * @param head The era the network head is on, from {@link resolveOperationEra}.
  * @param kind Whether this operation deploys a contract or calls one already deployed.
  * @throws EraArtifactMismatchError with reason `'current-era-artifact-on-pre-fork-head'` for a

--- a/packages/contracts/src/ledger8-contract.ts
+++ b/packages/contracts/src/ledger8-contract.ts
@@ -25,13 +25,13 @@
  * container, and the fact that retained-era circuits and `initialState` return
  * plain objects where the current era returns `Promise`s.
  *
- * There is no era predicate in this file. The single RUNTIME predicate is
+ * There is no era decision in this file. The single RUNTIME decision is
  * `resolveArtifactEra` in `./internal/era`; do not add a second one here.
  *
  * @see {@link OverloadTyping} for why the declarations are hand-written and
  *      runtime-pinned, how openness is expressed without `any`, and why the
  *      order of the overload arms is load-bearing.
- * @see {@link EraDispatch} for the runtime predicate and what it may not use.
+ * @see {@link EraDispatch} for the runtime decision and what it may not use.
  */
 
 import type {

--- a/packages/contracts/src/ledger8-contract.ts
+++ b/packages/contracts/src/ledger8-contract.ts
@@ -26,7 +26,7 @@
  * plain objects where the current era returns `Promise`s.
  *
  * There is no era predicate in this file. The single RUNTIME predicate is
- * `pipelineEraOf` in `./internal/era`; do not add a second one here.
+ * `resolveArtifactEra` in `./internal/era`; do not add a second one here.
  *
  * @see {@link OverloadTyping} for why the declarations are hand-written and
  *      runtime-pinned, how openness is expressed without `any`, and why the
@@ -685,7 +685,7 @@ export type AnyLedger8FoundContract = Ledger8FoundContract<Ledger8Contract>;
  * one the rest of this package uses.
  *
  * DO NOT DELETE AS UNUSED, and do not inline it either. It is consumed by
- * `EraArtifactMismatchError` in `./errors`, which is what `pipelineEraOf` in `./internal/era`
+ * `EraArtifactMismatchError` in `./errors`, which is what `resolveArtifactEra` in `./internal/era`
  * raises when it is handed an object belonging to neither era.
  * `src/test/typecheck/overloads.test-d.ts` pins the wording verbatim, and it is not re-exported
  * from the package index.

--- a/packages/contracts/src/submit-call-tx.ts
+++ b/packages/contracts/src/submit-call-tx.ts
@@ -21,7 +21,7 @@ import { type CallResult } from './call';
 import { type ContractProviders } from './contract-providers';
 import { CURRENT_PIPELINE_ERA } from './era';
 import { CallTxFailedError, IncompleteCallTxPrivateStateConfig } from './errors';
-import { isLedger8Request } from './internal/era';
+import { isLedger8Request, resolveArtifactEra } from './internal/era';
 import { submitLedger8CallTx, submitLedger8CallTxAsync, toLedger8CallEntryOptions } from './internal/ledger8-entry';
 import * as Transaction from './internal/transaction';
 import {
@@ -158,8 +158,10 @@ export async function submitCallTx<C extends Contract<undefined>, PCK extends Co
  * @throws {CallTxFailedError} When transaction fails in either guaranteed or fallible phase.
  *         The error contains the finalized transaction data and circuit ID for debugging.
  * @throws {EraArtifactMismatchError} When `options.compiledContract` belongs to neither Compact
- *         era, or is a raw current-era contract instance passed instead of its `CompiledContract`
- *         container. Raised before any provider is consulted.
+ *         era, is a raw current-era contract instance passed instead of its `CompiledContract`
+ *         container, or its artifacts declare no toolchain this framework can place. Raised before
+ *         anything is built or submitted; the ZK config provider is asked for the artifacts'
+ *         declared runtime version, and no other provider is consulted.
  *
  * @remarks
  * The returned {@link FinalizedCallTxData} (and the {@link CallResult} variant)
@@ -172,7 +174,8 @@ export async function submitCallTx<C extends Contract.Any, PCK extends Contract.
   options: CallTxOptions<C, PCK> | AnyLedger8CallTxOptions,
   transactionContext?: TransactionContext<C, PCK>
 ): Promise<FinalizedCallTxData<C, PCK> | CallResult<C, PCK> | AnyLedger8FinalizedCallTxData> {
-  if (isLedger8Request<AnyLedger8CallTxOptions>(options)) {
+  const artifactEra = await resolveArtifactEra(options.compiledContract, providers.zkConfigProvider);
+  if (isLedger8Request<AnyLedger8CallTxOptions>(options, artifactEra)) {
     // The retained-era pipeline runs OUTSIDE the scoped-transaction machinery:
     // that machinery merges live current-era transactions, and a retained-era
     // call is composed and submitted on its own, so there is nothing for it to
@@ -287,8 +290,10 @@ export async function submitCallTxAsync<C extends Ledger8Contract, K extends Led
  *         or rejects with an error if the submission fails.
  *
  * @throws {EraArtifactMismatchError} When `options.compiledContract` belongs to neither Compact
- *         era, or is a raw current-era contract instance passed instead of its `CompiledContract`
- *         container. Raised before any provider is consulted.
+ *         era, is a raw current-era contract instance passed instead of its `CompiledContract`
+ *         container, or its artifacts declare no toolchain this framework can place. Raised before
+ *         anything is built or submitted; the ZK config provider is asked for the artifacts'
+ *         declared runtime version, and no other provider is consulted.
  *
  * @remarks
  * The returned {@link SubmittedCallTx} is privacy-sensitive and carries the
@@ -342,7 +347,8 @@ export async function submitCallTxAsync<C extends Contract.Any, PCK extends Cont
   providers: SubmitCallTxProviders<C, PCK>,
   options: CallTxOptions<C, PCK> | AnyLedger8CallTxOptions
 ): Promise<SubmittedCallTx<C, PCK> | AnyLedger8SubmittedCallTx> {
-  if (isLedger8Request<AnyLedger8CallTxOptions>(options)) {
+  const artifactEra = await resolveArtifactEra(options.compiledContract, providers.zkConfigProvider);
+  if (isLedger8Request<AnyLedger8CallTxOptions>(options, artifactEra)) {
     return submitLedger8CallTxAsync(providers, toLedger8CallEntryOptions(options));
   }
   assertIsContractAddress(options.contractAddress);

--- a/packages/contracts/src/test/breadcrumbs.test.ts
+++ b/packages/contracts/src/test/breadcrumbs.test.ts
@@ -247,7 +247,7 @@ describe('the breadcrumb emitters', () => {
         decision: 'pipeline-selection',
         version: 'v8',
         protocolVersion: V8_HEAD,
-        source: 'compiled-contract-shape',
+        source: 'artifact-runtime-version-declaration',
         readingProvenance: 'operation-start',
         path: 'ledger8',
         contractAddress: CONTRACT_ADDRESS
@@ -270,7 +270,7 @@ describe('the breadcrumb emitters', () => {
         decision: 'pipeline-selection',
         version: 'v8',
         protocolVersion: V8_HEAD,
-        source: 'compiled-contract-shape',
+        source: 'artifact-runtime-version-declaration',
         readingProvenance: 'operation-start',
         path: 'ledger8'
       }
@@ -424,7 +424,7 @@ describe('pipeline selection pairs the artifact pipeline with the head era', () 
         decision: 'pipeline-selection',
         version: 'v8',
         protocolVersion: V8_HEAD,
-        source: 'compiled-contract-shape',
+        source: 'artifact-runtime-version-declaration',
         readingProvenance: 'operation-start',
         path: 'ledger8',
         contractAddress: CONTRACT_ADDRESS
@@ -444,7 +444,7 @@ describe('pipeline selection pairs the artifact pipeline with the head era', () 
       decision: 'pipeline-selection',
       version: 'v9',
       protocolVersion: V9_HEAD,
-      source: 'compiled-contract-shape',
+      source: 'artifact-runtime-version-declaration',
       readingProvenance: 'operation-start',
       path: 'ledger8',
       contractAddress: CONTRACT_ADDRESS
@@ -492,7 +492,7 @@ describe('pipeline selection pairs the artifact pipeline with the head era', () 
       decision: 'pipeline-selection',
       version: 'v8',
       protocolVersion: V8_HEAD,
-      source: 'compiled-contract-shape',
+      source: 'artifact-runtime-version-declaration',
       readingProvenance: 'operation-start',
       path: 'ledger8',
       contractAddress: CONTRACT_ADDRESS

--- a/packages/contracts/src/test/contracts-type-acl.test.ts
+++ b/packages/contracts/src/test/contracts-type-acl.test.ts
@@ -107,6 +107,7 @@ describe('Contracts type ACL', () => {
       'DeployTxOptionsBase',
       'DeployTxOptionsWithPrivateState',
       'DeployTxOptionsWithPrivateStateId',
+      'EraArtifactMismatchOptions',
       'EraArtifactMismatchReason',
       'EraSeam',
       'FinalizedCallTxData',

--- a/packages/contracts/src/test/era-artifact-declaration.test.ts
+++ b/packages/contracts/src/test/era-artifact-declaration.test.ts
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import { ArtifactRuntimeVersionUnavailableError, type ProverKey, type VerifierKey, ZKConfigProvider, type ZKIR } from '@midnight-ntwrk/midnight-js-types';
+import { ZkArtifactContractInfoError } from '@midnight-ntwrk/midnight-js-utils';
 import { describe, expect, it, type Mock, vi } from 'vitest';
 
 import { type PipelineEra } from '../era';
@@ -101,10 +103,10 @@ describe('resolveArtifactEra: the era comes from what the artifact declares', ()
     });
   });
 
-  it('refuses when the provider cannot say, and keeps the provider failure on cause', async () => {
+  it('refuses when the artifacts declare nothing, and keeps the provider failure on cause', async () => {
     // Never a fallback to the generated code's shape: an undeclared era is a refusal, because every
     // answer this framework could invent would be a guess about which ledger executes the call.
-    const unavailable = new Error('no contract-info.json at https://cdn.example/compiler/');
+    const unavailable = new ZkArtifactContractInfoError('no contract-info.json at https://cdn.example/compiler/');
     const source = refusing(unavailable);
 
     const error = await resolveArtifactEra(retainedShape(), source).catch((thrown: unknown) => thrown);
@@ -112,6 +114,45 @@ describe('resolveArtifactEra: the era comes from what the artifact declares', ()
     expect(error).toBeInstanceOf(EraArtifactMismatchError);
     expect(error).toMatchObject({ reason: 'artifact-era-undeclared' });
     expect((error as EraArtifactMismatchError).cause).toBe(unavailable);
+  });
+
+  it('separates a provider that CANNOT declare an era from artifacts that do not', async () => {
+    // The real third-party case, through the real base class rather than a stand-in: a provider
+    // written before the retained era existed never overrode the member. Its fix is to implement
+    // the method, not to serve a file, so it may not be reported as an artifact problem.
+    class ArtifactOnlyProvider extends ZKConfigProvider<string> {
+      async getZKIR(): Promise<ZKIR> {
+        return new Uint8Array() as ZKIR;
+      }
+
+      async getProverKey(): Promise<ProverKey> {
+        return new Uint8Array() as ProverKey;
+      }
+
+      async getVerifierKey(): Promise<VerifierKey> {
+        return new Uint8Array() as VerifierKey;
+      }
+    }
+
+    const error = await resolveArtifactEra(retainedShape(), new ArtifactOnlyProvider()).catch(
+      (thrown: unknown) => thrown
+    );
+
+    expect(error).toBeInstanceOf(EraArtifactMismatchError);
+    expect(error).toMatchObject({ reason: 'provider-cannot-declare-era' });
+    expect((error as EraArtifactMismatchError).cause).toBeInstanceOf(ArtifactRuntimeVersionUnavailableError);
+    // The base class names the provider that could not answer; that naming must survive the wrap.
+    expect(((error as EraArtifactMismatchError).cause as Error).message).toMatch(/ArtifactOnlyProvider/);
+  });
+
+  it.each([
+    ['a transport failure', new TypeError('fetch failed')],
+    ['a permission fault', Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })]
+  ])('propagates %s unchanged rather than reporting it as an era problem', async (_label, failure) => {
+    // These say nothing about which era the artifacts belong to. Relabelling them sends the caller
+    // to serve a file that is already there, and buries the real fault on `cause`. The sibling
+    // `readHeadEra` states the same rule for the head read.
+    await expect(resolveArtifactEra(retainedShape(), refusing(failure))).rejects.toBe(failure);
   });
 
   it('refuses a raw current-era contract by its async initialState before any provider read', async () => {

--- a/packages/contracts/src/test/era-artifact-declaration.test.ts
+++ b/packages/contracts/src/test/era-artifact-declaration.test.ts
@@ -1,0 +1,145 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, type Mock, vi } from 'vitest';
+
+import { type PipelineEra } from '../era';
+import { EraArtifactMismatchError } from '../errors';
+import { type ArtifactRuntimeVersionSource, resolveArtifactEra } from '../internal/era';
+import { createMockCompiledContract } from './test-mocks';
+
+type RuntimeVersionSpy = Mock<() => Promise<string>>;
+
+const declaring = (runtimeVersion: string): ArtifactRuntimeVersionSource & { getArtifactRuntimeVersion: RuntimeVersionSpy } => ({
+  getArtifactRuntimeVersion: vi.fn<() => Promise<string>>().mockResolvedValue(runtimeVersion)
+});
+
+const refusing = (error: Error): ArtifactRuntimeVersionSource & { getArtifactRuntimeVersion: RuntimeVersionSpy } => ({
+  getArtifactRuntimeVersion: vi.fn<() => Promise<string>>().mockRejectedValue(error)
+});
+
+// The shape the retained toolchain generates: `impureCircuits` and a SYNCHRONOUS `initialState`.
+const retainedShape = (): object => ({
+  impureCircuits: { increment: (): void => undefined },
+  initialState: (): Record<string, never> => ({})
+});
+
+// What a bundler emits for the CURRENT era's `async initialState` when it targets below ES2017:
+// a plain function returning a promise. `constructor.name` reads 'Function' on it, exactly as it
+// does on a real retained artifact -- which is why the era may not be read from that name.
+const transpiledCurrentEraShape = (): object => ({
+  impureCircuits: { deposit: (): Promise<void> => Promise.resolve() },
+  initialState: (): Promise<Record<string, never>> => Promise.resolve({})
+});
+
+describe('resolveArtifactEra: the era comes from what the artifact declares', () => {
+  it('places a current-era container without consulting the artifact set at all', async () => {
+    // Arrange: the container carries its own era marker -- an own `tag` no build step rewrites --
+    // so the current era pays nothing for this dispatch.
+    const source = declaring('0.19.0');
+
+    // Act
+    const era = await resolveArtifactEra(createMockCompiledContract(), source);
+
+    // Assert
+    expect(era).toBe<PipelineEra>('ledger9');
+    expect(source.getArtifactRuntimeVersion).not.toHaveBeenCalled();
+  });
+
+  it('places a retained artifact from the runtime version its compiler recorded', async () => {
+    const source = declaring('0.16.0');
+
+    const era = await resolveArtifactEra(retainedShape(), source);
+
+    expect(era).toBe<PipelineEra>('ledger8');
+    expect(source.getArtifactRuntimeVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads the declared version patch-insensitively', async () => {
+    expect(await resolveArtifactEra(retainedShape(), declaring('0.16.7'))).toBe<PipelineEra>('ledger8');
+  });
+
+  it('REFUSES a current-era contract whose async initialState a build step erased', async () => {
+    // The regression this whole change exists for. Structurally this object is indistinguishable
+    // from a retained artifact -- `constructor.name` reads 'Function' on both -- so routing on that
+    // name sent a current-era contract into the retained pipeline. The declared runtime version
+    // separates them, and it is the same on both sides of any transpilation.
+    const source = declaring('0.19.0');
+
+    await expect(resolveArtifactEra(transpiledCurrentEraShape(), source)).rejects.toBeInstanceOf(
+      EraArtifactMismatchError
+    );
+    await expect(resolveArtifactEra(transpiledCurrentEraShape(), source)).rejects.toMatchObject({
+      reason: 'unwrapped-current-era-contract'
+    });
+  });
+
+  it('refuses an artifact set whose runtime version this framework cannot place, naming it', async () => {
+    const source = declaring('0.99.0');
+
+    await expect(resolveArtifactEra(retainedShape(), source)).rejects.toMatchObject({
+      reason: 'unknown-artifact-runtime-version'
+    });
+    await expect(resolveArtifactEra(retainedShape(), source)).rejects.toThrow(/0\.99\.0/);
+  });
+
+  it('refuses a malformed runtime version rather than reading a prefix of it', async () => {
+    await expect(resolveArtifactEra(retainedShape(), declaring('sixteen'))).rejects.toMatchObject({
+      reason: 'unknown-artifact-runtime-version'
+    });
+  });
+
+  it('refuses when the provider cannot say, and keeps the provider failure on cause', async () => {
+    // Never a fallback to the generated code's shape: an undeclared era is a refusal, because every
+    // answer this framework could invent would be a guess about which ledger executes the call.
+    const unavailable = new Error('no contract-info.json at https://cdn.example/compiler/');
+    const source = refusing(unavailable);
+
+    const error = await resolveArtifactEra(retainedShape(), source).catch((thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(EraArtifactMismatchError);
+    expect(error).toMatchObject({ reason: 'artifact-era-undeclared' });
+    expect((error as EraArtifactMismatchError).cause).toBe(unavailable);
+  });
+
+  it('refuses a raw current-era contract by its async initialState before any provider read', async () => {
+    // An `AsyncFunction` is proof of the current era that no build step can fabricate, only erase.
+    // It is therefore allowed to REFUSE on its own -- and never to route anything anywhere.
+    const source = declaring('0.16.0');
+    const rawCurrentEra = {
+      impureCircuits: { deposit: async (): Promise<void> => undefined },
+      initialState: async (): Promise<Record<string, never>> => ({})
+    };
+
+    await expect(resolveArtifactEra(rawCurrentEra, source)).rejects.toMatchObject({
+      reason: 'unwrapped-current-era-contract'
+    });
+    expect(source.getArtifactRuntimeVersion).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['a plain object', {}],
+    ['null', null],
+    ['a string', 'contract'],
+    ['an object with a non-string tag', { tag: 7 }]
+  ])('refuses %s without consulting the artifact set', async (_label, candidate) => {
+    const source = declaring('0.16.0');
+
+    await expect(resolveArtifactEra(candidate, source)).rejects.toMatchObject({
+      reason: 'unrecognised-contract-shape'
+    });
+    expect(source.getArtifactRuntimeVersion).not.toHaveBeenCalled();
+  });
+});

--- a/packages/contracts/src/test/era-dispatch-ledger8.test.ts
+++ b/packages/contracts/src/test/era-dispatch-ledger8.test.ts
@@ -18,10 +18,10 @@ import { fileURLToPath } from 'node:url';
 
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { type PipelineEra, pipelineEraOf } from '../internal/era';
+import { type PipelineEra, resolveArtifactEra } from '../internal/era';
 import type { CoinReceiver016Contract, CoinReceiver016Module, Counter016Contract, Counter016Module } from './ledger8-fixture-types';
 
-// The retained-era half of `pipelineEraOf`'s coverage, and the reason it is a FILE of its own
+// The retained-era half of `resolveArtifactEra`'s coverage, and the reason it is a FILE of its own
 // rather than a `describe` inside `era-dispatch.test.ts`: the real `compact-runtime@0.16`
 // artifacts need a module-scoped runtime stub (their generated code opens with
 // `checkRuntimeVersion('0.16.0')`, which the installed current runtime rejects outright), while
@@ -29,7 +29,7 @@ import type { CoinReceiver016Contract, CoinReceiver016Module, Counter016Contract
 // registry cannot serve both, so the two halves are split and each runs against a real artifact.
 //
 // `ledger8-contract.test.ts` asserts the STRUCTURE these artifacts have. This file asserts that
-// `pipelineEraOf` reads that structure correctly -- the two are separate claims, and the second is
+// `resolveArtifactEra` reads that structure correctly -- the two are separate claims, and the second is
 // the one the era dispatch depends on.
 const FIXTURES_DIR = resolve(fileURLToPath(new URL('../../../../', import.meta.url)), 'testkit-js/testkit-js/src/fixtures/hf');
 const COUNTER_016_MODULE = resolve(FIXTURES_DIR, 'counter-016/compiled/contract/index.js');
@@ -67,7 +67,12 @@ vi.mock('@midnight-ntwrk/compact-runtime', () => {
   };
 });
 
-describe('pipelineEraOf against the REAL retained-era artifacts', () => {
+// What a retained bundle declares about itself: the compact-runtime its compiler recorded in
+// `compiler/contract-info.json`. These fixtures were built by compactc 0.31.1, whose runtime is
+// 0.16.0 -- asserted against the real file in `fixtures-hf`, not assumed here.
+const RETAINED_BUNDLE = { getArtifactRuntimeVersion: async (): Promise<string> => '0.16.0' };
+
+describe('resolveArtifactEra against the REAL retained-era artifacts', () => {
   let counter: Counter016Contract;
   let coinReceiver: CoinReceiver016Contract;
 
@@ -78,18 +83,20 @@ describe('pipelineEraOf against the REAL retained-era artifacts', () => {
     coinReceiver = new coinReceiverModule.Contract({});
   });
 
-  it('routes the real zero-argument retained artifact to the retained-era pipeline', () => {
-    // The discriminator, restated as an assertion so a toolchain change that made the retained
-    // codegen async would fail HERE, naming the cause, rather than in the routing below.
+  it('routes the real zero-argument retained artifact to the retained-era pipeline', async () => {
+    // The shape, restated as an assertion so a toolchain change that made the retained codegen
+    // async would fail HERE, naming the cause, rather than in the routing below. It is a
+    // PRECONDITION of the routing, not the routing's reason: the era itself comes from what the
+    // bundle declares.
     expect(counter.initialState.constructor.name).toBe('Function');
 
-    expect(pipelineEraOf(counter)).toBe<PipelineEra>('ledger8');
+    await expect(resolveArtifactEra(counter, RETAINED_BUNDLE)).resolves.toBe('ledger8' satisfies PipelineEra);
   });
 
-  it('routes the real argument-taking retained artifact the same way', () => {
+  it('routes the real argument-taking retained artifact the same way', async () => {
     expect(coinReceiver.initialState.constructor.name).toBe('Function');
 
-    expect(pipelineEraOf(coinReceiver)).toBe<PipelineEra>('ledger8');
+    await expect(resolveArtifactEra(coinReceiver, RETAINED_BUNDLE)).resolves.toBe('ledger8' satisfies PipelineEra);
   });
 
   it('places the real artifact without consulting the compact-js brand, which it does not carry', () => {

--- a/packages/contracts/src/test/era-dispatch-ledger8.test.ts
+++ b/packages/contracts/src/test/era-dispatch-ledger8.test.ts
@@ -69,7 +69,8 @@ vi.mock('@midnight-ntwrk/compact-runtime', () => {
 
 // What a retained bundle declares about itself: the compact-runtime its compiler recorded in
 // `compiler/contract-info.json`. These fixtures were built by compactc 0.31.1, whose runtime is
-// 0.16.0 -- asserted against the real file in `fixtures-hf`, not assumed here.
+// 0.16.0 -- asserted against the real counter-016 file in
+// `testkit-js/testkit-js/test/counter-016-artifacts.ut.test.ts`, not assumed here.
 const RETAINED_BUNDLE = { getArtifactRuntimeVersion: async (): Promise<string> => '0.16.0' };
 
 describe('resolveArtifactEra against the REAL retained-era artifacts', () => {

--- a/packages/contracts/src/test/era-dispatch.test.ts
+++ b/packages/contracts/src/test/era-dispatch.test.ts
@@ -30,7 +30,7 @@ import {
 import {
   assertEraCompatible,
   type PipelineEra,
-  pipelineEraOf,
+  resolveArtifactEra,
   resolveContractStateEra,
   resolveOperationEra
 } from '../internal/era';
@@ -86,18 +86,38 @@ const rejectingHeadSource = (error: Error): { readonly queryLatestProtocolVersio
 const V8_HEAD = 1_000_000;
 const V9_HEAD = 2_000_000;
 
-describe('pipelineEraOf: which execution pipeline an artifact belongs to', () => {
-  it('routes the current-era CompiledContract container to the ledger9 pipeline', () => {
+// A bundle declaring the retained toolchain, which is what the retained-era arm of the dispatch
+// reads. Declared here rather than mocked per test: every case below that reaches it wants the same
+// answer, and the cases that must NOT reach it assert that separately.
+const RETAINED_BUNDLE = { getArtifactRuntimeVersion: async (): Promise<string> => '0.16.0' };
+
+describe('resolveArtifactEra: which execution pipeline an artifact belongs to', () => {
+  it('routes the current-era CompiledContract container to the ledger9 pipeline', async () => {
     // Arrange: the container this repo's own mocks build, which is what every current-era
     // caller passes.
     const container = createMockCompiledContract();
 
     // Act + Assert
-    expect(pipelineEraOf(container)).toBe<PipelineEra>('ledger9');
+    await expect(resolveArtifactEra(container, RETAINED_BUNDLE)).resolves.toBe('ledger9' satisfies PipelineEra);
   });
 
-  it('routes an object with the retained-era shape to the retained-era pipeline', () => {
-    // The real retained (`compact-runtime@0.16`) artifact is asserted against this predicate in
+  it('does not consult the artifact bundle for a current-era container', async () => {
+    // The container declares its own era with an own `tag`, so the current era buys no round trip
+    // and needs no file it does not already ship. A bundle that would REFUSE proves it was never
+    // asked.
+    const refusingBundle = {
+      getArtifactRuntimeVersion: async (): Promise<string> => {
+        throw new Error('the current-era arm must not read the artifact bundle');
+      }
+    };
+
+    await expect(resolveArtifactEra(createMockCompiledContract(), refusingBundle)).resolves.toBe(
+      'ledger9' satisfies PipelineEra
+    );
+  });
+
+  it('routes an object with the retained-era shape to the retained-era pipeline', async () => {
+    // The real retained (`compact-runtime@0.16`) artifact is asserted against this resolver in
     // `era-dispatch-ledger8.test.ts`, which needs a module-scoped runtime stub this file must not
     // install: the current-era artifact below needs the REAL runtime. The shape asserted there and
     // the shape built here are the same one -- `impureCircuits` with a SYNCHRONOUS `initialState`.
@@ -106,7 +126,7 @@ describe('pipelineEraOf: which execution pipeline an artifact belongs to', () =>
       initialState: (): Record<string, never> => ({})
     };
 
-    expect(pipelineEraOf(retained)).toBe<PipelineEra>('ledger8');
+    await expect(resolveArtifactEra(retained, RETAINED_BUNDLE)).resolves.toBe('ledger8' satisfies PipelineEra);
   });
 
   describe('the near-miss a JavaScript caller actually hits', () => {
@@ -121,24 +141,25 @@ describe('pipelineEraOf: which execution pipeline an artifact belongs to', () =>
       });
     });
 
-    it('refuses a raw current-era Contract instance passed instead of its container', () => {
-      // This is the blind spot the superseded provisional predicate documented and could not close: a raw current-era
-      // contract carries `impureCircuits` too, so a structural test for that member alone
-      // misclassifies it as retained-era. The `AsyncFunction` `initialState` is what separates
-      // them, and it is a property of the real generated artifact, not of this test.
+    it('refuses a raw current-era Contract instance passed instead of its container', async () => {
+      // This is the blind spot the superseded provisional predicate documented and could not close:
+      // a raw current-era contract carries `impureCircuits` too, so a structural test for that
+      // member alone misclassifies it as retained-era. An `AsyncFunction` `initialState` refuses it
+      // outright -- a build step can erase that name but never fabricate it, so reading it is sound
+      // in the refusing direction and unsound in the accepting one.
       expect(rawCurrentEraContract.initialState.constructor.name).toBe('AsyncFunction');
 
-      expect(() => pipelineEraOf(rawCurrentEraContract)).toThrow(EraArtifactMismatchError);
-      try {
-        pipelineEraOf(rawCurrentEraContract);
-        expect.unreachable('pipelineEraOf accepted a raw current-era contract');
-      } catch (error) {
-        expect(error).toBeInstanceOf(EraArtifactMismatchError);
-        expect((error as EraArtifactMismatchError).reason).toBe('unwrapped-current-era-contract');
-        expect(hasErrorCode(error, CONTRACTS_ERROR_CODES.ERA_ARTIFACT_MISMATCH)).toBe(true);
-        // The message has to name the actual mistake, because the fix is one step: wrap it.
-        expect((error as EraArtifactMismatchError).message).toMatch(/CompiledContract/);
-      }
+      await expect(resolveArtifactEra(rawCurrentEraContract, RETAINED_BUNDLE)).rejects.toBeInstanceOf(
+        EraArtifactMismatchError
+      );
+      const error = await resolveArtifactEra(rawCurrentEraContract, RETAINED_BUNDLE).catch(
+        (thrown: unknown) => thrown
+      );
+      expect(error).toBeInstanceOf(EraArtifactMismatchError);
+      expect((error as EraArtifactMismatchError).reason).toBe('unwrapped-current-era-contract');
+      expect(hasErrorCode(error, CONTRACTS_ERROR_CODES.ERA_ARTIFACT_MISMATCH)).toBe(true);
+      // The message has to name the actual mistake, because the fix is one step: wrap it.
+      expect((error as EraArtifactMismatchError).message).toMatch(/CompiledContract/);
     });
   });
 
@@ -149,17 +170,14 @@ describe('pipelineEraOf: which execution pipeline an artifact belongs to', () =>
     ['a string', 'contract'],
     ['an object with a non-string tag', { tag: 7 }],
     ['an object whose initialState is not a function', { impureCircuits: {}, initialState: 'nope' }]
-  ])('refuses %s as belonging to neither era', (_label, candidate) => {
-    try {
-      pipelineEraOf(candidate);
-      expect.unreachable('pipelineEraOf accepted an object belonging to neither era');
-    } catch (error) {
-      expect(error).toBeInstanceOf(EraArtifactMismatchError);
-      expect((error as EraArtifactMismatchError).reason).toBe('unrecognised-contract-shape');
-      expect(hasErrorCode(error, CONTRACTS_ERROR_CODES.ERA_ARTIFACT_MISMATCH)).toBe(true);
-      // The single settled wording, reused rather than re-invented here.
-      expect((error as EraArtifactMismatchError).message).toContain(NEITHER_ERA_CONTRACT_MESSAGE);
-    }
+  ])('refuses %s as belonging to neither era', async (_label, candidate) => {
+    const error = await resolveArtifactEra(candidate, RETAINED_BUNDLE).catch((thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(EraArtifactMismatchError);
+    expect((error as EraArtifactMismatchError).reason).toBe('unrecognised-contract-shape');
+    expect(hasErrorCode(error, CONTRACTS_ERROR_CODES.ERA_ARTIFACT_MISMATCH)).toBe(true);
+    // The single settled wording, reused rather than re-invented here.
+    expect((error as EraArtifactMismatchError).message).toContain(NEITHER_ERA_CONTRACT_MESSAGE);
   });
 
   it.each([
@@ -175,36 +193,33 @@ describe('pipelineEraOf: which execution pipeline an artifact belongs to', () =>
         yield 1;
       }
     ]
-  ])('refuses an object carrying impureCircuits whose initialState is %s', (_label, initialState) => {
-    // The retained era is recognised POSITIVELY -- `initialState.constructor.name === 'Function'` --
-    // so anything else with `impureCircuits` is refused rather than falling through into the
-    // retained pipeline. These two are the shapes a future or hand-rolled artifact could really
-    // have; a `class` cannot be separated this way, because a class's own constructor IS `Function`.
+  ])('refuses an object carrying impureCircuits whose initialState is %s', async (_label, initialState) => {
+    // `constructor.name` is read to REFUSE and never to accept, so anything that is not a plain
+    // function is rejected here before the bundle is consulted. A plain function gets no verdict
+    // from this reading at all -- it only earns the right to have its bundle asked.
     const candidate = { impureCircuits: { increment: (): void => undefined }, initialState };
 
-    try {
-      pipelineEraOf(candidate);
-      expect.unreachable('pipelineEraOf routed a non-Function initialState into the retained pipeline');
-    } catch (error) {
-      expect(error).toBeInstanceOf(EraArtifactMismatchError);
-      expect((error as EraArtifactMismatchError).reason).toBe('unrecognised-contract-shape');
-    }
+    const error = await resolveArtifactEra(candidate, RETAINED_BUNDLE).catch((thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(EraArtifactMismatchError);
+    expect((error as EraArtifactMismatchError).reason).toBe('unrecognised-contract-shape');
   });
 
-  it('deliberately does NOT discriminate on the compact-js CompiledContract brand', () => {
+  it('deliberately does NOT discriminate on the compact-js CompiledContract brand', async () => {
     // PIN, do not "improve" this away. `CompiledContract.make` installs the registered brand on a
     // PROTOTYPE (`Object.create(CompiledContractProto)`), and every combinator that makes a
     // container usable returns `{ ...self, ... }` -- an own-enumerable-only spread that drops the
     // prototype. So a brand test reports FALSE for every real, witness-bearing container, and a
-    // predicate built on it would misclassify every current-era caller. This repo's own mock goes
+    // check built on it would misclassify every current-era caller. This repo's own mock goes
     // through `withVacantWitnesses`, which makes it a free regression test for exactly that.
     const container = createMockCompiledContract();
 
     expect(COMPILED_CONTRACT_BRAND in container).toBe(false);
     // `pipe` is dropped by the same spread, which is the vendor half of the same defect.
     expect('pipe' in container).toBe(false);
-    // And the predicate still places it correctly, because it does not consult the brand.
-    expect(pipelineEraOf(container)).toBe<PipelineEra>('ledger9');
+    // And the container is still placed correctly, because the `tag` it assigns to ITSELF survives
+    // the spread that drops the brand.
+    await expect(resolveArtifactEra(container, RETAINED_BUNDLE)).resolves.toBe('ledger9' satisfies PipelineEra);
   });
 });
 

--- a/packages/contracts/src/test/era-error-surface.test.ts
+++ b/packages/contracts/src/test/era-error-surface.test.ts
@@ -60,12 +60,18 @@ describe('the era and verification-path errors a caller has to catch are reachab
     const REMEDIATION: Readonly<Record<EraArtifactMismatchReason, string>> = {
       'unwrapped-current-era-contract': 'wrap-it',
       'unrecognised-contract-shape': 'recompile',
-      'current-era-artifact-on-pre-fork-head': 'wait-for-fork'
+      'current-era-artifact-on-pre-fork-head': 'wait-for-fork',
+      'artifact-era-undeclared': 'serve-contract-info',
+      'unknown-artifact-runtime-version': 'upgrade-midnight-js'
     };
 
     expect(REMEDIATION[new EraArtifactMismatchError('unwrapped-current-era-contract').reason]).toBe('wrap-it');
     expect(REMEDIATION[new EraArtifactMismatchError('unrecognised-contract-shape').reason]).toBe('recompile');
     expect(REMEDIATION[new EraArtifactMismatchError('current-era-artifact-on-pre-fork-head').reason]).toBe('wait-for-fork');
+    expect(REMEDIATION[new EraArtifactMismatchError('artifact-era-undeclared').reason]).toBe('serve-contract-info');
+    expect(REMEDIATION[new EraArtifactMismatchError('unknown-artifact-runtime-version').reason]).toBe(
+      'upgrade-midnight-js'
+    );
   });
 
   it('retains the two eras on a head/state disagreement, so a caller can report which pair failed', () => {

--- a/packages/contracts/src/test/era-error-surface.test.ts
+++ b/packages/contracts/src/test/era-error-surface.test.ts
@@ -62,6 +62,7 @@ describe('the era and verification-path errors a caller has to catch are reachab
       'unrecognised-contract-shape': 'recompile',
       'current-era-artifact-on-pre-fork-head': 'wait-for-fork',
       'artifact-era-undeclared': 'serve-contract-info',
+      'provider-cannot-declare-era': 'implement-the-member',
       'unknown-artifact-runtime-version': 'upgrade-midnight-js'
     };
 
@@ -69,6 +70,9 @@ describe('the era and verification-path errors a caller has to catch are reachab
     expect(REMEDIATION[new EraArtifactMismatchError('unrecognised-contract-shape').reason]).toBe('recompile');
     expect(REMEDIATION[new EraArtifactMismatchError('current-era-artifact-on-pre-fork-head').reason]).toBe('wait-for-fork');
     expect(REMEDIATION[new EraArtifactMismatchError('artifact-era-undeclared').reason]).toBe('serve-contract-info');
+    expect(REMEDIATION[new EraArtifactMismatchError('provider-cannot-declare-era').reason]).toBe(
+      'implement-the-member'
+    );
     expect(REMEDIATION[new EraArtifactMismatchError('unknown-artifact-runtime-version').reason]).toBe(
       'upgrade-midnight-js'
     );

--- a/packages/contracts/src/test/keep-state.test.ts
+++ b/packages/contracts/src/test/keep-state.test.ts
@@ -165,6 +165,7 @@ describe('the keep-state pipeline (previous-toolchain contract, post-fork head)'
 
   const postForkProviders = (envelope: Uint8Array): RetainedProviders => {
     const zkConfigProvider: ZKConfigProvider<typeof CIRCUIT_ID> = {
+      getArtifactRuntimeVersion: vi.fn().mockResolvedValue('0.16.0'),
       getVerifierKeys: vi.fn(),
       getZKIR: vi.fn(),
       getProverKey: vi.fn(),

--- a/packages/contracts/src/test/ledger8-contract.test.ts
+++ b/packages/contracts/src/test/ledger8-contract.test.ts
@@ -22,7 +22,7 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { deployContract } from '../deploy-contract';
 import { EraArtifactMismatchError, Ledger8DeployUnmaintainableError } from '../errors';
-import { isLedger8Request } from '../internal/era';
+import { resolveArtifactEra } from '../internal/era';
 import type { Ledger8ContractProviders } from '../ledger8-contract';
 import type {
   CoinReceiver016Contract,
@@ -252,6 +252,7 @@ describe('the retained-era contract family matches the real compact-runtime@0.16
       getZKIR: vi.fn(),
       getProverKey: vi.fn(),
       getVerifierKey: vi.fn(),
+      getArtifactRuntimeVersion: vi.fn().mockResolvedValue('0.16.0'),
       getVerifierKeys: vi.fn(),
       get: vi.fn(),
       asKeyMaterialProvider: vi.fn()
@@ -270,39 +271,45 @@ describe('the retained-era contract family matches the real compact-runtime@0.16
       coinReceiverContract = new (await loadCoinReceiver016()).Contract({});
     });
 
-    it('recognises the real retained-era artifacts, and a current-era container as not', () => {
-      // `isLedger8Request` is the single era predicate, in the narrowing form these entry points
-      // need; it replaced a provisional `'impureCircuits' in ...` check that answered TRUE for a
-      // raw current-era contract instance, which carries that member too.
-      expect(isLedger8Request({ compiledContract: contract })).toBe(true);
-      expect(isLedger8Request({ compiledContract: coinReceiverContract })).toBe(true);
-      expect(isLedger8Request({ compiledContract: { tag: 'counter', pipe: (): void => undefined } })).toBe(false);
+    it('places the real retained-era artifacts, and a current-era container as not', async () => {
+      // `resolveArtifactEra` is the single era decision. The retained artifacts are placed from the
+      // runtime version their bundle declares; the current-era container is placed from its own
+      // `tag`, without the bundle being consulted at all.
+      await expect(resolveArtifactEra(contract, zkConfigProvider)).resolves.toBe('ledger8');
+      await expect(resolveArtifactEra(coinReceiverContract, zkConfigProvider)).resolves.toBe('ledger8');
+      await expect(
+        resolveArtifactEra({ tag: 'counter', pipe: (): void => undefined }, zkConfigProvider)
+      ).resolves.toBe('ledger9');
     });
 
-    it('rejects a REAL current-era container, not just a hand-rolled stand-in', () => {
+    it('places a REAL current-era container, not just a hand-rolled stand-in', async () => {
       // `createMockCompiledContract` goes through `CompiledContract.make(...).pipe(withVacantWitnesses)`,
       // which is how every real container is built. A literal `{ tag, pipe }` resembles only the
-      // transient `make()` result and would keep passing if the predicate were widened.
-      expect(isLedger8Request({ compiledContract: createMockCompiledContract() })).toBe(false);
+      // transient `make()` result and would keep passing if the check were widened.
+      await expect(resolveArtifactEra(createMockCompiledContract(), zkConfigProvider)).resolves.toBe('ledger9');
     });
 
-    it('refuses a RAW current-era contract instance, which also carries impureCircuits', () => {
+    it('refuses a RAW current-era contract instance, which also carries impureCircuits', async () => {
       // The blind spot that made the error message lie. A raw current-era instance is what a
       // JavaScript consumer passes when they forget the container, and `impureCircuits` alone does
-      // not tell the eras apart -- the current toolchain installs it too. Only the sync/async split
-      // does, which is the discriminator the type family is already built on. The consolidated
-      // predicate REFUSES such a value rather than reporting `false`, so the caller is told what is
-      // wrong instead of failing later, against the current-era pipeline, for an unrelated reason.
-      expect(() => isLedger8Request({ compiledContract: rawCurrentEraContract })).toThrow(EraArtifactMismatchError);
+      // not tell the eras apart -- the current toolchain installs it too. Here the real artifact
+      // still carries its `async initialState`, which is proof of the current era on its own, so it
+      // is refused before the bundle is read. A build that erased that `async` is refused too, by
+      // the runtime version the bundle declares -- see `era-artifact-declaration.test.ts`.
+      await expect(resolveArtifactEra(rawCurrentEraContract, zkConfigProvider)).rejects.toBeInstanceOf(
+        EraArtifactMismatchError
+      );
     });
 
-    it('refuses a contract belonging to neither era, where the superseded check returned false', () => {
-      // The changed failure mode, and the reason the predicate was replaced rather than patched:
-      // the provisional check answered `false` here and let the request fall into the current-era
-      // pipeline, to fail later on something unrelated to the era.
-      expect(() => isLedger8Request({ compiledContract: undefined })).toThrow(EraArtifactMismatchError);
-      expect(() => isLedger8Request({ compiledContract: null })).toThrow(EraArtifactMismatchError);
-      expect(() => isLedger8Request({ compiledContract: 'not a contract' })).toThrow(EraArtifactMismatchError);
+    it('refuses a contract belonging to neither era, where the superseded check returned false', async () => {
+      // The changed failure mode, and the reason the provisional check was replaced rather than
+      // patched: it answered `false` here and let the request fall into the current-era pipeline,
+      // to fail later on something unrelated to the era.
+      await expect(resolveArtifactEra(undefined, zkConfigProvider)).rejects.toBeInstanceOf(EraArtifactMismatchError);
+      await expect(resolveArtifactEra(null, zkConfigProvider)).rejects.toBeInstanceOf(EraArtifactMismatchError);
+      await expect(resolveArtifactEra('not a contract', zkConfigProvider)).rejects.toBeInstanceOf(
+        EraArtifactMismatchError
+      );
     });
 
     // The one arm that still refuses outright is the deploy. Its reason is measured and is nothing

--- a/packages/contracts/src/test/ledger8-contract.test.ts
+++ b/packages/contracts/src/test/ledger8-contract.test.ts
@@ -124,10 +124,12 @@ describe('the retained-era contract family matches the real compact-runtime@0.16
     expect(ownMembers.sort()).toEqual(['circuits', 'impureCircuits', 'provableCircuits', 'witnesses'].sort());
   });
 
-  it('exposes initialState as a SYNCHRONOUS function — the load-bearing half of the era discriminator', () => {
+  it('exposes initialState as a SYNCHRONOUS function, which admits the artifact without placing it', () => {
     expect(typeof contract.initialState).toBe('function');
-    // `AsyncFunction` here would mean the artifact was produced by the current toolchain, whose
-    // codegen is fully async. `Function` is what makes the retained shape structurally distinct.
+    // A PRECONDITION of the retained route, not its reason. `AsyncFunction` here would mean the
+    // artifact was produced by the current toolchain and would refuse it outright; `Function` is
+    // what a real retained artifact AND a transpiled current-era one both read, so it decides
+    // nothing on its own -- the declared runtime version does. See `era-artifact-declaration.test.ts`.
     expect(contract.initialState.constructor.name).toBe('Function');
   });
 

--- a/packages/contracts/src/test/scoped-era.test.ts
+++ b/packages/contracts/src/test/scoped-era.test.ts
@@ -349,6 +349,10 @@ describe('a retained-era call handed a scope', () => {
     // caller got something `hasErrorCode` cannot see.
     const providers = createMockProviders();
     providers.publicDataProvider.queryLatestProtocolVersion = vi.fn().mockResolvedValue(POST_FORK_PROTOCOL_VERSION);
+    // The bundle has to declare the RETAINED toolchain for this call to reach the scope refusal at
+    // all: the shared mock set is the current-era one, and an artifact whose declaration disagrees
+    // with its shape is refused at the era decision, before any scope is consulted.
+    providers.zkConfigProvider.getArtifactRuntimeVersion = vi.fn().mockResolvedValue('0.16.0');
     eraLoadSlot.rejectFor = undefined;
 
     let caught: unknown;

--- a/packages/contracts/src/test/scoped-era.test.ts
+++ b/packages/contracts/src/test/scoped-era.test.ts
@@ -40,7 +40,7 @@ import { CONTRACTS_ERROR_CODES, hasErrorCode } from '@midnight-ntwrk/midnight-js
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MixedEraScopeError, ScopedTxEraUnsupportedError } from '../errors';
-import { pipelineEraOf } from '../internal/era';
+import { resolveArtifactEra } from '../internal/era';
 import { assertScopeAdmitsRetainedEraCall, scopedTransaction, TransactionContextImpl } from '../internal/transaction';
 import { submitCallTx } from '../submit-call-tx';
 import { submitTx } from '../submit-tx';
@@ -294,7 +294,7 @@ describe('the era ordering the forward-only fork guard relies on', () => {
 });
 
 describe('a retained-era call handed a scope', () => {
-  // A retained-era artifact, in the shape `pipelineEraOf` recognises: own
+  // A retained-era artifact, in the shape `resolveArtifactEra` recognises: own
   // `impureCircuits`, and an `initialState` that is a SYNCHRONOUS function.
   // Asserted below rather than assumed, so this fixture cannot drift into the
   // current-era arm and make the negative vacuous.
@@ -310,8 +310,12 @@ describe('a retained-era call handed a scope', () => {
     args: []
   });
 
-  it('is the shape the era dispatch calls retained-era', () => {
-    expect(pipelineEraOf(retainedContract)).toBe('ledger8');
+  it('is the shape the era dispatch calls retained-era', async () => {
+    // Paired with the artifact declaration a retained bundle carries, because the shape alone no
+    // longer decides the era -- it only says which declaration is consulted.
+    const declaringRetained = { getArtifactRuntimeVersion: async (): Promise<string> => '0.16.0' };
+
+    await expect(resolveArtifactEra(retainedContract, declaringRetained)).resolves.toBe('ledger8');
   });
 
   it('is REFUSED rather than silently run outside the scope it was handed', () => {

--- a/packages/contracts/src/test/stale-head.test.ts
+++ b/packages/contracts/src/test/stale-head.test.ts
@@ -447,6 +447,7 @@ describe('the fork-crossing failure through the retained-era entry points', () =
   /** A retained-era provider set on a PRE-FORK head, with the three seams recorded. */
   const preForkProviders = (): RetainedProviders => {
     const zkConfigProvider: ZKConfigProvider<typeof CIRCUIT_ID> = {
+      getArtifactRuntimeVersion: vi.fn().mockResolvedValue('0.16.0'),
       getVerifierKeys: vi.fn(),
       getZKIR: vi.fn(),
       getProverKey: vi.fn(),

--- a/packages/contracts/src/test/submit-call-tx.test.ts
+++ b/packages/contracts/src/test/submit-call-tx.test.ts
@@ -31,7 +31,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CURRENT_PIPELINE_ERA } from '../era';
 import { isLedger8Result } from '../era-results';
 import { CallTxFailedError, IncompleteCallTxPrivateStateConfig } from '../errors';
-import { pipelineEraOf } from '../internal/era';
+import { resolveArtifactEra } from '../internal/era';
 import { submitCallTx, submitCallTxAsync } from '../submit-call-tx';
 import { submitTx, submitTxAsync } from '../submit-tx';
 import { withContractScopedTransaction } from '../transaction';
@@ -185,9 +185,9 @@ describe('submit-call-tx', () => {
 
         const result = await submitCallTx(mockProviders, options);
 
-        // The same fact `pipelineEraOf` resolves from the artifact when the
+        // The same fact `resolveArtifactEra` resolves from the artifact when the
         // entry point routes the call, published so a caller can read it too.
-        expect(result.era).toBe(pipelineEraOf(mockCompiledContract));
+        expect(result.era).toBe(await resolveArtifactEra(mockCompiledContract, mockProviders.zkConfigProvider));
         expect(result.era).toBe('ledger9');
       });
 

--- a/packages/contracts/src/test/test-mocks.ts
+++ b/packages/contracts/src/test/test-mocks.ts
@@ -293,6 +293,7 @@ export const createMockProviders = (): ContractProviders<Contract.Any, AnyProvab
     importSigningKeys: vi.fn()
   },
   zkConfigProvider: {
+    getArtifactRuntimeVersion: vi.fn().mockResolvedValue('0.16.0'),
     getVerifierKeys: vi.fn(),
     getZKIR: vi.fn(),
     getProverKey: vi.fn(),

--- a/packages/contracts/src/test/test-mocks.ts
+++ b/packages/contracts/src/test/test-mocks.ts
@@ -293,7 +293,10 @@ export const createMockProviders = (): ContractProviders<Contract.Any, AnyProvab
     importSigningKeys: vi.fn()
   },
   zkConfigProvider: {
-    getArtifactRuntimeVersion: vi.fn().mockResolvedValue('0.16.0'),
+    // The CURRENT-era value, because this is the current-era provider set. A retained value here
+    // would be read by nothing today and would silently route a regression into the retained
+    // pipeline instead of failing at the era decision.
+    getArtifactRuntimeVersion: vi.fn().mockResolvedValue('0.19.0'),
     getVerifierKeys: vi.fn(),
     getZKIR: vi.fn(),
     getProverKey: vi.fn(),

--- a/packages/contracts/src/test/v8-native.test.ts
+++ b/packages/contracts/src/test/v8-native.test.ts
@@ -82,7 +82,7 @@ import {
   VerifierKeyMismatchError
 } from '../errors';
 import { findDeployedContract } from '../find-deployed-contract';
-import { pipelineEraOf } from '../internal/era';
+import { resolveArtifactEra } from '../internal/era';
 import { findLedger8Contract, runLedger8Deploy, submitLedger8CallTx } from '../internal/ledger8-entry';
 import {
   assertSnapshotVerifierKey,
@@ -317,6 +317,7 @@ const retainedProviders = (recording: CoinReceiverRecording, envelope: Uint8Arra
   // and its `getVerifierKeys` return type is covariant in that key, so the
   // narrower provider is built explicitly rather than widened.
 const zkConfigProvider: ZKConfigProvider<typeof CIRCUIT_ID> = {
+    getArtifactRuntimeVersion: vi.fn().mockResolvedValue('0.16.0'),
     getVerifierKeys: vi.fn(),
     getZKIR: vi.fn(),
     getProverKey: vi.fn(),
@@ -969,11 +970,11 @@ describe('the retained-native pipeline through the unchanged entry points', () =
 
     const finalized = await submitCallTx(providers, callOptions());
 
-    // The two facts, side by side. `pipelineEraOf` reads the artifact; the
+    // The two facts, side by side. `resolveArtifactEra` reads the artifact; the
     // record says which ledger recorded the transaction. Pre-fork they happen
     // to agree on the era being retained -- post-fork the record reads `'v9'`
     // for this same call, and the tag must still say `'ledger8'`.
-    expect(finalized.era).toBe(pipelineEraOf(contract));
+    expect(finalized.era).toBe(await resolveArtifactEra(contract, providers.zkConfigProvider));
     expect(finalized.era).toBe('ledger8');
   });
 

--- a/packages/fetch-zk-config-provider/README.md
+++ b/packages/fetch-zk-config-provider/README.md
@@ -47,12 +47,23 @@ The provider expects the following URL structure on the server:
 
 ```
 {baseURL}/
+├── compiler/
+│   ├── contract-manifest.json  # Integrity manifest (compactc 0.33 and later)
+│   └── contract-info.json      # Compiler description, carries runtime-version
 ├── keys/
 │   ├── {circuitId}.prover      # Prover key (binary)
 │   └── {circuitId}.verifier    # Verifier key (binary)
 └── zkir/
     └── {circuitId}.bzkir       # ZK intermediate representation (binary)
 ```
+
+`compiler/` is what lets the framework establish which ledger era a contract's
+artifacts belong to. The integrity manifest is preferred, because
+`expectedManifestHash` pins it to a digest the application controls;
+`contract-info.json` is the fallback for bundles built before compactc emitted a
+manifest, and it is verified against the manifest whenever one is present. A
+bundle that ships neither can still serve keys and ZKIR, but cannot be used with
+retained-era (pre-fork) contracts.
 
 ## Exports
 

--- a/packages/fetch-zk-config-provider/src/fetch-zk-config-provider.ts
+++ b/packages/fetch-zk-config-provider/src/fetch-zk-config-provider.ts
@@ -142,16 +142,27 @@ export class FetchZkConfigProvider<K extends string> extends ZKConfigProvider<K>
   }
 
   /**
-   * Fetches the `runtime-version` from `compiler/contract-info.json` beside the artifacts.
+   * Reports the `compact-runtime` this bundle was built against, preferring the source an
+   * application can anchor to a hash it controls.
    *
-   * Cached per provider instance, like the integrity manifest and for the same reason: the file is
-   * one statement about the whole bundle. A FAILED fetch is not cached, so a transient network
-   * error does not permanently refuse an artifact set that is really there.
+   * The INTEGRITY MANIFEST is consulted first, because `expectedManifestHash` pins it to a digest
+   * the application supplies at build time, while everything else is fetched from the same host as
+   * the artifacts it describes. This value selects which ledger pipeline executes the call, so
+   * whoever serves the artifacts must not be the one who decides it.
+   *
+   * `compiler/contract-info.json` is the fallback, for bundles that carry no manifest at all --
+   * `compactc` only began emitting one in 0.33, which is exactly the retained-era case. It is put
+   * through the same integrity gate as every key and ZKIR, so under the default `require` an
+   * unvouched-for description is refused rather than trusted.
+   *
+   * Cached per provider instance. A FAILED fetch is not cached, so a transient network error does
+   * not permanently refuse an artifact set that is really there.
    *
    * @returns The declared runtime version, verbatim.
-   * @throws ZkArtifactContractInfoError if the location does not serve the file, answers with an
-   * SPA fallback page, or serves something that is not a compiler description. Absence is a refusal
-   * rather than a default: this framework cannot name an artifact set's era on its behalf.
+   * @throws ZkArtifactContractInfoError if the location does not serve the description, answers
+   * with an SPA fallback page, or serves something that is not a compiler description.
+   * @throws ZkArtifactIntegrityError if the description is not covered by the manifest under a mode
+   * that requires it.
    */
   override async getArtifactRuntimeVersion(): Promise<string> {
     // The cached promise CLEARS ITSELF on failure, so a transient error is retried rather than
@@ -166,18 +177,40 @@ export class FetchZkConfigProvider<K extends string> extends ZKConfigProvider<K>
   }
 
   private async fetchRuntimeVersion(): Promise<string> {
+    const manifest = await this.loadManifest();
+    if (manifest?.runtimeVersion !== undefined) {
+      return manifest.runtimeVersion;
+    }
+
     const url = new URL(`${ZK_MANIFEST_DIR}/${ZK_CONTRACT_INFO_FILE_NAME}`, this.base).toString();
     const response = await this.fetchFunc(url, { method: 'GET' });
-    // An HTML answer is treated as absence rather than parsed: a CDN serving its SPA fallback with
-    // a 200 is the common shape of "this file is not there".
-    if (!response.ok || FetchZkConfigProvider.isHtmlFallback(response)) {
+    if (!response.ok) {
       throw new ZkArtifactContractInfoError(
         `No ${ZK_CONTRACT_INFO_FILE_NAME} was available at ${url} (status ${response.status}), so the ` +
           `era of these artifacts cannot be established. Serve the compiler output directory that ` +
           `compactc emits beside the keys.`
       );
     }
-    return parseZkArtifactRuntimeVersion(new TextDecoder().decode(new Uint8Array(await response.arrayBuffer())));
+    // An HTML answer is reported as its own condition rather than parsed: a CDN serving its SPA
+    // fallback with a 200 is the common shape of "this file is not there", and an operator told
+    // only that the file is missing will keep re-uploading one that is already in place.
+    if (FetchZkConfigProvider.isHtmlFallback(response)) {
+      throw new ZkArtifactContractInfoError(
+        `Expected ${ZK_CONTRACT_INFO_FILE_NAME} at ${url}, but the response content-type was ` +
+          `${JSON.stringify(response.headers.get('content-type'))}. This usually means the file does ` +
+          `not exist and the server returned an SPA fallback page.`
+      );
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    verifyZkArtifactIntegrity({
+      manifest,
+      relativePath: `${ZK_MANIFEST_DIR}/${ZK_CONTRACT_INFO_FILE_NAME}`,
+      bytes,
+      mode: this.integrityOptions.verify ?? 'require',
+      onWarn: this.integrityOptions.onWarn
+    });
+
+    return parseZkArtifactRuntimeVersion(new TextDecoder().decode(bytes));
   }
 
   private async verifyArtifact(dir: typeof KEY_PATH | typeof ZKIR_PATH, fileName: string, bytes: Uint8Array): Promise<void> {

--- a/packages/fetch-zk-config-provider/src/fetch-zk-config-provider.ts
+++ b/packages/fetch-zk-config-provider/src/fetch-zk-config-provider.ts
@@ -25,9 +25,12 @@ import {
   assertManifestHash,
   assertSafeName,
   parseZkArtifactManifest,
+  parseZkArtifactRuntimeVersion,
   verifyZkArtifactIntegrity,
+  ZK_CONTRACT_INFO_FILE_NAME,
   ZK_MANIFEST_DIR,
   ZK_MANIFEST_FILE_NAME,
+  ZkArtifactContractInfoError,
   ZkArtifactIntegrityError,
   type ZkArtifactManifest,
   type ZkConfigIntegrityOptions
@@ -50,6 +53,7 @@ export class FetchZkConfigProvider<K extends string> extends ZKConfigProvider<K>
   private readonly fetchFunc: typeof fetch;
   private readonly integrityOptions: FetchZkConfigProviderOptions;
   private manifestPromise?: Promise<ZkArtifactManifest | undefined>;
+  private runtimeVersionPromise?: Promise<string>;
 
   /**
    * @param baseURL The endpoint to query for ZK artifacts.
@@ -135,6 +139,45 @@ export class FetchZkConfigProvider<K extends string> extends ZKConfigProvider<K>
       assertManifestHash(bytes, expectedManifestHash);
     }
     return parseZkArtifactManifest(new TextDecoder().decode(bytes));
+  }
+
+  /**
+   * Fetches the `runtime-version` from `compiler/contract-info.json` beside the artifacts.
+   *
+   * Cached per provider instance, like the integrity manifest and for the same reason: the file is
+   * one statement about the whole bundle. A FAILED fetch is not cached, so a transient network
+   * error does not permanently refuse an artifact set that is really there.
+   *
+   * @returns The declared runtime version, verbatim.
+   * @throws ZkArtifactContractInfoError if the location does not serve the file, answers with an
+   * SPA fallback page, or serves something that is not a compiler description. Absence is a refusal
+   * rather than a default: this framework cannot name an artifact set's era on its behalf.
+   */
+  override async getArtifactRuntimeVersion(): Promise<string> {
+    // The cached promise CLEARS ITSELF on failure, so a transient error is retried rather than
+    // remembered. Written as one self-clearing chain rather than as a stored promise compared
+    // against the slot: nothing can replace the slot between the rejection and this handler, so a
+    // comparison would only add a branch no test can reach.
+    this.runtimeVersionPromise ??= this.fetchRuntimeVersion().catch((error: unknown) => {
+      this.runtimeVersionPromise = undefined;
+      throw error;
+    });
+    return this.runtimeVersionPromise;
+  }
+
+  private async fetchRuntimeVersion(): Promise<string> {
+    const url = new URL(`${ZK_MANIFEST_DIR}/${ZK_CONTRACT_INFO_FILE_NAME}`, this.base).toString();
+    const response = await this.fetchFunc(url, { method: 'GET' });
+    // An HTML answer is treated as absence rather than parsed: a CDN serving its SPA fallback with
+    // a 200 is the common shape of "this file is not there".
+    if (!response.ok || FetchZkConfigProvider.isHtmlFallback(response)) {
+      throw new ZkArtifactContractInfoError(
+        `No ${ZK_CONTRACT_INFO_FILE_NAME} was available at ${url} (status ${response.status}), so the ` +
+          `era of these artifacts cannot be established. Serve the compiler output directory that ` +
+          `compactc emits beside the keys.`
+      );
+    }
+    return parseZkArtifactRuntimeVersion(new TextDecoder().decode(new Uint8Array(await response.arrayBuffer())));
   }
 
   private async verifyArtifact(dir: typeof KEY_PATH | typeof ZKIR_PATH, fileName: string, bytes: Uint8Array): Promise<void> {

--- a/packages/fetch-zk-config-provider/src/test/fetch-zk-config-provider.test.ts
+++ b/packages/fetch-zk-config-provider/src/test/fetch-zk-config-provider.test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { computeSha256Hex, ZkArtifactIntegrityError } from '@midnight-ntwrk/midnight-js-utils';
+import { computeSha256Hex, ZkArtifactContractInfoError, ZkArtifactIntegrityError } from '@midnight-ntwrk/midnight-js-utils';
 import { fetch } from 'cross-fetch';
 import type { BinaryLike } from 'crypto';
 import * as crypto from 'crypto';
@@ -505,6 +505,127 @@ describe('Fetch ZK config Provider', () => {
         expect(manifestFetchAttempts).toBeGreaterThanOrEqual(2);
       } finally {
         flaky.close();
+      }
+    });
+  });
+
+  describe('getArtifactRuntimeVersion', () => {
+    // Serves only what this member reads. The retained toolchain emits no integrity manifest, so the
+    // era has to come from contract-info.json, which every compactc emits.
+    const serveContractInfo = async (body?: string): Promise<{ url: string; close: () => void }> => {
+      const app = express();
+      if (body !== undefined) {
+        app.get('/compiler/contract-info.json', (_, res) => {
+          res.type('application/json').send(body);
+        });
+      }
+      const listening = app.listen();
+      const address = listening.address();
+      if (address === null || typeof address === 'string') {
+        throw new Error('express did not report a usable address');
+      }
+      return { url: `http://localhost:${address.port}`, close: () => listening.close() };
+    };
+
+    it('reports the runtime version the compiler recorded', async () => {
+      // Arrange
+      const served = await serveContractInfo(JSON.stringify({ 'runtime-version': '0.16.0' }));
+      try {
+        const provider = new FetchZkConfigProvider(served.url);
+
+        // Act
+        const runtimeVersion = await provider.getArtifactRuntimeVersion();
+
+        // Assert
+        expect(runtimeVersion).toBe('0.16.0');
+      } finally {
+        served.close();
+      }
+    });
+
+    it('refuses a location that serves no compiler description', async () => {
+      const served = await serveContractInfo();
+      try {
+        const provider = new FetchZkConfigProvider(served.url);
+
+        await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactContractInfoError);
+      } finally {
+        served.close();
+      }
+    });
+
+    it('refuses an SPA fallback page served in place of the compiler description', async () => {
+      // The failure this guards is a silent one: a CDN answering 200 with index.html would otherwise
+      // be parsed as an artifact description rather than reported as a missing file.
+      const app = express();
+      app.get('/compiler/contract-info.json', (_, res) => {
+        res.type('text/html').send('<!doctype html><html></html>');
+      });
+      const listening = app.listen();
+      const address = listening.address();
+      if (address === null || typeof address === 'string') {
+        throw new Error('express did not report a usable address');
+      }
+      try {
+        const provider = new FetchZkConfigProvider(`http://localhost:${address.port}`);
+
+        await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactContractInfoError);
+      } finally {
+        listening.close();
+      }
+    });
+
+    it('retries after a failed fetch rather than caching the failure', async () => {
+      // A transient network error must not permanently refuse an artifact set that is really there:
+      // the era read would then stay broken for the life of the provider.
+      let attempts = 0;
+      const app = express();
+      app.get('/compiler/contract-info.json', (_, res) => {
+        attempts += 1;
+        if (attempts === 1) {
+          res.status(503).send('unavailable');
+          return;
+        }
+        res.type('application/json').send(JSON.stringify({ 'runtime-version': '0.16.0' }));
+      });
+      const listening = app.listen();
+      const address = listening.address();
+      if (address === null || typeof address === 'string') {
+        throw new Error('express did not report a usable address');
+      }
+      try {
+        const provider = new FetchZkConfigProvider(`http://localhost:${address.port}`);
+
+        await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactContractInfoError);
+
+        await expect(provider.getArtifactRuntimeVersion()).resolves.toBe('0.16.0');
+        expect(attempts).toBe(2);
+      } finally {
+        listening.close();
+      }
+    });
+
+    it('fetches the description once and answers later calls from that reading', async () => {
+      let attempts = 0;
+      const app = express();
+      app.get('/compiler/contract-info.json', (_, res) => {
+        attempts += 1;
+        res.type('application/json').send(JSON.stringify({ 'runtime-version': '0.16.0' }));
+      });
+      const listening = app.listen();
+      const address = listening.address();
+      if (address === null || typeof address === 'string') {
+        throw new Error('express did not report a usable address');
+      }
+      try {
+        const provider = new FetchZkConfigProvider(`http://localhost:${address.port}`);
+
+        await provider.getArtifactRuntimeVersion();
+        await provider.getArtifactRuntimeVersion();
+
+        expect(attempts).toBe(1);
+      } finally {
+        listening.close();
       }
     });
   });

--- a/packages/fetch-zk-config-provider/src/test/fetch-zk-config-provider.test.ts
+++ b/packages/fetch-zk-config-provider/src/test/fetch-zk-config-provider.test.ts
@@ -512,6 +512,11 @@ describe('Fetch ZK config Provider', () => {
   describe('getArtifactRuntimeVersion', () => {
     // Serves only what this member reads. The retained toolchain emits no integrity manifest, so the
     // era has to come from contract-info.json, which every compactc emits.
+    // A location serving no integrity manifest is the retained (pre-compactc-0.33) case, so these
+    // providers use the mode the manifest documentation names for it. Under the default `require`
+    // the absence is itself a refusal, asserted separately below.
+    const RETAINED_BUNDLE_OPTIONS = { verify: 'require-if-present' } as const;
+
     const serveContractInfo = async (body?: string): Promise<{ url: string; close: () => void }> => {
       const app = express();
       if (body !== undefined) {
@@ -531,7 +536,7 @@ describe('Fetch ZK config Provider', () => {
       // Arrange
       const served = await serveContractInfo(JSON.stringify({ 'runtime-version': '0.16.0' }));
       try {
-        const provider = new FetchZkConfigProvider(served.url);
+        const provider = new FetchZkConfigProvider(served.url, RETAINED_BUNDLE_OPTIONS);
 
         // Act
         const runtimeVersion = await provider.getArtifactRuntimeVersion();
@@ -546,7 +551,7 @@ describe('Fetch ZK config Provider', () => {
     it('refuses a location that serves no compiler description', async () => {
       const served = await serveContractInfo();
       try {
-        const provider = new FetchZkConfigProvider(served.url);
+        const provider = new FetchZkConfigProvider(served.url, RETAINED_BUNDLE_OPTIONS);
 
         await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactContractInfoError);
       } finally {
@@ -567,11 +572,82 @@ describe('Fetch ZK config Provider', () => {
         throw new Error('express did not report a usable address');
       }
       try {
-        const provider = new FetchZkConfigProvider(`http://localhost:${address.port}`);
+        const provider = new FetchZkConfigProvider(`http://localhost:${address.port}`, RETAINED_BUNDLE_OPTIONS);
 
         await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactContractInfoError);
       } finally {
         listening.close();
+      }
+    });
+
+    it('takes the runtime version from the INTEGRITY MANIFEST when the location serves one', async () => {
+      // The manifest is the only file an application can anchor to a hash it controls
+      // (`expectedManifestHash`). Where it declares the version, reading it from anywhere else would
+      // let whoever serves the artifacts decide which ledger pipeline runs.
+      const app = express();
+      app.get('/compiler/contract-manifest.json', (_, res) => {
+        res.type('application/json').send(JSON.stringify({ 'manifest-version': '1', 'runtime-version': '0.19.0' }));
+      });
+      app.get('/compiler/contract-info.json', (_, res) => {
+        res.type('application/json').send(JSON.stringify({ 'runtime-version': '0.16.0' }));
+      });
+      const listening = app.listen();
+      const address = listening.address();
+      if (address === null || typeof address === 'string') {
+        throw new Error('express did not report a usable address');
+      }
+      try {
+        const provider = new FetchZkConfigProvider(`http://localhost:${address.port}`, RETAINED_BUNDLE_OPTIONS);
+
+        await expect(provider.getArtifactRuntimeVersion()).resolves.toBe('0.19.0');
+      } finally {
+        listening.close();
+      }
+    });
+
+    it('refuses a contract description the manifest does not vouch for', async () => {
+      // A manifest covering the file but not declaring the version itself: the description is read,
+      // and it has to survive the same integrity gate every key and ZKIR passes.
+      const contractInfo = JSON.stringify({ 'runtime-version': '0.16.0' });
+      const app = express();
+      app.get('/compiler/contract-manifest.json', (_, res) => {
+        res.type('application/json').send(
+          JSON.stringify({
+            'manifest-version': '1',
+            compiler: {
+              type: 'directory',
+              'contract-info.json': { type: 'file', size: contractInfo.length, hash: '00'.repeat(32) }
+            }
+          })
+        );
+      });
+      app.get('/compiler/contract-info.json', (_, res) => {
+        res.type('application/json').send(contractInfo);
+      });
+      const listening = app.listen();
+      const address = listening.address();
+      if (address === null || typeof address === 'string') {
+        throw new Error('express did not report a usable address');
+      }
+      try {
+        const provider = new FetchZkConfigProvider(`http://localhost:${address.port}`);
+
+        await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactIntegrityError);
+      } finally {
+        listening.close();
+      }
+    });
+
+    it('refuses to read an unvouched-for description at all under the default require mode', async () => {
+      // Consistent with every other artifact this provider serves: with verification required and
+      // no manifest available, nothing is trusted -- including the file that decides the era.
+      const served = await serveContractInfo(JSON.stringify({ 'runtime-version': '0.16.0' }));
+      try {
+        const provider = new FetchZkConfigProvider(served.url);
+
+        await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactIntegrityError);
+      } finally {
+        served.close();
       }
     });
 
@@ -594,7 +670,7 @@ describe('Fetch ZK config Provider', () => {
         throw new Error('express did not report a usable address');
       }
       try {
-        const provider = new FetchZkConfigProvider(`http://localhost:${address.port}`);
+        const provider = new FetchZkConfigProvider(`http://localhost:${address.port}`, RETAINED_BUNDLE_OPTIONS);
 
         await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactContractInfoError);
 
@@ -618,7 +694,7 @@ describe('Fetch ZK config Provider', () => {
         throw new Error('express did not report a usable address');
       }
       try {
-        const provider = new FetchZkConfigProvider(`http://localhost:${address.port}`);
+        const provider = new FetchZkConfigProvider(`http://localhost:${address.port}`, RETAINED_BUNDLE_OPTIONS);
 
         await provider.getArtifactRuntimeVersion();
         await provider.getArtifactRuntimeVersion();

--- a/packages/node-zk-config-provider/README.md
+++ b/packages/node-zk-config-provider/README.md
@@ -46,12 +46,23 @@ The provider expects the following directory structure:
 
 ```
 {directory}/
+├── compiler/
+│   ├── contract-manifest.json  # Integrity manifest (compactc 0.33 and later)
+│   └── contract-info.json      # Compiler description, carries runtime-version
 ├── keys/
 │   ├── {circuitId}.prover      # Prover key (binary)
 │   └── {circuitId}.verifier    # Verifier key (binary)
 └── zkir/
     └── {circuitId}.bzkir       # ZK intermediate representation (binary)
 ```
+
+`compiler/` is what lets the framework establish which ledger era a contract's
+artifacts belong to. The integrity manifest is preferred, because
+`expectedManifestHash` pins it to a digest the application controls;
+`contract-info.json` is the fallback for bundles built before compactc emitted a
+manifest, and it is verified against the manifest whenever one is present. A
+bundle that ships neither can still serve keys and ZKIR, but cannot be used with
+retained-era (pre-fork) contracts.
 
 ## Exports
 

--- a/packages/node-zk-config-provider/src/node-zk-config-provider.ts
+++ b/packages/node-zk-config-provider/src/node-zk-config-provider.ts
@@ -19,9 +19,12 @@ import {
   assertManifestHash,
   assertSafeName,
   parseZkArtifactManifest,
+  parseZkArtifactRuntimeVersion,
   verifyZkArtifactIntegrity,
+  ZK_CONTRACT_INFO_FILE_NAME,
   ZK_MANIFEST_DIR,
   ZK_MANIFEST_FILE_NAME,
+  ZkArtifactContractInfoError,
   ZkArtifactIntegrityError,
   type ZkArtifactManifest,
   type ZkConfigIntegrityOptions
@@ -45,6 +48,7 @@ const isErrnoException = (error: unknown): error is NodeJS.ErrnoException =>
  */
 export class NodeZkConfigProvider<K extends string> extends ZKConfigProvider<K> {
   private manifestPromise?: Promise<ZkArtifactManifest | undefined>;
+  private runtimeVersionPromise?: Promise<string>;
 
   /**
    * @param directory The base directory containing the key and ZKIR subdirectories.
@@ -103,6 +107,49 @@ export class NodeZkConfigProvider<K extends string> extends ZKConfigProvider<K> 
       assertManifestHash(bytes, expectedManifestHash);
     }
     return parseZkArtifactManifest(bytes.toString('utf-8'));
+  }
+
+  /**
+   * Reads the `runtime-version` from `compiler/contract-info.json` beside the artifacts.
+   *
+   * Cached per provider instance, like the integrity manifest and for the same reason: the file is
+   * one statement about the whole bundle, so re-reading it once per operation would buy nothing. A
+   * FAILED read is not cached, so a bundle that becomes readable later is picked up.
+   *
+   * @returns The declared runtime version, verbatim.
+   * @throws ZkArtifactContractInfoError if the file is absent, unreadable, or declares no runtime
+   * version. Absence is a refusal rather than a default: this framework cannot name an artifact
+   * set's era on its behalf.
+   */
+  override async getArtifactRuntimeVersion(): Promise<string> {
+    // The cached promise CLEARS ITSELF on failure, so a transient error is retried rather than
+    // remembered. Written as one self-clearing chain rather than as a stored promise compared
+    // against the slot: nothing can replace the slot between the rejection and this handler, so a
+    // comparison would only add a branch no test can reach.
+    this.runtimeVersionPromise ??= this.readRuntimeVersion().catch((error: unknown) => {
+      this.runtimeVersionPromise = undefined;
+      throw error;
+    });
+    return this.runtimeVersionPromise;
+  }
+
+  private async readRuntimeVersion(): Promise<string> {
+    const infoPath = path.resolve(this.directory, ZK_MANIFEST_DIR, ZK_CONTRACT_INFO_FILE_NAME);
+    let bytes: Buffer;
+    try {
+      bytes = await fs.readFile(infoPath);
+    } catch (error) {
+      if (isErrnoException(error) && error.code === 'ENOENT') {
+        throw new ZkArtifactContractInfoError(
+          `No ${ZK_CONTRACT_INFO_FILE_NAME} was found at ${infoPath}, so the era of these artifacts ` +
+            `cannot be established. Serve the compiler output directory that compactc emits beside ` +
+            `the keys.`,
+          { cause: error }
+        );
+      }
+      throw error;
+    }
+    return parseZkArtifactRuntimeVersion(bytes.toString('utf-8'));
   }
 
   private async verifyArtifact(subDir: typeof KEY_DIR | typeof ZKIR_DIR, fileName: string, bytes: Uint8Array): Promise<void> {

--- a/packages/node-zk-config-provider/src/node-zk-config-provider.ts
+++ b/packages/node-zk-config-provider/src/node-zk-config-provider.ts
@@ -110,16 +110,28 @@ export class NodeZkConfigProvider<K extends string> extends ZKConfigProvider<K> 
   }
 
   /**
-   * Reads the `runtime-version` from `compiler/contract-info.json` beside the artifacts.
+   * Reports the `compact-runtime` this bundle was built against, preferring the source an
+   * application can anchor to a hash it controls.
    *
-   * Cached per provider instance, like the integrity manifest and for the same reason: the file is
-   * one statement about the whole bundle, so re-reading it once per operation would buy nothing. A
-   * FAILED read is not cached, so a bundle that becomes readable later is picked up.
+   * The INTEGRITY MANIFEST is consulted first, because `expectedManifestHash` pins it to a digest
+   * the application supplies at build time, while everything else in the bundle is fetched from the
+   * same place as the artifacts it describes. This value selects which ledger pipeline executes the
+   * call, so whoever serves the artifacts must not be the one who decides it.
+   *
+   * `compiler/contract-info.json` is the fallback, for bundles that carry no manifest at all --
+   * `compactc` only began emitting one in 0.33, which is exactly the retained-era case. It is put
+   * through the same integrity gate as every key and ZKIR, so under the default `require` an
+   * unvouched-for description is refused rather than trusted.
+   *
+   * Cached per provider instance, like the manifest and for the same reason: the answer is one
+   * statement about the whole bundle. A FAILED read is not cached.
    *
    * @returns The declared runtime version, verbatim.
-   * @throws ZkArtifactContractInfoError if the file is absent, unreadable, or declares no runtime
-   * version. Absence is a refusal rather than a default: this framework cannot name an artifact
-   * set's era on its behalf.
+   * @throws ZkArtifactContractInfoError if the description is absent or declares no runtime version.
+   * Absence is a refusal rather than a default: this framework cannot name an artifact set's era on
+   * its behalf.
+   * @throws ZkArtifactIntegrityError if the description is not covered by the manifest under a mode
+   * that requires it.
    */
   override async getArtifactRuntimeVersion(): Promise<string> {
     // The cached promise CLEARS ITSELF on failure, so a transient error is retried rather than
@@ -134,6 +146,11 @@ export class NodeZkConfigProvider<K extends string> extends ZKConfigProvider<K> 
   }
 
   private async readRuntimeVersion(): Promise<string> {
+    const manifest = await this.loadManifest();
+    if (manifest?.runtimeVersion !== undefined) {
+      return manifest.runtimeVersion;
+    }
+
     const infoPath = path.resolve(this.directory, ZK_MANIFEST_DIR, ZK_CONTRACT_INFO_FILE_NAME);
     let bytes: Buffer;
     try {
@@ -149,6 +166,14 @@ export class NodeZkConfigProvider<K extends string> extends ZKConfigProvider<K> 
       }
       throw error;
     }
+    verifyZkArtifactIntegrity({
+      manifest,
+      relativePath: `${ZK_MANIFEST_DIR}/${ZK_CONTRACT_INFO_FILE_NAME}`,
+      bytes,
+      mode: this.integrityOptions.verify ?? 'require',
+      onWarn: this.integrityOptions.onWarn
+    });
+
     return parseZkArtifactRuntimeVersion(bytes.toString('utf-8'));
   }
 

--- a/packages/node-zk-config-provider/src/test/node-zk-provider.test.ts
+++ b/packages/node-zk-config-provider/src/test/node-zk-provider.test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { computeSha256Hex, ZkArtifactIntegrityError } from '@midnight-ntwrk/midnight-js-utils';
+import { computeSha256Hex, ZkArtifactContractInfoError, ZkArtifactIntegrityError } from '@midnight-ntwrk/midnight-js-utils';
 import type { BinaryLike } from 'crypto';
 import * as crypto from 'crypto';
 import * as fs from 'fs/promises';
@@ -335,5 +335,80 @@ describe('Node ZK config Provider', () => {
       expect(computeSha256Hex(offsetView)).toBe(computeSha256Hex(small));
       expect(computeSha256Hex(new Uint8Array(offsetView.buffer))).not.toBe(computeSha256Hex(offsetView));
     });
+  });
+});
+
+describe('NodeZkConfigProvider.getArtifactRuntimeVersion', () => {
+  // A bundle carrying only what this member reads: the compiler's own description of the artifact
+  // set. `contract-info.json` is emitted by every compactc, including the retained toolchain that
+  // emits no integrity manifest, which is why the era is read from it rather than from the manifest.
+  const buildInfoDir = async (contractInfo?: string): Promise<string> => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'node-zk-info-'));
+    await fs.mkdir(path.join(dir, 'keys'));
+    await fs.mkdir(path.join(dir, 'zkir'));
+    if (contractInfo !== undefined) {
+      await fs.mkdir(path.join(dir, 'compiler'));
+      await fs.writeFile(path.join(dir, 'compiler', 'contract-info.json'), contractInfo);
+    }
+    return dir;
+  };
+
+  it('reports the runtime version the compiler recorded', async () => {
+    // Arrange
+    const dir = await buildInfoDir(JSON.stringify({ 'compiler-version': '0.31.1', 'runtime-version': '0.16.0' }));
+    const provider = new NodeZkConfigProvider(dir);
+
+    // Act
+    const runtimeVersion = await provider.getArtifactRuntimeVersion();
+
+    // Assert
+    expect(runtimeVersion).toBe('0.16.0');
+  });
+
+  it('refuses a bundle that ships no compiler description, naming the file it looked for', async () => {
+    const provider = new NodeZkConfigProvider(await buildInfoDir());
+
+    await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactContractInfoError);
+    await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(/contract-info\.json/);
+  });
+
+  it('refuses a compiler description that is not readable as one', async () => {
+    const provider = new NodeZkConfigProvider(await buildInfoDir('<!doctype html>'));
+
+    await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactContractInfoError);
+  });
+
+  it('propagates a read failure that is not a missing file, unwrapped', async () => {
+    // Only ABSENCE is translated into an era refusal. Anything else -- a permissions fault, a
+    // directory where the file belongs -- is a fault in the caller's environment and is reported as
+    // itself, so it is not mistaken for an artifact set that declares nothing.
+    const dir = await buildInfoDir();
+    await fs.mkdir(path.join(dir, 'compiler'));
+    await fs.mkdir(path.join(dir, 'compiler', 'contract-info.json'));
+    const provider = new NodeZkConfigProvider(dir);
+
+    await expect(provider.getArtifactRuntimeVersion()).rejects.not.toBeInstanceOf(ZkArtifactContractInfoError);
+  });
+
+  it('reads the description once and answers later calls from that reading', async () => {
+    // Arrange: a bundle that answers, then loses the file underneath the provider.
+    const dir = await buildInfoDir(JSON.stringify({ 'runtime-version': '0.16.0' }));
+    const provider = new NodeZkConfigProvider(dir);
+    await provider.getArtifactRuntimeVersion();
+    await fs.rm(path.join(dir, 'compiler', 'contract-info.json'));
+
+    // Act + Assert: a second read would now fail, so answering proves the first was retained.
+    await expect(provider.getArtifactRuntimeVersion()).resolves.toBe('0.16.0');
+  });
+
+  it('retries after a failed read rather than caching the failure', async () => {
+    const dir = await buildInfoDir();
+    const provider = new NodeZkConfigProvider(dir);
+    await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactContractInfoError);
+
+    await fs.mkdir(path.join(dir, 'compiler'));
+    await fs.writeFile(path.join(dir, 'compiler', 'contract-info.json'), JSON.stringify({ 'runtime-version': '0.16.0' }));
+
+    await expect(provider.getArtifactRuntimeVersion()).resolves.toBe('0.16.0');
   });
 });

--- a/packages/node-zk-config-provider/src/test/node-zk-provider.test.ts
+++ b/packages/node-zk-config-provider/src/test/node-zk-provider.test.ts
@@ -342,6 +342,12 @@ describe('NodeZkConfigProvider.getArtifactRuntimeVersion', () => {
   // A bundle carrying only what this member reads: the compiler's own description of the artifact
   // set. `contract-info.json` is emitted by every compactc, including the retained toolchain that
   // emits no integrity manifest, which is why the era is read from it rather than from the manifest.
+  // A bundle with NO integrity manifest is the retained (pre-compactc-0.33) case, so every provider
+  // over one is constructed with the mode the manifest documentation names for exactly that:
+  // `require-if-present`. Under the default `require` the absence is itself a refusal, which is
+  // asserted separately below.
+  const RETAINED_BUNDLE_OPTIONS = { verify: 'require-if-present' } as const;
+
   const buildInfoDir = async (contractInfo?: string): Promise<string> => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'node-zk-info-'));
     await fs.mkdir(path.join(dir, 'keys'));
@@ -356,7 +362,7 @@ describe('NodeZkConfigProvider.getArtifactRuntimeVersion', () => {
   it('reports the runtime version the compiler recorded', async () => {
     // Arrange
     const dir = await buildInfoDir(JSON.stringify({ 'compiler-version': '0.31.1', 'runtime-version': '0.16.0' }));
-    const provider = new NodeZkConfigProvider(dir);
+    const provider = new NodeZkConfigProvider(dir, RETAINED_BUNDLE_OPTIONS);
 
     // Act
     const runtimeVersion = await provider.getArtifactRuntimeVersion();
@@ -366,16 +372,58 @@ describe('NodeZkConfigProvider.getArtifactRuntimeVersion', () => {
   });
 
   it('refuses a bundle that ships no compiler description, naming the file it looked for', async () => {
-    const provider = new NodeZkConfigProvider(await buildInfoDir());
+    const provider = new NodeZkConfigProvider(await buildInfoDir(), RETAINED_BUNDLE_OPTIONS);
 
     await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactContractInfoError);
     await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(/contract-info\.json/);
   });
 
   it('refuses a compiler description that is not readable as one', async () => {
-    const provider = new NodeZkConfigProvider(await buildInfoDir('<!doctype html>'));
+    const provider = new NodeZkConfigProvider(await buildInfoDir('<!doctype html>'), RETAINED_BUNDLE_OPTIONS);
 
     await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactContractInfoError);
+  });
+
+  it('takes the runtime version from the INTEGRITY MANIFEST when there is one', async () => {
+    // The manifest is the only file in the bundle an application can anchor to a hash it controls
+    // (`expectedManifestHash`). Where it declares the version, reading it from anywhere else would
+    // let whoever serves the artifacts decide which ledger pipeline runs.
+    const dir = await buildInfoDir(JSON.stringify({ 'runtime-version': '0.16.0' }));
+    await fs.writeFile(
+      path.join(dir, 'compiler', 'contract-manifest.json'),
+      JSON.stringify({ 'manifest-version': '1', 'runtime-version': '0.19.0' })
+    );
+    const provider = new NodeZkConfigProvider(dir, RETAINED_BUNDLE_OPTIONS);
+
+    await expect(provider.getArtifactRuntimeVersion()).resolves.toBe('0.19.0');
+  });
+
+  it('refuses a contract description the manifest does not vouch for', async () => {
+    // A manifest that covers the file but does not declare the version itself: the description is
+    // read, and it has to survive the same integrity gate every key and ZKIR passes.
+    const contractInfo = JSON.stringify({ 'runtime-version': '0.16.0' });
+    const dir = await buildInfoDir(contractInfo);
+    await fs.writeFile(
+      path.join(dir, 'compiler', 'contract-manifest.json'),
+      JSON.stringify({
+        'manifest-version': '1',
+        compiler: {
+          type: 'directory',
+          'contract-info.json': { type: 'file', size: contractInfo.length, hash: '00'.repeat(32) }
+        }
+      })
+    );
+    const provider = new NodeZkConfigProvider(dir);
+
+    await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactIntegrityError);
+  });
+
+  it('refuses to read an unvouched-for description at all under the default require mode', async () => {
+    // Consistent with every other artifact this provider serves: with verification required and no
+    // manifest present, nothing is trusted -- including the file that decides the ledger era.
+    const provider = new NodeZkConfigProvider(await buildInfoDir(JSON.stringify({ 'runtime-version': '0.16.0' })));
+
+    await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactIntegrityError);
   });
 
   it('propagates a read failure that is not a missing file, unwrapped', async () => {
@@ -385,15 +433,18 @@ describe('NodeZkConfigProvider.getArtifactRuntimeVersion', () => {
     const dir = await buildInfoDir();
     await fs.mkdir(path.join(dir, 'compiler'));
     await fs.mkdir(path.join(dir, 'compiler', 'contract-info.json'));
-    const provider = new NodeZkConfigProvider(dir);
+    const provider = new NodeZkConfigProvider(dir, RETAINED_BUNDLE_OPTIONS);
 
+    // Asserted POSITIVELY: `not.toBeInstanceOf` alone would pass for any unrelated fault, including
+    // one that never reached the file at all, so it would not test what this test is named for.
+    await expect(provider.getArtifactRuntimeVersion()).rejects.toMatchObject({ code: 'EISDIR' });
     await expect(provider.getArtifactRuntimeVersion()).rejects.not.toBeInstanceOf(ZkArtifactContractInfoError);
   });
 
   it('reads the description once and answers later calls from that reading', async () => {
     // Arrange: a bundle that answers, then loses the file underneath the provider.
     const dir = await buildInfoDir(JSON.stringify({ 'runtime-version': '0.16.0' }));
-    const provider = new NodeZkConfigProvider(dir);
+    const provider = new NodeZkConfigProvider(dir, RETAINED_BUNDLE_OPTIONS);
     await provider.getArtifactRuntimeVersion();
     await fs.rm(path.join(dir, 'compiler', 'contract-info.json'));
 
@@ -403,7 +454,7 @@ describe('NodeZkConfigProvider.getArtifactRuntimeVersion', () => {
 
   it('retries after a failed read rather than caching the failure', async () => {
     const dir = await buildInfoDir();
-    const provider = new NodeZkConfigProvider(dir);
+    const provider = new NodeZkConfigProvider(dir, RETAINED_BUNDLE_OPTIONS);
     await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(ZkArtifactContractInfoError);
 
     await fs.mkdir(path.join(dir, 'compiler'));

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -194,6 +194,32 @@ export class InvalidProtocolSchemeError extends Error {
 }
 
 /**
+ * An error indicating that a {@link ZKConfigProvider} cannot report which `compact-runtime` its
+ * artifact set was compiled against.
+ *
+ * The retained-era pipeline establishes an artifact's era from that declared version, so a provider
+ * that cannot serve it cannot be used with retained-era artifacts. Every provider this framework
+ * ships can serve it; a provider written outside it may not, which is the case named here.
+ *
+ * Raised rather than answered with a default, because every default would be a guess about which
+ * ledger era a caller's artifacts belong to.
+ */
+export class ArtifactRuntimeVersionUnavailableError extends Error {
+  /**
+   * @param providerName The runtime name of the provider that could not answer.
+   */
+  constructor(public readonly providerName: string) {
+    super(
+      `The ZK config provider '${providerName}' does not report the compact-runtime version its ` +
+        `artifacts were compiled against, so the era of those artifacts cannot be established. ` +
+        `Override getArtifactRuntimeVersion() on it to read the runtime-version from the ` +
+        `contract-info.json the compiler emits beside the keys, or use a provider that already does.`
+    );
+    this.name = 'ArtifactRuntimeVersionUnavailableError';
+  }
+}
+
+/**
  * An error thrown when exporting private states fails.
  */
 export class PrivateStateExportError extends Error {

--- a/packages/types/src/test/zk-config-provider.test.ts
+++ b/packages/types/src/test/zk-config-provider.test.ts
@@ -1,0 +1,53 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { ArtifactRuntimeVersionUnavailableError } from '../errors';
+import type { ProverKey, VerifierKey, ZKIR } from '../midnight-types';
+import { ZKConfigProvider } from '../zk-config-provider';
+
+// A provider written against the surface as it stood before the retained era existed: the three
+// artifact reads and nothing else. The point of the suite is what such a provider does now.
+class ArtifactOnlyZkConfigProvider extends ZKConfigProvider<string> {
+  async getZKIR(): Promise<ZKIR> {
+    return new Uint8Array() as ZKIR;
+  }
+
+  async getProverKey(): Promise<ProverKey> {
+    return new Uint8Array() as ProverKey;
+  }
+
+  async getVerifierKey(): Promise<VerifierKey> {
+    return new Uint8Array() as VerifierKey;
+  }
+}
+
+describe('ZKConfigProvider.getArtifactRuntimeVersion', () => {
+  it('refuses to answer for a provider that does not expose the compiler output', async () => {
+    // Arrange
+    const provider = new ArtifactOnlyZkConfigProvider();
+
+    // Act + Assert: the refusal is the contract. A provider that cannot say which toolchain built
+    // its artifacts must not be allowed to answer with a guess.
+    await expect(provider.getArtifactRuntimeVersion()).rejects.toBeInstanceOf(ArtifactRuntimeVersionUnavailableError);
+  });
+
+  it('names the provider that could not answer, so the caller knows which one to fix', async () => {
+    const provider = new ArtifactOnlyZkConfigProvider();
+
+    await expect(provider.getArtifactRuntimeVersion()).rejects.toThrow(/ArtifactOnlyZkConfigProvider/);
+  });
+});

--- a/packages/types/src/zk-config-provider.ts
+++ b/packages/types/src/zk-config-provider.ts
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import { ArtifactRuntimeVersionUnavailableError } from './errors';
 import type { ProverKey, VerifierKey, ZKConfig, ZKIR } from './midnight-types';
 
 /**
@@ -49,6 +50,27 @@ export abstract class ZKConfigProvider<K extends string> {
    * @param circuitId The circuit ID of the verifier key to retrieve.
    */
   abstract getVerifierKey(circuitId: K): Promise<VerifierKey>;
+
+  /**
+   * Reports the `compact-runtime` version the artifact set this provider serves was compiled
+   * against, as `compactc` recorded it in `compiler/contract-info.json` (for example `'0.16.0'`).
+   *
+   * A DECLARED fact, read from the compiler's own output, and the only era statement about an
+   * artifact that survives a consumer's build: a bundler's `target` rewrites generated code, and a
+   * minifier rewrites its names, but neither touches this file. It is what lets a caller's contract
+   * be placed on the ledger-era timeline without inspecting the shape of the generated JavaScript.
+   *
+   * Not abstract, and deliberately so: only the retained-era pipeline consults it, so a provider
+   * written for current-era artifacts alone stays valid without implementing it and fails loudly
+   * only if it is handed retained-era artifacts. Both providers this framework ships override it.
+   *
+   * @returns The declared runtime version, verbatim.
+   * @throws ArtifactRuntimeVersionUnavailableError from this base implementation, which has no
+   * artifact location to read and must not guess one.
+   */
+  async getArtifactRuntimeVersion(): Promise<string> {
+    throw new ArtifactRuntimeVersionUnavailableError(this.constructor.name);
+  }
 
   /**
    * Retrieves the verifier keys produced by `compactc` compiler for the given circuits.

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -25,4 +25,5 @@ export * from './security-utils';
 export * from './serialized-tag';
 export * from './signing-key-utils';
 export * from './type-utils';
+export * from './zk-artifact-contract-info';
 export * from './zk-artifact-manifest';

--- a/packages/utils/src/internal/json-object.ts
+++ b/packages/utils/src/internal/json-object.ts
@@ -1,0 +1,27 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Whether a `JSON.parse` result is a JSON OBJECT, as opposed to an array or `null`.
+ *
+ * Arrays are excluded deliberately. `typeof [] === 'object'` and `[] !== null`, so a naive check
+ * admits them, and a parser that admits an array then reports it as an object missing its members
+ * -- which sends a caller to fix a document that is not the one they served.
+ *
+ * Not exported from the package barrel: it is shared between this package's own parsers, not part
+ * of the published surface.
+ */
+export const isJsonObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/packages/utils/src/test/zk-artifact-contract-info.test.ts
+++ b/packages/utils/src/test/zk-artifact-contract-info.test.ts
@@ -1,0 +1,67 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseZkArtifactRuntimeVersion,
+  ZK_CONTRACT_INFO_FILE_NAME,
+  ZkArtifactContractInfoError
+} from '../zk-artifact-contract-info';
+
+describe('parseZkArtifactRuntimeVersion', () => {
+  it('reads the runtime version the compiler recorded', () => {
+    // Arrange: the shape `compactc` emits, trimmed to the members this parser reads.
+    const rawJson = JSON.stringify({
+      'compiler-version': '0.31.1',
+      'language-version': '0.23.0',
+      'runtime-version': '0.16.0',
+      circuits: []
+    });
+
+    // Act
+    const runtimeVersion = parseZkArtifactRuntimeVersion(rawJson);
+
+    // Assert
+    expect(runtimeVersion).toBe('0.16.0');
+  });
+
+  it('names the file it could not parse when the bytes are not JSON', () => {
+    expect(() => parseZkArtifactRuntimeVersion('<!doctype html>')).toThrow(ZkArtifactContractInfoError);
+    expect(() => parseZkArtifactRuntimeVersion('<!doctype html>')).toThrow(ZK_CONTRACT_INFO_FILE_NAME);
+  });
+
+  it('refuses a JSON document that is not an object', () => {
+    expect(() => parseZkArtifactRuntimeVersion('"0.16.0"')).toThrow(ZkArtifactContractInfoError);
+  });
+
+  it('refuses a document that declares no runtime version', () => {
+    const rawJson = JSON.stringify({ 'compiler-version': '0.31.1', circuits: [] });
+
+    expect(() => parseZkArtifactRuntimeVersion(rawJson)).toThrow(ZkArtifactContractInfoError);
+  });
+
+  it('refuses a runtime version that is not a string, rather than coercing it', () => {
+    const rawJson = JSON.stringify({ 'runtime-version': 16 });
+
+    expect(() => parseZkArtifactRuntimeVersion(rawJson)).toThrow(ZkArtifactContractInfoError);
+  });
+
+  it('refuses an empty runtime version', () => {
+    const rawJson = JSON.stringify({ 'runtime-version': '' });
+
+    expect(() => parseZkArtifactRuntimeVersion(rawJson)).toThrow(ZkArtifactContractInfoError);
+  });
+});

--- a/packages/utils/src/test/zk-artifact-contract-info.test.ts
+++ b/packages/utils/src/test/zk-artifact-contract-info.test.ts
@@ -43,8 +43,16 @@ describe('parseZkArtifactRuntimeVersion', () => {
     expect(() => parseZkArtifactRuntimeVersion('<!doctype html>')).toThrow(ZK_CONTRACT_INFO_FILE_NAME);
   });
 
-  it('refuses a JSON document that is not an object', () => {
-    expect(() => parseZkArtifactRuntimeVersion('"0.16.0"')).toThrow(ZkArtifactContractInfoError);
+  it.each([
+    ['a bare string', '"0.16.0"'],
+    ['an array', '[]'],
+    ['null', 'null']
+  ])('refuses %s, which is not a contract description at all', (_label, rawJson) => {
+    // An array passes a naive `typeof === 'object'` check and would then be reported as a
+    // description that merely forgot its runtime version -- sending the caller to recompile a
+    // contract whose artifacts are fine and whose served file is simply the wrong document.
+    expect(() => parseZkArtifactRuntimeVersion(rawJson)).toThrow(ZkArtifactContractInfoError);
+    expect(() => parseZkArtifactRuntimeVersion(rawJson)).toThrow(/must be a JSON object/);
   });
 
   it('refuses a document that declares no runtime version', () => {
@@ -53,10 +61,13 @@ describe('parseZkArtifactRuntimeVersion', () => {
     expect(() => parseZkArtifactRuntimeVersion(rawJson)).toThrow(ZkArtifactContractInfoError);
   });
 
-  it('refuses a runtime version that is not a string, rather than coercing it', () => {
+  it('refuses a runtime version that is not a string, and names the value it saw', () => {
+    // Named, because a truncated or hand-edited file is otherwise indistinguishable from an old
+    // toolchain -- and the two have different fixes.
     const rawJson = JSON.stringify({ 'runtime-version': 16 });
 
     expect(() => parseZkArtifactRuntimeVersion(rawJson)).toThrow(ZkArtifactContractInfoError);
+    expect(() => parseZkArtifactRuntimeVersion(rawJson)).toThrow(/16/);
   });
 
   it('refuses an empty runtime version', () => {

--- a/packages/utils/src/test/zk-artifact-manifest.test.ts
+++ b/packages/utils/src/test/zk-artifact-manifest.test.ts
@@ -91,9 +91,12 @@ describe('parseZkArtifactManifest', () => {
     expect(() => parseZkArtifactManifest(rawJson)).toThrow(/must be a JSON object/);
   });
 
-  it('throws on an array root (fails the manifest-version check)', () => {
-    // Arrays pass the record guard (typeof [] === 'object'), so they surface as a version error.
-    expect(() => parseZkArtifactManifest('[]')).toThrow(/manifest-version/);
+  it('throws on an array root, as the wrong kind of document rather than a version problem', () => {
+    // Arrays used to pass the record guard (typeof [] === 'object') and surface as a version error,
+    // which named the wrong fault: an array is not a manifest missing its version, it is not a
+    // manifest at all. The guard is now shared with the contract-description parser and excludes
+    // arrays, so both report the document kind.
+    expect(() => parseZkArtifactManifest('[]')).toThrow(/must be a JSON object/);
   });
 
   it('normalizes uppercase entry hashes to lowercase so verification accepts them', () => {

--- a/packages/utils/src/zk-artifact-contract-info.ts
+++ b/packages/utils/src/zk-artifact-contract-info.ts
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import { isJsonObject } from './internal/json-object';
+
 /** File name of the `compactc`-emitted contract description, beside the integrity manifest. */
 export const ZK_CONTRACT_INFO_FILE_NAME = 'contract-info.json';
 
@@ -30,9 +32,6 @@ export class ZkArtifactContractInfoError extends Error {
     this.name = 'ZkArtifactContractInfoError';
   }
 }
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null;
 
 /**
  * Reads the `runtime-version` a `compactc` `contract-info.json` declares.
@@ -58,14 +57,23 @@ export function parseZkArtifactRuntimeVersion(rawJson: string): string {
   } catch (error) {
     throw new ZkArtifactContractInfoError(`${ZK_CONTRACT_INFO_FILE_NAME} is not valid JSON`, { cause: error });
   }
-  if (!isRecord(root)) {
+  if (!isJsonObject(root)) {
     throw new ZkArtifactContractInfoError(`${ZK_CONTRACT_INFO_FILE_NAME} must be a JSON object`);
   }
   const runtimeVersion = root['runtime-version'];
-  if (typeof runtimeVersion !== 'string' || runtimeVersion.length === 0) {
+  if (runtimeVersion === undefined) {
     throw new ZkArtifactContractInfoError(
       `${ZK_CONTRACT_INFO_FILE_NAME} declares no "runtime-version", so the toolchain that produced ` +
         `these artifacts cannot be established. Recompile the contract with a compactc that emits it.`
+    );
+  }
+  // Named rather than merely refused: a truncated or hand-edited file is otherwise indistinguishable
+  // from an artifact set built by a toolchain too old to record the version, and the two have
+  // different fixes.
+  if (typeof runtimeVersion !== 'string' || runtimeVersion.length === 0) {
+    throw new ZkArtifactContractInfoError(
+      `${ZK_CONTRACT_INFO_FILE_NAME} declares an unusable "runtime-version": expected a non-empty ` +
+        `string, got ${JSON.stringify(runtimeVersion)}`
     );
   }
   return runtimeVersion;

--- a/packages/utils/src/zk-artifact-contract-info.ts
+++ b/packages/utils/src/zk-artifact-contract-info.ts
@@ -1,0 +1,72 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** File name of the `compactc`-emitted contract description, beside the integrity manifest. */
+export const ZK_CONTRACT_INFO_FILE_NAME = 'contract-info.json';
+
+/**
+ * Thrown when a `compactc` `contract-info.json` cannot be read as one, or declares no runtime
+ * version.
+ *
+ * Distinct from {@link ZkArtifactIntegrityError}: nothing here is a failed integrity check. The
+ * file is the artifact set's own statement of which toolchain produced it, and this error says
+ * that statement is missing or unreadable.
+ */
+export class ZkArtifactContractInfoError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'ZkArtifactContractInfoError';
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+/**
+ * Reads the `runtime-version` a `compactc` `contract-info.json` declares.
+ *
+ * Only the runtime version is returned, because it is the only member callers act on: it names the
+ * `compact-runtime` the artifact set was compiled against, which is what places the artifact on the
+ * ledger-era timeline. Every other member of the file is the contract's own description and belongs
+ * to the toolchain, not to this framework.
+ *
+ * Fail-closed throughout: a missing, empty or non-string `runtime-version` throws rather than
+ * answering `undefined`, because an absent answer here is indistinguishable from an artifact set
+ * that declares nothing, and a caller cannot act on either.
+ *
+ * @param rawJson The file's bytes, decoded as UTF-8 text.
+ * @returns The declared runtime version, verbatim.
+ * @throws ZkArtifactContractInfoError if the text is not a JSON object, or declares no usable
+ * `runtime-version`.
+ */
+export function parseZkArtifactRuntimeVersion(rawJson: string): string {
+  let root: unknown;
+  try {
+    root = JSON.parse(rawJson);
+  } catch (error) {
+    throw new ZkArtifactContractInfoError(`${ZK_CONTRACT_INFO_FILE_NAME} is not valid JSON`, { cause: error });
+  }
+  if (!isRecord(root)) {
+    throw new ZkArtifactContractInfoError(`${ZK_CONTRACT_INFO_FILE_NAME} must be a JSON object`);
+  }
+  const runtimeVersion = root['runtime-version'];
+  if (typeof runtimeVersion !== 'string' || runtimeVersion.length === 0) {
+    throw new ZkArtifactContractInfoError(
+      `${ZK_CONTRACT_INFO_FILE_NAME} declares no "runtime-version", so the toolchain that produced ` +
+        `these artifacts cannot be established. Recompile the contract with a compactc that emits it.`
+    );
+  }
+  return runtimeVersion;
+}

--- a/packages/utils/src/zk-artifact-manifest.ts
+++ b/packages/utils/src/zk-artifact-manifest.ts
@@ -16,6 +16,8 @@
 import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex } from '@noble/hashes/utils.js';
 
+import { isJsonObject } from './internal/json-object';
+
 /** Directory (relative to a provider's base location) holding the manifest. */
 export const ZK_MANIFEST_DIR = 'compiler';
 /** File name of the `compactc`-emitted integrity manifest. */
@@ -81,9 +83,6 @@ export interface ZkArtifactManifest {
   readonly files: ReadonlyMap<string, ZkArtifactManifestFile>;
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null;
-
 const asOptionalString = (value: unknown): string | undefined =>
   typeof value === 'string' ? value : undefined;
 
@@ -102,7 +101,7 @@ export function parseZkArtifactManifest(rawJson: string): ZkArtifactManifest {
   } catch (error) {
     throw new ZkArtifactIntegrityError('ZK artifact manifest is not valid JSON', { cause: error });
   }
-  if (!isRecord(root)) {
+  if (!isJsonObject(root)) {
     throw new ZkArtifactIntegrityError('ZK artifact manifest must be a JSON object');
   }
   if (root['manifest-version'] !== SUPPORTED_MANIFEST_VERSION) {
@@ -113,11 +112,11 @@ export function parseZkArtifactManifest(rawJson: string): ZkArtifactManifest {
 
   const files = new Map<string, ZkArtifactManifestFile>();
   for (const [dirName, dirValue] of Object.entries(root)) {
-    if (!isRecord(dirValue) || dirValue.type !== 'directory') {
+    if (!isJsonObject(dirValue) || dirValue.type !== 'directory') {
       continue;
     }
     for (const [childName, childValue] of Object.entries(dirValue)) {
-      if (childName === 'type' || !isRecord(childValue) || childValue.type !== 'file') {
+      if (childName === 'type' || !isJsonObject(childValue) || childValue.type !== 'file') {
         continue; // ignore the `type` discriminator and nested sub-directories (depth > 1)
       }
       const key = `${dirName}/${childName}`;


### PR DESCRIPTION
## Summary

Closes the fail-open in the era dispatch that the #1218 architecture review filed as finding 2.

`pipelineEraOf` decided which pipeline an operation takes from the shape of the caller's generated contract — `initialState.constructor.name === 'Function'` meant the retained era. That is not a stable fact about the artifact. A consumer build targeting below ES2017 (TypeScript, esbuild, older Babel presets) lowers the current era's `async initialState` into a plain function, and the name then reads `'Function'`. A raw current-era contract therefore stopped being refused and was routed into the **retained** pipeline: the one branch of that function that failed open, silently, on a build setting this framework never sees.

The era is now never inferred from generated code. The two eras are answered differently, and the difference is worth being exact about:

| era | what answers it | bundle read? |
|-----|-----------------|--------------|
| current | the `CompiledContract` container it arrives in, recognised by its own `tag` | no |
| retained | the `runtime-version` its artifact set declares | yes, cached per provider |

The current-era answer is a **container check**, not a statement by the compiler: `CompiledContract.make(tag, ctor)` takes the tag's value from the caller, so it carries no era information. What places the object is that nothing else has this shape and that an own property survives both a bundler and the spread the container's own combinators perform. The retained era has no such container, which is why it is the arm that asks the artifact set.

- The current era pays **nothing** — no new file, no round trip, dispatch unchanged.
- `constructor.name` may now only **refuse**, never route. `AsyncFunction` is proof of the current era that a build can erase but never fabricate, so it still refuses a raw instance outright; a plain-function reading proves nothing and only earns the artifact the right to have its bundle asked. The `class`-as-`initialState` hole the old doc admitted closes with it.
- The retained answer is taken from the **integrity manifest** when the bundle has one — the only file an application can anchor to a digest it controls, via `expectedManifestHash`. This value decides which ledger executes the call, so whoever serves the artifacts must not be the one who decides it. `compiler/contract-info.json` is the fallback for pre-0.33 bundles, and where a manifest exists it vouches for that file too, so the fallback passes the same integrity gate as every key and ZKIR.
- `RUNTIME_VERSION_TO_ERA` maps `major.minor` to a pipeline era in one frozen table, behind a compile-time gate (`Assert<T extends true>`) that every era is reachable from some declared version. Verified by adding an unmapped era and watching `TS2344` fire.
- Three refusals, no default between them: `artifact-era-undeclared` (the artifacts declare nothing), `provider-cannot-declare-era` (the provider has no such capability — a different fix), and `unknown-artifact-runtime-version` (named in the message). Anything else a provider throws — transport, permission, a bug — propagates unchanged rather than being relabelled as an era problem.

`docs/adr/0012` records the decision and the rejected alternatives.

### Breaking

`ZKConfigProvider` gains `getArtifactRuntimeVersion()`. It is **concrete**, with a default that throws `ArtifactRuntimeVersionUnavailableError`, so a provider subclass written outside this framework keeps compiling and keeps working for current-era artifacts, and fails by name only if handed retained-era ones. A provider supplied as an **object literal** must add the member.

Retained-era callers must serve `compiler/` alongside `keys/` and `zkir/`, and — because a retained bundle carries no manifest — must construct the provider with `verify: 'require-if-present'`, the mode the integrity work already defines for pre-0.33 artifacts and which their key and ZKIR reads need anyway.

Stacked on #1218 — merge that first.

## Test plan

- [x] Tests written first (TDD), verified RED before each implementation step, in both commits.
- [x] The regression is pinned: `era-artifact-declaration.test.ts` builds the transpiled shape (plain function returning a promise, `constructor.name === 'Function'`) and asserts it is **refused**. Independently confirmed by mutation — reverting `resolveArtifactEra` to the old behaviour fails 5 cases in that file.
- [x] "Not consulted" is asserted, not assumed: the current-era arm runs against a provider that throws if asked.
- [x] Integrity is pinned both ways: the manifest's version wins over a disagreeing `contract-info.json`, a description the manifest does not vouch for is refused, and under the default `require` an unvouched-for description is refused outright.
- [x] The capability refusal goes through the real `ZKConfigProvider` base class, not a stand-in.
- [x] Real artifacts kept in the loop — the real `compact-runtime@0.16` fixtures and the real current-era one.
- [x] Full repo suite green, uncached: `yarn test --force` -> 31/31 tasks, `Cached: 0 cached`.
- [x] `yarn lint` clean, `yarn typecheck:tests` clean, `yarn build` succeeds.

## Review

Five specialised review agents ran over the first commit. The second commit fixes everything they found at critical and high severity — the unverified era-deciding read, the decorative compile-time gate, the over-broad `catch`, the breadcrumb that named a retired selection input, and the overstated `tag` framing — plus the test and documentation defects they identified.

One finding is deliberately **not** addressed here and is worth a separate decision: `isLedger8Request(_options, era)` is a type predicate whose narrowing is decided by a separate argument, so in principle an era resolved from one contract could narrow another. Closing it properly means returning a discriminated union carrying the narrowed options, which changes the shape of all four call sites.