### PR TITLE
refactor(midnight-js)!: publish the retained era as one Ledger8 namespace

### DIFF
--- a/docs/adr/0013-publish-the-retained-era-as-one-namespace.md
+++ b/docs/adr/0013-publish-the-retained-era-as-one-namespace.md
@@ -1,0 +1,105 @@
+# 0013. Publish the retained era as one namespace
+
+- Status: Accepted
+- Date: 2026-09-11
+- Deciders: Szymon Paluchowski
+- Related: #1302, #1218 (the dual-ledger dispatch this sits on), #1004
+
+## Context
+
+`@midnight-ntwrk/midnight-js-contracts` dispatches two Compact toolchains
+through one set of entry points, so it carries two families of nearly the same
+types. The current era's family is permanent. The retained era's family exists
+only while the fork window is open: 29 types (`Ledger8FoundContract`,
+`Ledger8CallTxOptions`, ...), 7 error classes, and one interface factory --
+37 names.
+
+Those 37 have to be REACHABLE. The entry-point overloads select them by
+inference, and inference alone does not let a caller name one: a consumer can
+make a retained-era call and still not declare a parameter for the result or
+constrain a helper of its own by the contract type. Two apparent substitutes do
+not work. A name mentioned in the emitted `.d.ts` is not an export, and this
+package publishes only a `"."` entry, so there is no subpath to reach it
+through; and `Awaited<ReturnType<typeof submitCallTx>>` resolves from the LAST
+overload by design, which is a current-era arm.
+
+Published flat, they are 37 published API names on a package whose consumers
+read the flat surface as the permanent one. Withdrawing them when the window
+closes would then be a second breaking change, after the one this release
+already makes.
+
+The eventual shape is an era-scoped subpath export (`./ledger8`), which would
+also move the retained ENTRY points off `"."`, drop one `submitCallTx` overload
+arm, and let the retained runtime load lazily. That change moves call sites and
+needs a matching entry in the `midnight-js` barrel, so it is not this decision.
+
+## Decision
+
+We will publish the retained era's family as ONE name: a curated module,
+`packages/contracts/src/ledger8.ts`, re-exported from the barrel as
+`export * as Ledger8`, with the `Ledger8` prefix dropped inside each member.
+
+Membership is two-clause. A name goes in when it disappears with the retained
+era AND is part of the retained era's own API family -- its contract and result
+types, its interface factory, the refusals its pipeline raises. A name that
+serves both eras stays flat, so a consumer that only receives results never
+imports the transitional half: `AnyEraFinalizedCallTxData`,
+`AnyEraSubmittedCallTx`, `isLedger8Result`, `AnyEraTxFailedError`, and the
+pipeline-era vocabulary.
+
+The declarations keep their `Ledger8`-prefixed names. The renaming happens in
+one file, and a declaration named `Ledger8X` is published as `Ledger8.X`.
+
+## Consequences
+
+- **Positive:** the permanent published surface grows by one name instead of 37.
+  Withdrawing the retained era's family becomes one file plus one re-export
+  line, changing no current-era name and leaving nothing to rewrite for a
+  consumer that never touched it.
+- **Positive:** the transitional half is visibly quarantined. A reader of an
+  import list can see whether a consumer depends on the fork window at all.
+- **Negative:** the declaration names and the published names diverge. The API
+  reference renders `{@link Ledger8X}` labels a consumer cannot import, and
+  compiler diagnostics name the namespace after its file (`ledger8`, lowercase).
+  The mapping rule is stated on the namespace's own doc comment so it lands on
+  the generated page.
+- **Negative:** `Ledger8.CallTxFailedError` reads as a subtype of the flat
+  `CallTxFailedError` and is a sibling -- both extend `AnyEraTxFailedError`, and
+  both answer the same error code. That hierarchy pre-dates this decision; the
+  qualified spelling makes the wrong reading easier.
+- **Negative:** importing the namespace to catch one error retains all eight
+  runtime members. The object is frozen and `#__PURE__`-annotated, but it is one
+  object.
+- **Negative:** a type-only consumer cannot use `import type { Ledger8 }` and
+  then `instanceof Ledger8.CallTxFailedError` (TS1361). One import now serves
+  both positions.
+- **Follow-ups:** the FORK-WINDOW group -- `StaleHeadError`,
+  `SubmitRejectionUndiagnosedError` and their payload types,
+  `HeadStateEraMismatchError`, `EraArtifactMismatchError`,
+  `ScopedTxEraUnsupportedError`, `MixedEraScopeError` -- also disappears when the
+  window closes and stays flat here, because filing it under a name that says
+  `Ledger8` would misname it. Its removal is a separate change, and whether it
+  earns a namespace of its own is an open question.
+- **Follow-ups:** `@midnight-ntwrk/midnight-js-protocol` still publishes
+  `Ledger8RuntimeMissingError` and `Ledger8InstanceMismatchError` flat, so the
+  umbrella package shows both policies side by side. Deciding whether protocol
+  follows is deferred.
+
+## Alternatives considered
+
+- **Leave the family flat.** Rejected: it makes the transitional surface
+  permanent in the only way that matters, by publishing it, and pays for the
+  removal twice.
+- **An era-scoped `./ledger8` subpath export.** The stronger end state, and
+  compatible with this decision -- `src/ledger8.ts` is the file that would
+  become its entry. Deferred because it moves call sites (testkit, consumer
+  e2e), changes the entry-point overload set, and needs a matching barrel entry;
+  none of that is required to stop publishing 37 names.
+- **A separate package.** Rejected: the dispatching entry points stay in this
+  package and reference the retained types in their signatures, so the
+  dependency would point the wrong way and the retained package could not be
+  removed independently anyway.
+- **One era-parameterized family (`CallTxOptions<E>`).** Rejected on the code:
+  `Ledger8Contract` is structurally different from the current era's `Contract`
+  (a raw instance with `impureCircuits`, against a `CompiledContract`
+  container). A shared generic would be a facade over two unrelated shapes.

--- a/docs/releases/v5.0.0/migration-guide.md
+++ b/docs/releases/v5.0.0/migration-guide.md
@@ -396,7 +396,7 @@ For a **deploy** the remediation is different, and it is also two steps:
 
 ### Runtime-deploy chapter: factory patterns
 
-This section is linked from `Ledger8DeployOnV9Error`
+This section is linked from `Ledger8.DeployOnV9Error`
 (`MIDNIGHT_JS_C_LEDGER8_DEPLOY_ON_V9`). That code is **currently dormant** — do not
 write a `catch` for the class. The refusal you will actually meet is the uncoded
 `Error` described below, and it has the same remediation.
@@ -432,6 +432,17 @@ exercised against a retained artifact, discovering only at the fork that the
 artifacts it ships take a release cycle to replace.
 
 ### What a retained-era call answers with
+
+Everything the retained era publishes is reached through ONE import, the
+`Ledger8` namespace of `midnight-js-contracts`: `Ledger8.FinalizedCallTxData`
+is the result type below, `Ledger8.Contract` the constraint for a helper of
+your own, `Ledger8.CallTxFailedError` the failure class. The era prefix is
+dropped inside, so each member is the retained twin of the flat current-era
+name it mirrors. The half that serves BOTH eras -- `AnyEraFinalizedCallTxData`,
+`isLedger8Result`, `AnyEraTxFailedError`, the `*_PIPELINE_ERA` vocabulary --
+stays flat, so a handler that only receives results imports nothing
+era-specific. When the fork window closes, the namespace goes and nothing else
+moves.
 
 A call against a contract you compiled with the previous toolchain still goes
 through `submitCallTx` / `submitCallTxAsync` / `findDeployedContract`
@@ -485,7 +496,7 @@ for a contract whose state envelope is still pre-fork, read the state through
 
 A call the chain recorded with a non-success status throws by class, and the
 class differs per era: `CallTxFailedError` on the current era,
-`Ledger8CallTxFailedError` on the retained one. The retained class is NOT a
+`Ledger8.CallTxFailedError` on the retained one. The retained class is NOT a
 `CallTxFailedError` — it cannot be, because that class carries a v9-only
 record.
 

--- a/docs/releases/v5.0.0/migration-guide.md
+++ b/docs/releases/v5.0.0/migration-guide.md
@@ -438,11 +438,12 @@ Everything the retained era publishes is reached through ONE import, the
 is the result type below, `Ledger8.Contract` the constraint for a helper of
 your own, `Ledger8.CallTxFailedError` the failure class. The era prefix is
 dropped inside, so each member is the retained twin of the flat current-era
-name it mirrors. The half that serves BOTH eras -- `AnyEraFinalizedCallTxData`,
-`isLedger8Result`, `AnyEraTxFailedError`, the `*_PIPELINE_ERA` vocabulary --
-stays flat, so a handler that only receives results imports nothing
-era-specific. When the fork window closes, the namespace goes and nothing else
-moves.
+name it mirrors, where one exists. The half that serves BOTH eras --
+`AnyEraFinalizedCallTxData`, `isLedger8Result`, `AnyEraTxFailedError`, the
+`*_PIPELINE_ERA` vocabulary -- stays flat, so a handler that only receives
+results imports nothing era-specific. When the fork window closes, the whole
+namespace goes in one step; the fork-window refusals (`StaleHeadError` and the
+rest of that group) are published flat and go in a separate one.
 
 A call against a contract you compiled with the previous toolchain still goes
 through `submitCallTx` / `submitCallTxAsync` / `findDeployedContract`

--- a/packages/contracts/docs/retained-era-namespace.md
+++ b/packages/contracts/docs/retained-era-namespace.md
@@ -6,13 +6,14 @@ title: RetainedEraNamespace
 
 The fork window is transitional; a duplicated public interface is not. This
 package dispatches two Compact toolchains, so it carries two families of nearly
-the same types -- `FoundContract` and `Ledger8FoundContract`,
-`CallTxOptions` and `Ledger8CallTxOptions`, thirty-seven names in all. The current
-era's family is permanent. The retained era's goes when the window closes.
+the same types -- `FoundContract` and `Ledger8FoundContract`, `CallTxOptions`
+and `Ledger8CallTxOptions`. The current era's family is permanent. The retained
+era's family -- 29 types, 7 error classes and one interface factory, 37 names --
+goes when the window closes.
 
-Published flat, side by side, those thirty-seven names would be thirty-seven
-published API names, and removing them would be a second breaking change after
-the one this release already makes. They are published as ONE name instead:
+Published flat, side by side, those 37 would be 37 published API names, and
+removing them would be a second breaking change after the one this release
+already makes. They are published as ONE name instead:
 
 ```typescript
 import { Ledger8, submitCallTx } from '@midnight-ntwrk/midnight-js-contracts';
@@ -29,8 +30,34 @@ try {
 ```
 
 The era prefix is dropped inside the namespace, because the namespace carries
-it. `Ledger8.FoundContract` is the retained twin of the flat `FoundContract`,
-name for name.
+it. Where the current era publishes the same concept flat -- `FoundContract`,
+`CallTxOptions`, `FinalizedCallTxData` -- `Ledger8.X` is its retained twin. Not
+every member has such a twin: `Circuit`, `Witness`, `Contract`, `CircuitContext`
+and the six error classes have no same-spelled name on this package's flat
+surface, because the current era's equivalents live under `Contract.*` in
+`@midnight-ntwrk/compact-js` or do not exist at all.
+
+## Why a namespace rather than nothing
+
+The retained-era types are not optional decoration. The entry-point overloads
+select them by INFERENCE, and inference alone does not let a caller NAME one: a
+consumer can make a retained-era call and still not write
+`function handle(r: Ledger8.FinalizedCallTxData<C, K>)`, declare a variable of
+the result type, or constrain a helper of its own by `Ledger8.Contract`.
+
+Two things that look like substitutes and are not:
+
+- **A name in the emitted `.d.ts` is not an export.** The overload signatures
+  mention the retained types, so the declaration file contains them -- but this
+  package publishes only a `"."` entry (`package.json` `exports`), so without a
+  published name there is no subpath to reach them through either.
+- **`Awaited<ReturnType<typeof submitCallTx>>` resolves from the LAST overload
+  by design**, which is a current-era arm. It hands back the current-era shape:
+  the wrong type for a retained-era call.
+
+The whole family travels together rather than just the four result types: a
+consumer who cannot also name `Ledger8.Circuit` and `Ledger8.Witness` cannot
+declare a contract type that satisfies `Ledger8.Contract` in the first place.
 
 ## Naming, in these documents and in the source
 
@@ -41,15 +68,22 @@ how the pipeline works. The rule for reading those references is mechanical:
 
 > a declaration named `Ledger8X` is published as `Ledger8.X`.
 
-The renaming happens in one place, `packages/contracts/src/ledger8.ts`, which
-is the only file that has to change when a member joins or leaves.
+The renaming happens in one place, `packages/contracts/src/ledger8.ts`. A member
+joining or leaving the family is edited there and in the two pinned lists that
+guard it (see "What guards it" below) -- and nowhere else.
 
 ## What qualifies for membership
 
-A name belongs in the namespace when it disappears with the retained era. That
-is the whole test, and it puts the error classes inside it too: a consumer
-catching `Ledger8.SeamFailedError` has written code that only means anything
-while the window is open.
+A name belongs in the namespace when BOTH hold:
+
+1. it disappears when the retained era does, and
+2. it is part of the retained era's own API family -- its contract and result
+   types, its interface factory, the refusals its pipeline raises.
+
+The second clause is what the namespace's name commits to: it is `Ledger8`, the
+ERA, not the fork window. The error classes pass both clauses and are inside: a
+consumer catching `Ledger8.SeamFailedError` has written code that only means
+anything while that pipeline runs.
 
 A name that serves BOTH eras stays on the flat surface, so a consumer that only
 RECEIVES results never imports the transitional half:
@@ -57,46 +91,80 @@ RECEIVES results never imports the transitional half:
 - `AnyEraFinalizedCallTxData`, `AnyEraSubmittedCallTx` and `isLedger8Result` --
   the union a shared handler declares, and the guard that narrows it.
 - `AnyEraTxFailedError` -- the base both eras' failure classes extend.
-  `Ledger8.CallTxFailedError` still extends it, so a handler written against
-  the base keeps catching the retained era without naming it.
+  `Ledger8.CallTxFailedError` still extends it, so a handler written against the
+  base keeps catching the retained era without naming it.
 - `CURRENT_PIPELINE_ERA`, `RETAINED_PIPELINE_ERA`, `PipelineEra` and its two
   literal aliases -- the vocabulary both pipelines are named by.
 - `UnrecognisedResultEraError` -- raised for a result tagged with neither era,
   which is not a retained-era condition.
 
+## The fork-window group, which is NOT in here
+
+A second group passes clause 1 and fails clause 2, and it is published flat:
+`StaleHeadError`, `SubmitRejectionUndiagnosedError` and their two payload types,
+`HeadStateEraMismatchError`, `EraArtifactMismatchError`,
+`ScopedTxEraUnsupportedError`, `MixedEraScopeError`. These describe the FORK
+WINDOW -- a head that moved under an operation, an artifact whose era does not
+pair with the head, a scope the head era cannot compose -- and they will need
+removing too, in their own change.
+
+They are not folded in here because grouping them under a name that says
+`Ledger8` would misfile them, and because inventing a second namespace for them
+is a decision nobody has asked for yet. What this document must not do is claim
+the property it does not have: withdrawing the retained era is ONE step for the
+era's own family and a SECOND step for the fork-window group.
+
 ## What is held back
 
 `Ledger8DeployedContract` is declared and NOT published, under the rule that a
-caller who can obtain a value must be able to name its type -- and no caller
-can obtain this one. `deployContract`'s retained arm refuses every
-retained-toolchain artifact with `Ledger8.DeployUnmaintainableError` before it
-touches a provider, so nothing constructs the type. Publishing it would
-document a handle nobody can hold and, because it extends
+caller who can obtain a value must be able to name its type -- and no caller can
+obtain this one. `deployContract`'s retained arm refuses every retained-toolchain
+artifact with `Ledger8.DeployUnmaintainableError` before any transaction is
+composed or submitted (it does read the ZK config provider first, to establish
+the artifact's declared runtime version), so nothing constructs the type.
+Publishing it would document a handle nobody can hold and, because it extends
 `Ledger8FoundContract`, would make every later repair of that handle a breaking
 change to a published type with no users. Publish it in the commit that makes
 the deploy arm produce one.
 
-The two refusal ERRORS are published, because a caller does receive those and
-has to catch them by class.
+Both refusal ERRORS are published, but they are not in the same position:
+`Ledger8.DeployUnmaintainableError` is the refusal a caller actually receives,
+and `Ledger8.DeployOnV9Error` sits behind it in the era pairing table, so it is
+dormant -- unreachable through `deployContract` today. Do not write a `catch`
+for it; it is published for completeness and becomes reachable when the deploy
+arm is wired.
 
 The `AnyLedger8*` aliases stay internal: they widen the era-dispatching
 IMPLEMENTATION signatures and are never a signature a caller sees.
 
 ## Withdrawing it
 
-When the fork window closes, the retained era is removed by deleting
-`src/ledger8.ts`, its one re-export line in `src/index.ts`, and the modules
-behind them. No current-era signature is touched, and no current-era name
-changes -- which is the property the flat family did not have.
+When the fork window closes, the retained era's own family goes by deleting
+`src/ledger8.ts` and its one re-export line in `src/index.ts`, then the modules
+that serve only it (`src/ledger8-contract.ts`, `src/internal/ledger8-*.ts`) and
+the retained members of the modules it SHARES with the current era -- `errors.ts`
+and `tx-interfaces.ts` hold both eras and are not deleted. The retained overload
+arms on `submitCallTx`, `submitCallTxAsync`, `findDeployedContract` and
+`deployContract` go with them, which narrows those entry points' overload sets.
+
+No current-era NAME changes, and no consumer that never touched the retained era
+has an import to rewrite. That is the property the flat family did not have: it
+would have removed 37 published names instead of one.
 
 ## What guards it
 
 - `src/test/ledger8-namespace.test.ts` pins the namespace's RUNTIME members by
-  strict equality, and asserts that no retained-era name has returned to the
-  flat surface.
-- `src/test/contracts-type-acl.test.ts` pins its TYPE members, read off the
-  barrel with the compiler's own resolution.
+  strict equality -- in the source and again in the built bundle -- asserts that
+  each is bound to the declaration it renames, and that no retained-era runtime
+  name has returned to the flat surface. The identity assertions are the ones
+  that matter: `Ledger8.createCircuitCallTxInterface` has the same spelling as
+  the flat current-era factory, so publishing the wrong one of the two passes
+  every name-based check.
+- `src/test/contracts-type-acl.test.ts` pins its TYPE members by name, read off
+  the barrel with the compiler's own resolution, and its flat list is what
+  catches a retained-era type re-exported flat.
 - `src/test/typecheck/ledger8-namespace.test-d.ts` asserts that what the entry
   points resolve to is namable THROUGH the namespace -- the other compile-level
-  suites import the source modules, which a consumer cannot, and would keep
-  passing with the family unreachable from the published surface.
+  suites import the source modules, which a consumer cannot -- and compares all
+  29 type members against the declarations they rename, which is what catches a
+  transposed pair in the rename table.

--- a/packages/contracts/docs/retained-era-namespace.md
+++ b/packages/contracts/docs/retained-era-namespace.md
@@ -1,0 +1,102 @@
+---
+title: RetainedEraNamespace
+---
+
+# The retained era is published under one name
+
+The fork window is transitional; a duplicated public interface is not. This
+package dispatches two Compact toolchains, so it carries two families of nearly
+the same types -- `FoundContract` and `Ledger8FoundContract`,
+`CallTxOptions` and `Ledger8CallTxOptions`, thirty-seven names in all. The current
+era's family is permanent. The retained era's goes when the window closes.
+
+Published flat, side by side, those thirty-seven names would be thirty-seven
+published API names, and removing them would be a second breaking change after
+the one this release already makes. They are published as ONE name instead:
+
+```typescript
+import { Ledger8, submitCallTx } from '@midnight-ntwrk/midnight-js-contracts';
+
+const result: Ledger8.FinalizedCallTxData<C, 'increment'> = await submitCallTx(providers, options);
+
+try {
+  await submitCallTx(providers, options);
+} catch (error) {
+  if (error instanceof Ledger8.CallTxFailedError) {
+    // the retained era's own failure class
+  }
+}
+```
+
+The era prefix is dropped inside the namespace, because the namespace carries
+it. `Ledger8.FoundContract` is the retained twin of the flat `FoundContract`,
+name for name.
+
+## Naming, in these documents and in the source
+
+The declarations keep their `Ledger8`-prefixed names
+(`packages/contracts/src/ledger8-contract.ts` declares `Ledger8FoundContract`),
+and every document in this directory refers to them that way when it explains
+how the pipeline works. The rule for reading those references is mechanical:
+
+> a declaration named `Ledger8X` is published as `Ledger8.X`.
+
+The renaming happens in one place, `packages/contracts/src/ledger8.ts`, which
+is the only file that has to change when a member joins or leaves.
+
+## What qualifies for membership
+
+A name belongs in the namespace when it disappears with the retained era. That
+is the whole test, and it puts the error classes inside it too: a consumer
+catching `Ledger8.SeamFailedError` has written code that only means anything
+while the window is open.
+
+A name that serves BOTH eras stays on the flat surface, so a consumer that only
+RECEIVES results never imports the transitional half:
+
+- `AnyEraFinalizedCallTxData`, `AnyEraSubmittedCallTx` and `isLedger8Result` --
+  the union a shared handler declares, and the guard that narrows it.
+- `AnyEraTxFailedError` -- the base both eras' failure classes extend.
+  `Ledger8.CallTxFailedError` still extends it, so a handler written against
+  the base keeps catching the retained era without naming it.
+- `CURRENT_PIPELINE_ERA`, `RETAINED_PIPELINE_ERA`, `PipelineEra` and its two
+  literal aliases -- the vocabulary both pipelines are named by.
+- `UnrecognisedResultEraError` -- raised for a result tagged with neither era,
+  which is not a retained-era condition.
+
+## What is held back
+
+`Ledger8DeployedContract` is declared and NOT published, under the rule that a
+caller who can obtain a value must be able to name its type -- and no caller
+can obtain this one. `deployContract`'s retained arm refuses every
+retained-toolchain artifact with `Ledger8.DeployUnmaintainableError` before it
+touches a provider, so nothing constructs the type. Publishing it would
+document a handle nobody can hold and, because it extends
+`Ledger8FoundContract`, would make every later repair of that handle a breaking
+change to a published type with no users. Publish it in the commit that makes
+the deploy arm produce one.
+
+The two refusal ERRORS are published, because a caller does receive those and
+has to catch them by class.
+
+The `AnyLedger8*` aliases stay internal: they widen the era-dispatching
+IMPLEMENTATION signatures and are never a signature a caller sees.
+
+## Withdrawing it
+
+When the fork window closes, the retained era is removed by deleting
+`src/ledger8.ts`, its one re-export line in `src/index.ts`, and the modules
+behind them. No current-era signature is touched, and no current-era name
+changes -- which is the property the flat family did not have.
+
+## What guards it
+
+- `src/test/ledger8-namespace.test.ts` pins the namespace's RUNTIME members by
+  strict equality, and asserts that no retained-era name has returned to the
+  flat surface.
+- `src/test/contracts-type-acl.test.ts` pins its TYPE members, read off the
+  barrel with the compiler's own resolution.
+- `src/test/typecheck/ledger8-namespace.test-d.ts` asserts that what the entry
+  points resolve to is namable THROUGH the namespace -- the other compile-level
+  suites import the source modules, which a consumer cannot, and would keep
+  passing with the family unreachable from the published surface.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -44,14 +44,12 @@ export {
 // the fixed message rather than retype it. The breadcrumb TYPES stay internal -- publishing the
 // shapes would pin them as API before a second consumer has asked for them.
 export { DISPATCH_BREADCRUMB_MESSAGE } from './internal/breadcrumbs';
-// The retained-era entry points run real pipelines with this release, so the era errors below are
-// reachable from a call a consumer makes rather than only from an internal helper. Two are NOT
-// reachable through an entry point yet and are exported for completeness:
-// `Ledger8DeployUnmaintainableError` is the only refusal `deployContract`'s retained arm makes, and
-// `Ledger8DeployOnV9Error` sits behind it in the era pairing table, so the pairing refusal cannot
-// be observed until the deploy arm is wired.
+// The era errors that serve BOTH eras. The retained era's own classes are published under the
+// `Ledger8` namespace below, together with the rest of the surface that goes when the fork window
+// closes -- `Ledger8.CallTxFailedError` still extends `AnyEraTxFailedError` here, so a handler
+// written against the base keeps catching it.
 //
-// The fork-window refusals are the other group. `StaleHeadError` is raised when a submission was
+// The fork-window refusals are the group that stays. `StaleHeadError` is raised when a submission was
 // rejected and a fresh head read confirms the network crossed the fork under the operation, and it
 // carries the two-step remediation for that operation kind. `SubmitRejectionUndiagnosedError` is
 // the other half of that diagnosis, for a head that could not be re-read or that reported an
@@ -80,13 +78,6 @@ export {
   IncompleteCallTxPrivateStateConfig,
   IncompleteFindContractPrivateStateConfig,
   IndexerInconsistencyError,
-  Ledger8AmbiguousEntryPointError,
-  Ledger8CallTxFailedError,
-  Ledger8DeployOnV9Error,
-  Ledger8DeployUnmaintainableError,
-  Ledger8RecipientUnmappableError,
-  Ledger8SeamFailedError,
-  Ledger8ShieldedSpendUnsupportedError,
   MixedEraScopeError,
   ScopedTransactionIdentityMismatchError,
   ScopedTxEraUnsupportedError,
@@ -123,38 +114,8 @@ export {
   submitRemoveVerifierKeyTx,
   submitReplaceAuthorityTx
 } from './governance';
-// The retained-era type family. Exported for the same reason the current era's
-// equivalents are: the entry-point OVERLOADS select these types by inference,
-// but inference alone does not let a consumer NAME one. Without these a caller
-// can make a retained-era call and still not write
-// `function handle(r: Ledger8FinalizedCallTxData<C, K>)`, declare a variable of
-// the result type, or constrain a helper of their own by `Ledger8Contract`.
-//
-// A name appearing in the emitted `.d.ts` because an overload signature
-// mentions it is NOT the same as that name being exported, and this package
-// publishes only a `"."` entry, so there is no subpath to reach them through
-// either. `Awaited<ReturnType<typeof submitCallTx>>` is no substitute: it
-// resolves from the LAST overload by design, so it hands back the current-era
-// shape -- the wrong type for a retained-era call.
-//
-// The whole family goes out together rather than just the four result types: a
-// consumer who cannot also name `Ledger8Circuit` and `Ledger8Witness` cannot
-// declare a contract type that satisfies `Ledger8Contract` in the first place.
-// The `AnyLedger8*` aliases stay internal -- they exist to widen the
-// era-dispatching IMPLEMENTATION signatures and are never a signature a caller
-// sees.
-//
-// ONE member is held back: `Ledger8DeployedContract`. The argument above is
-// that a caller who can obtain a value needs to be able to name its type --
-// and no caller can obtain this one. `deployContract`'s retained arm refuses
-// every retained-toolchain artifact with `Ledger8DeployUnmaintainableError`
-// before it touches a provider, so nothing constructs the type. Exporting it
-// would publish a documented five-member type nobody can hold, and, because it
-// extends `Ledger8FoundContract`, would make every later repair of the handle
-// surface a breaking change to a published type with no users. The two refusal
-// ERRORS are exported, because those a caller does receive and must be able to
-// catch by class. Export the type in the commit that makes the deploy arm
-// produce one.
+// The era vocabulary, which BOTH pipelines are named by -- neither half of it goes when the
+// retained era does.
 export {
   CURRENT_PIPELINE_ERA,
   type CurrentPipelineEra,
@@ -166,37 +127,15 @@ export {
 // result by inference, and these let a caller who RECEIVES either one declare a
 // parameter for both and narrow it by name.
 export { type AnyEraFinalizedCallTxData, type AnyEraSubmittedCallTx, isLedger8Result } from './era-results';
-export type {
-  Ledger8CallResultPrivate,
-  Ledger8CallResultPublic,
-  Ledger8CallTxOptions,
-  Ledger8CallTxOptionsBase,
-  Ledger8CallTxOptionsWithPrivateStateId,
-  Ledger8CallTxTarget,
-  Ledger8Circuit,
-  Ledger8CircuitCallTxInterface,
-  Ledger8CircuitContext,
-  Ledger8CircuitId,
-  Ledger8CircuitParameters,
-  Ledger8CircuitResult,
-  Ledger8CircuitReturnType,
-  Ledger8ConstructorParameters,
-  Ledger8Contract,
-  Ledger8ContractCall,
-  Ledger8ContractCallPublic,
-  Ledger8ContractProviders,
-  Ledger8DeployContractOptions,
-  Ledger8DeployContractOptionsBase,
-  Ledger8FinalizedCallTxData,
-  Ledger8FinalizedCallTxPublicData,
-  Ledger8FindDeployedContractOptions,
-  Ledger8FoundContract,
-  Ledger8InitialStateResult,
-  Ledger8PrivateState,
-  Ledger8SubmittedCallTx,
-  Ledger8UnsubmittedCallTxData,
-  Ledger8Witness
-} from './ledger8-contract';
+// The RETAINED era, whole, under one name. The entry-point overloads select these types by
+// inference, and inference alone does not let a consumer NAME one -- `Ledger8.FinalizedCallTxData`
+// is how a caller declares the result it was handed, and `Ledger8.Contract` how it constrains a
+// helper of its own.
+//
+// One export rather than the thirty-seven it re-exports, because the retained era is transitional
+// and a flat family is not: see `docs/retained-era-namespace.md` for what qualifies for membership,
+// what is deliberately held back, and how the whole surface is withdrawn in one step.
+export * as Ledger8 from './ledger8';
 export { submitCallTx, submitCallTxAsync, type SubmitCallTxProviders } from './submit-call-tx';
 export { DeployTxOptions,submitDeployTx } from './submit-deploy-tx';
 export { submitTx, submitTxAsync, SubmitTxOptions, SubmitTxProviders } from './submit-tx';
@@ -206,11 +145,7 @@ export {
   TransactionContext,
   withContractScopedTransaction
 } from './transaction';
-export {
-  CircuitCallTxInterface,
-  createCallTxOptions,
-  createCircuitCallTxInterface,
-  createLedger8CircuitCallTxInterface} from './tx-interfaces';
+export { CircuitCallTxInterface, createCallTxOptions, createCircuitCallTxInterface } from './tx-interfaces';
 export {
   FinalizedCallTxData,
   FinalizedCallTxPublicData,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -49,7 +49,7 @@ export { DISPATCH_BREADCRUMB_MESSAGE } from './internal/breadcrumbs';
 // closes -- `Ledger8.CallTxFailedError` still extends `AnyEraTxFailedError` here, so a handler
 // written against the base keeps catching it.
 //
-// The fork-window refusals are the group that stays. `StaleHeadError` is raised when a submission was
+// The fork-window refusals are the other group. `StaleHeadError` is raised when a submission was
 // rejected and a fresh head read confirms the network crossed the fork under the operation, and it
 // carries the two-step remediation for that operation kind. `SubmitRejectionUndiagnosedError` is
 // the other half of that diagnosis, for a head that could not be re-read or that reported an
@@ -114,8 +114,8 @@ export {
   submitRemoveVerifierKeyTx,
   submitReplaceAuthorityTx
 } from './governance';
-// The era vocabulary, which BOTH pipelines are named by -- neither half of it goes when the
-// retained era does.
+// The era vocabulary, which BOTH pipelines are named by, so a caller that tags or branches on an
+// era never reaches for the retained-era namespace to do it.
 export {
   CURRENT_PIPELINE_ERA,
   type CurrentPipelineEra,

--- a/packages/contracts/src/ledger8.ts
+++ b/packages/contracts/src/ledger8.ts
@@ -1,0 +1,70 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Everything the RETAINED era publishes, under one name.
+ *
+ * The barrel re-exports this module as `Ledger8`, so a caller writes
+ * `Ledger8.FoundContract<C>` and `Ledger8.CallTxFailedError` -- the retained
+ * twin of the flat current-era name it mirrors. The era prefix is dropped
+ * inside, because the namespace already carries it.
+ *
+ * Membership is exactly the surface that disappears when the fork window
+ * closes. Names that serve BOTH eras stay on the flat surface, so a consumer
+ * that only receives results never imports the transitional half. See
+ * `docs/retained-era-namespace.md`.
+ */
+
+export {
+  Ledger8AmbiguousEntryPointError as AmbiguousEntryPointError,
+  Ledger8CallTxFailedError as CallTxFailedError,
+  Ledger8DeployOnV9Error as DeployOnV9Error,
+  Ledger8DeployUnmaintainableError as DeployUnmaintainableError,
+  Ledger8RecipientUnmappableError as RecipientUnmappableError,
+  Ledger8SeamFailedError as SeamFailedError,
+  Ledger8ShieldedSpendUnsupportedError as ShieldedSpendUnsupportedError
+} from './errors';
+export type {
+  Ledger8CallResultPrivate as CallResultPrivate,
+  Ledger8CallResultPublic as CallResultPublic,
+  Ledger8CallTxOptions as CallTxOptions,
+  Ledger8CallTxOptionsBase as CallTxOptionsBase,
+  Ledger8CallTxOptionsWithPrivateStateId as CallTxOptionsWithPrivateStateId,
+  Ledger8CallTxTarget as CallTxTarget,
+  Ledger8Circuit as Circuit,
+  Ledger8CircuitCallTxInterface as CircuitCallTxInterface,
+  Ledger8CircuitContext as CircuitContext,
+  Ledger8CircuitId as CircuitId,
+  Ledger8CircuitParameters as CircuitParameters,
+  Ledger8CircuitResult as CircuitResult,
+  Ledger8CircuitReturnType as CircuitReturnType,
+  Ledger8ConstructorParameters as ConstructorParameters,
+  Ledger8Contract as Contract,
+  Ledger8ContractCall as ContractCall,
+  Ledger8ContractCallPublic as ContractCallPublic,
+  Ledger8ContractProviders as ContractProviders,
+  Ledger8DeployContractOptions as DeployContractOptions,
+  Ledger8DeployContractOptionsBase as DeployContractOptionsBase,
+  Ledger8FinalizedCallTxData as FinalizedCallTxData,
+  Ledger8FinalizedCallTxPublicData as FinalizedCallTxPublicData,
+  Ledger8FindDeployedContractOptions as FindDeployedContractOptions,
+  Ledger8FoundContract as FoundContract,
+  Ledger8InitialStateResult as InitialStateResult,
+  Ledger8PrivateState as PrivateState,
+  Ledger8SubmittedCallTx as SubmittedCallTx,
+  Ledger8UnsubmittedCallTxData as UnsubmittedCallTxData,
+  Ledger8Witness as Witness
+} from './ledger8-contract';
+export { createLedger8CircuitCallTxInterface as createCircuitCallTxInterface } from './tx-interfaces';

--- a/packages/contracts/src/ledger8.ts
+++ b/packages/contracts/src/ledger8.ts
@@ -17,14 +17,17 @@
  * Everything the RETAINED era publishes, under one name.
  *
  * The barrel re-exports this module as `Ledger8`, so a caller writes
- * `Ledger8.FoundContract<C>` and `Ledger8.CallTxFailedError` -- the retained
- * twin of the flat current-era name it mirrors. The era prefix is dropped
- * inside, because the namespace already carries it.
+ * `Ledger8.FoundContract<C>` and `Ledger8.CallTxFailedError`. The era prefix is
+ * dropped inside, because the namespace already carries it -- so a declaration
+ * this reference calls `Ledger8X` is the member published as `Ledger8.X`.
  *
- * Membership is exactly the surface that disappears when the fork window
- * closes. Names that serve BOTH eras stay on the flat surface, so a consumer
- * that only receives results never imports the transitional half. See
- * `docs/retained-era-namespace.md`.
+ * Membership is the retained era's own family: its contract and result types,
+ * its interface factory, and the refusals its pipeline raises. Names that serve
+ * BOTH eras stay on the flat surface, so a consumer that only receives results
+ * never imports the transitional half.
+ *
+ * @see {@link RetainedEraNamespace} for what qualifies, what is held back, and
+ *      how the surface is withdrawn.
  */
 
 export {

--- a/packages/contracts/src/test/contracts-type-acl.test.ts
+++ b/packages/contracts/src/test/contracts-type-acl.test.ts
@@ -31,6 +31,24 @@ const compilerOptions = (): ts.CompilerOptions => {
 };
 
 /**
+ * Resolves a namespace re-export (`export * as Ledger8 from ...`) to the module
+ * it stands for, so its members can be pinned the same way the barrel's own
+ * are.
+ *
+ * Throws rather than returning the barrel when the name is absent: a namespace
+ * silently swapped for the module itself would compare the retained era's
+ * member list against the whole package and report a difference nobody can
+ * read.
+ */
+const namespaceSymbol = (checker: ts.TypeChecker, moduleSymbol: ts.Symbol, name: string): ts.Symbol => {
+  const exported = checker.getExportsOfModule(moduleSymbol).find((symbol) => symbol.getName() === name);
+  if (!exported) {
+    throw new Error(`${BARREL} exports no namespace named '${name}'`);
+  }
+  return exported.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(exported) : exported;
+};
+
+/**
  * The names the barrel exports that carry NO runtime meaning, read from the
  * source with the compiler's own resolution.
  *
@@ -44,7 +62,7 @@ const compilerOptions = (): ts.CompilerOptions => {
  * `packages/protocol/src/test/protocol-type-acl.test.ts`. Deliberately
  * duplicated rather than shared: neither package depends on the other's tests.
  */
-const typeOnlyExportNames = (): string[] => {
+const typeOnlyExportNames = (namespaceExport?: string): string[] => {
   const program = ts.createProgram([BARREL], compilerOptions());
   const checker = program.getTypeChecker();
   const source = program.getSourceFile(BARREL);
@@ -55,9 +73,10 @@ const typeOnlyExportNames = (): string[] => {
   if (!moduleSymbol) {
     throw new Error(`${BARREL} resolves to no module symbol`);
   }
+  const container = namespaceExport === undefined ? moduleSymbol : namespaceSymbol(checker, moduleSymbol, namespaceExport);
 
   return checker
-    .getExportsOfModule(moduleSymbol)
+    .getExportsOfModule(container)
     .filter((exported) => {
       const resolved = exported.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(exported) : exported;
       return (resolved.flags & ts.SymbolFlags.Value) === 0;
@@ -120,35 +139,6 @@ describe('Contracts type ACL', () => {
       'FindDeployedContractOptionsExistingPrivateState',
       'FindDeployedContractOptionsStorePrivateState',
       'FoundContract',
-      'Ledger8CallResultPrivate',
-      'Ledger8CallResultPublic',
-      'Ledger8CallTxOptions',
-      'Ledger8CallTxOptionsBase',
-      'Ledger8CallTxOptionsWithPrivateStateId',
-      'Ledger8CallTxTarget',
-      'Ledger8Circuit',
-      'Ledger8CircuitCallTxInterface',
-      'Ledger8CircuitContext',
-      'Ledger8CircuitId',
-      'Ledger8CircuitParameters',
-      'Ledger8CircuitResult',
-      'Ledger8CircuitReturnType',
-      'Ledger8ConstructorParameters',
-      'Ledger8Contract',
-      'Ledger8ContractCall',
-      'Ledger8ContractCallPublic',
-      'Ledger8ContractProviders',
-      'Ledger8DeployContractOptions',
-      'Ledger8DeployContractOptionsBase',
-          'Ledger8FinalizedCallTxData',
-      'Ledger8FinalizedCallTxPublicData',
-      'Ledger8FindDeployedContractOptions',
-      'Ledger8FoundContract',
-      'Ledger8InitialStateResult',
-      'Ledger8PrivateState',
-      'Ledger8SubmittedCallTx',
-      'Ledger8UnsubmittedCallTxData',
-      'Ledger8Witness',
       'LogEvent',
       'PipelineEra',
       'PublicContractStates',
@@ -174,6 +164,50 @@ describe('Contracts type ACL', () => {
       'UnsubmittedDeployTxPrivateDataFull',
       'UnsubmittedDeployTxPublicData',
       'UnsubmittedTxData'
+    ]);
+  });
+
+  /**
+   * @given the `Ledger8` namespace the barrel re-exports
+   * @when its type-only members are read with the compiler's own resolution
+   * @then they equal the pinned set exactly
+   *
+   * The retained-era family left the flat surface, and the list above stopped
+   * covering it with it. Pinned here instead: dropping this suite would leave
+   * ~30 published types with no gate at all, which is the surface the previous
+   * list existed to guard.
+   */
+  it('publishes exactly this retained-era type surface', () => {
+    expect(typeOnlyExportNames('Ledger8')).toEqual([
+      'CallResultPrivate',
+      'CallResultPublic',
+      'CallTxOptions',
+      'CallTxOptionsBase',
+      'CallTxOptionsWithPrivateStateId',
+      'CallTxTarget',
+      'Circuit',
+      'CircuitCallTxInterface',
+      'CircuitContext',
+      'CircuitId',
+      'CircuitParameters',
+      'CircuitResult',
+      'CircuitReturnType',
+      'ConstructorParameters',
+      'Contract',
+      'ContractCall',
+      'ContractCallPublic',
+      'ContractProviders',
+      'DeployContractOptions',
+      'DeployContractOptionsBase',
+      'FinalizedCallTxData',
+      'FinalizedCallTxPublicData',
+      'FindDeployedContractOptions',
+      'FoundContract',
+      'InitialStateResult',
+      'PrivateState',
+      'SubmittedCallTx',
+      'UnsubmittedCallTxData',
+      'Witness'
     ]);
   });
 });

--- a/packages/contracts/src/test/contracts-value-acl.test.ts
+++ b/packages/contracts/src/test/contracts-value-acl.test.ts
@@ -34,6 +34,10 @@ const DIST_INDEX_PATH = 'dist/index.js';
  * Type-only exports have no runtime binding and are pinned separately, by
  * `contracts-type-acl.test.ts`, which reads them off the barrel with the
  * compiler's own resolution.
+ *
+ * `Ledger8` is one name here and a namespace of its own behind it: the members
+ * inside it are pinned by `ledger8-namespace.test.ts`, so this list stays a
+ * list of the names a consumer imports.
  */
 const RUNTIME_EXPORTS: readonly string[] = [
   'AnyEraTxFailedError',
@@ -51,13 +55,7 @@ const RUNTIME_EXPORTS: readonly string[] = [
   'IncompleteFindContractPrivateStateConfig',
   'IndexerInconsistencyError',
   'InsertVerifierKeyTxFailedError',
-  'Ledger8AmbiguousEntryPointError',
-  'Ledger8CallTxFailedError',
-  'Ledger8DeployOnV9Error',
-  'Ledger8DeployUnmaintainableError',
-  'Ledger8RecipientUnmappableError',
-  'Ledger8SeamFailedError',
-  'Ledger8ShieldedSpendUnsupportedError',
+  'Ledger8',
   'MixedEraScopeError',
   'RETAINED_PIPELINE_ERA',
   'RemoveVerifierKeyTxFailedError',
@@ -74,7 +72,6 @@ const RUNTIME_EXPORTS: readonly string[] = [
   'createCircuitMaintenanceTxInterface',
   'createCircuitMaintenanceTxInterfaces',
   'createContractMaintenanceTxInterface',
-  'createLedger8CircuitCallTxInterface',
   'createUnprovenCallTx',
   'createUnprovenCallTxFromInitialStates',
   'createUnprovenDeployTx',

--- a/packages/contracts/src/test/contracts-value-acl.test.ts
+++ b/packages/contracts/src/test/contracts-value-acl.test.ts
@@ -101,6 +101,15 @@ const RUNTIME_EXPORTS: readonly string[] = [
 // local export list at the end.
 const EXPORT_STATEMENT = /^export\s*\{([^}]*)\}/gm;
 
+// And the namespace form. Rollup happens to hoist `export * as Ledger8` into the
+// brace list above as `ledger8 as Ledger8`, so the brace scan alone catches it
+// today -- but that is an emit detail. `preserveModules`, a different bundler or
+// plain `tsc` leave the statement standing, and a scan that reads brace lists
+// only would then report the name as a DROPPED export rather than as a statement
+// it could not parse: a failure that sends a reader looking for a deleted export
+// that is still there.
+const NAMESPACE_EXPORT_STATEMENT = /^export\s*\*\s*as\s+(\w+)\s+from/gm;
+
 /**
  * Reads the exported names out of the built bundle.
  *
@@ -119,16 +128,19 @@ const readDistExports = (): string[] => {
   if (!existsSync(absolute)) {
     throw new Error(`${DIST_INDEX_PATH} is missing -- build the package before running this test`);
   }
-  const statements = [...readFileSync(absolute, 'utf8').matchAll(EXPORT_STATEMENT)];
+  const bundle = readFileSync(absolute, 'utf8');
+  const statements = [...bundle.matchAll(EXPORT_STATEMENT)];
   if (statements.length === 0) {
     throw new Error(`${DIST_INDEX_PATH} declares no 'export { ... }' statement`);
   }
-  return statements.flatMap(([, clause]) =>
+  const named = statements.flatMap(([, clause]) =>
     clause
       .split(',')
       .map((name) => name.trim().split(/\s+as\s+/).pop() ?? '')
       .filter((name) => name.length > 0)
   );
+  const namespaced = [...bundle.matchAll(NAMESPACE_EXPORT_STATEMENT)].map(([, name]) => name);
+  return [...named, ...namespaced];
 };
 
 describe('Contracts value ACL', () => {

--- a/packages/contracts/src/test/era-error-surface.test.ts
+++ b/packages/contracts/src/test/era-error-surface.test.ts
@@ -27,7 +27,7 @@ import {
   EraInvariantViolationError,
   HeadStateEraMismatchError,
   IndexerInconsistencyError,
-  Ledger8DeployOnV9Error,
+  Ledger8,
   VerifierKeyMismatchError
 } from '../index';
 
@@ -35,7 +35,7 @@ describe('the era and verification-path errors a caller has to catch are reachab
   it('carries the registered code on an instance built through the barrel export', () => {
     const cases = [
       { error: new EraArtifactMismatchError('unrecognised-contract-shape'), code: CONTRACTS_ERROR_CODES.ERA_ARTIFACT_MISMATCH },
-      { error: new Ledger8DeployOnV9Error(), code: CONTRACTS_ERROR_CODES.LEDGER8_DEPLOY_ON_V9 },
+      { error: new Ledger8.DeployOnV9Error(), code: CONTRACTS_ERROR_CODES.LEDGER8_DEPLOY_ON_V9 },
       { error: new HeadStateEraMismatchError('v9', 'v8'), code: CONTRACTS_ERROR_CODES.HEAD_STATE_ERA_MISMATCH },
       { error: new IndexerInconsistencyError('v9', 'v8'), code: CONTRACTS_ERROR_CODES.INDEXER_INCONSISTENCY },
       { error: new BlankVerifierKeySlotError('increment'), code: CONTRACTS_ERROR_CODES.BLANK_VERIFIER_KEY_SLOT },

--- a/packages/contracts/src/test/ledger8-namespace.test.ts
+++ b/packages/contracts/src/test/ledger8-namespace.test.ts
@@ -1,0 +1,96 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CONTRACTS_ERROR_CODES, hasErrorCode } from '@midnight-ntwrk/midnight-js-utils';
+import { describe, expect, it } from 'vitest';
+
+// Imported from the package BARREL, because the barrel is what this suite is about: the retained
+// era reaches a consumer through ONE name, and everything it publishes is reachable under it.
+import * as barrel from '../index';
+import { AnyEraTxFailedError, Ledger8 } from '../index';
+
+/**
+ * Every runtime member the retained-era namespace publishes.
+ *
+ * Asserted by strict equality in both directions, so a member dropped from the namespace and a
+ * member that leaked into it fail the same test.
+ */
+const RETAINED_ERA_MEMBERS = [
+  'AmbiguousEntryPointError',
+  'CallTxFailedError',
+  'DeployOnV9Error',
+  'DeployUnmaintainableError',
+  'RecipientUnmappableError',
+  'SeamFailedError',
+  'ShieldedSpendUnsupportedError',
+  'createCircuitCallTxInterface'
+];
+
+/**
+ * The era-NEUTRAL half, which stays on the flat surface.
+ *
+ * A caller that receives a result from either era uses these without opting into the retained era
+ * at all, so moving them under the namespace would make the neutral path depend on the
+ * transitional one.
+ */
+const ERA_NEUTRAL_MEMBERS = [
+  'AnyEraTxFailedError',
+  'CURRENT_PIPELINE_ERA',
+  'RETAINED_PIPELINE_ERA',
+  'isLedger8Result',
+  'UnrecognisedResultEraError'
+];
+
+describe('the retained era is published as one namespace', () => {
+  it('publishes exactly the retained-era runtime members under it', () => {
+    const published = Object.keys(Ledger8).sort();
+
+    expect(published).toEqual([...RETAINED_ERA_MEMBERS].sort());
+  });
+
+  it('leaves no retained-era name on the flat surface', () => {
+    // The regression this package is one release away from re-introducing: a later commit adds a
+    // retained-era export next to the current-era ones, and the whole family is back on the flat
+    // surface with nobody noticing until the fork window closes and it cannot be removed.
+    //
+    // Matched on CONTAINING the era name rather than starting with it, so a helper named
+    // `createLedger8...` is caught too -- the first one was published under exactly that name.
+    const allowedFlat = ['Ledger8', 'isLedger8Result'];
+    const leaked = Object.keys(barrel).filter((name) => name.includes('Ledger8') && !allowedFlat.includes(name));
+
+    expect(leaked).toEqual([]);
+  });
+
+  it('keeps the era-neutral half flat, so receiving a result needs no opt-in', () => {
+    const missing = ERA_NEUTRAL_MEMBERS.filter((name) => !(name in barrel));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('carries the registered error code on a class reached through the namespace', () => {
+    // The namespace is a RENAME of the existing classes, not a second set of them. A same-named
+    // stub would satisfy the key list above and fail here.
+    const error = new Ledger8.DeployOnV9Error();
+
+    expect(hasErrorCode(error, CONTRACTS_ERROR_CODES.LEDGER8_DEPLOY_ON_V9)).toBe(true);
+  });
+
+  it('keeps the retained failure class under the era-neutral base a consumer catches', () => {
+    // A handler written as `catch (e) { if (e instanceof AnyEraTxFailedError) }` must keep catching
+    // the retained-era failure. Asserted on the class rather than an instance: the constructor
+    // takes a finalized record, and what is at stake here is the hierarchy, not a message.
+    expect(Object.getPrototypeOf(Ledger8.CallTxFailedError)).toBe(AnyEraTxFailedError);
+  });
+});

--- a/packages/contracts/src/test/ledger8-namespace.test.ts
+++ b/packages/contracts/src/test/ledger8-namespace.test.ts
@@ -13,13 +13,32 @@
  * limitations under the License.
  */
 
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
 import { CONTRACTS_ERROR_CODES, hasErrorCode } from '@midnight-ntwrk/midnight-js-utils';
 import { describe, expect, it } from 'vitest';
 
+// The left-hand side of the renaming table, from the modules that DECLARE it. The namespace is
+// `Ledger8X as X` written by hand, and a transposed pair keeps every name on the surface -- the key
+// list below cannot see it. `createLedger8CircuitCallTxInterface` is the sharpest case: its
+// namespace-local name is the SAME spelling as the flat current-era factory, so publishing the
+// wrong one of the two leaves every gate green.
+import {
+  Ledger8AmbiguousEntryPointError,
+  Ledger8CallTxFailedError,
+  Ledger8DeployOnV9Error,
+  Ledger8DeployUnmaintainableError,
+  Ledger8RecipientUnmappableError,
+  Ledger8SeamFailedError,
+  Ledger8ShieldedSpendUnsupportedError
+} from '../errors';
 // Imported from the package BARREL, because the barrel is what this suite is about: the retained
 // era reaches a consumer through ONE name, and everything it publishes is reachable under it.
 import * as barrel from '../index';
 import { AnyEraTxFailedError, Ledger8 } from '../index';
+import { createLedger8CircuitCallTxInterface } from '../tx-interfaces';
 
 /**
  * Every runtime member the retained-era namespace publishes.
@@ -53,6 +72,30 @@ const ERA_NEUTRAL_MEMBERS = [
   'UnrecognisedResultEraError'
 ];
 
+/**
+ * The members of the namespace the BUILT bundle ships.
+ *
+ * The bundle rather than `../index`, for the reason `contracts-value-acl.test.ts` states: vitest
+ * resolves the barrel through its own per-file transform, so a member rollup elides from the frozen
+ * namespace object stays invisible to every assertion made against the source -- while a consumer's
+ * `instanceof Ledger8.SeamFailedError` throws on an undefined right-hand side.
+ *
+ * A missing bundle throws rather than skipping: a skipped test reports as a pass. Turbo's `test`
+ * task dependsOn `build`, so `dist/` is present in CI.
+ */
+const distNamespaceMembers = async (): Promise<string[]> => {
+  const absolute = resolve(__dirname, '../../dist/index.js');
+  if (!existsSync(absolute)) {
+    throw new Error('dist/index.js is missing -- build the package before running this test');
+  }
+  const shipped: Record<string, unknown> = await import(pathToFileURL(absolute).href);
+  const namespace = shipped.Ledger8;
+  if (typeof namespace !== 'object' || namespace === null) {
+    throw new Error("dist/index.js publishes no 'Ledger8' namespace object");
+  }
+  return Object.keys(namespace).sort();
+};
+
 describe('the retained era is published as one namespace', () => {
   it('publishes exactly the retained-era runtime members under it', () => {
     const published = Object.keys(Ledger8).sort();
@@ -60,17 +103,37 @@ describe('the retained era is published as one namespace', () => {
     expect(published).toEqual([...RETAINED_ERA_MEMBERS].sort());
   });
 
-  it('leaves no retained-era name on the flat surface', () => {
-    // The regression this package is one release away from re-introducing: a later commit adds a
-    // retained-era export next to the current-era ones, and the whole family is back on the flat
-    // surface with nobody noticing until the fork window closes and it cannot be removed.
-    //
+  it('leaves no retained-era RUNTIME name on the flat surface', () => {
     // Matched on CONTAINING the era name rather than starting with it, so a helper named
-    // `createLedger8...` is caught too -- the first one was published under exactly that name.
+    // `createLedger8...` is caught too.
+    //
+    // RUNTIME names only: `Object.keys` sees bindings, and 29 of the 37 members are types, which
+    // have none. A flat retained-era TYPE re-export is caught by the strict list in
+    // `contracts-type-acl.test.ts` instead -- that suite is the other half of this guard, and
+    // narrowing it would reopen the larger half of the hole.
     const allowedFlat = ['Ledger8', 'isLedger8Result'];
     const leaked = Object.keys(barrel).filter((name) => name.includes('Ledger8') && !allowedFlat.includes(name));
 
     expect(leaked).toEqual([]);
+  });
+
+  it('binds every member to the declaration it renames', () => {
+    // Identity, not spelling. Every assertion below fails if the rename table in `src/ledger8.ts`
+    // points a member at the wrong declaration -- the one failure mode the key list cannot see.
+    expect(Ledger8.AmbiguousEntryPointError).toBe(Ledger8AmbiguousEntryPointError);
+    expect(Ledger8.CallTxFailedError).toBe(Ledger8CallTxFailedError);
+    expect(Ledger8.DeployOnV9Error).toBe(Ledger8DeployOnV9Error);
+    expect(Ledger8.DeployUnmaintainableError).toBe(Ledger8DeployUnmaintainableError);
+    expect(Ledger8.RecipientUnmappableError).toBe(Ledger8RecipientUnmappableError);
+    expect(Ledger8.SeamFailedError).toBe(Ledger8SeamFailedError);
+    expect(Ledger8.ShieldedSpendUnsupportedError).toBe(Ledger8ShieldedSpendUnsupportedError);
+    expect(Ledger8.createCircuitCallTxInterface).toBe(createLedger8CircuitCallTxInterface);
+  });
+
+  it('ships the same members in the built bundle', async () => {
+    const shipped = await distNamespaceMembers();
+
+    expect(shipped).toEqual([...RETAINED_ERA_MEMBERS].sort());
   });
 
   it('keeps the era-neutral half flat, so receiving a result needs no opt-in', () => {
@@ -91,6 +154,10 @@ describe('the retained era is published as one namespace', () => {
     // A handler written as `catch (e) { if (e instanceof AnyEraTxFailedError) }` must keep catching
     // the retained-era failure. Asserted on the class rather than an instance: the constructor
     // takes a finalized record, and what is at stake here is the hierarchy, not a message.
-    expect(Object.getPrototypeOf(Ledger8.CallTxFailedError)).toBe(AnyEraTxFailedError);
+    //
+    // `prototype instanceof` rather than the DIRECT prototype: what a consumer relies on is that
+    // the base catches it, at any depth. `TxFailedError extends AnyEraTxFailedError` shows an
+    // intermediate base is an established shape here, and inserting one must not fail this test.
+    expect(Ledger8.CallTxFailedError.prototype instanceof AnyEraTxFailedError).toBe(true);
   });
 });

--- a/packages/contracts/src/test/typecheck/ledger8-namespace.test-d.ts
+++ b/packages/contracts/src/test/typecheck/ledger8-namespace.test-d.ts
@@ -1,0 +1,56 @@
+/*
+ * This file is part of midnight-js.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expectTypeOf, it } from 'vitest';
+
+// Through the BARREL, and through the namespace alone. `typecheck/overloads.test-d.ts` asserts the
+// same resolutions against the source modules, which a consumer cannot import: it would keep
+// passing with the retained-era types unreachable from the published surface entirely.
+import { type Ledger8, submitCallTx, submitCallTxAsync } from '../../index';
+import type { Counter016Contract, Counter016PrivateState } from '../ledger8-fixture-types';
+
+declare const providers: Ledger8.ContractProviders<Counter016Contract, 'increment'>;
+declare const options: Ledger8.CallTxOptionsBase<Counter016Contract, 'increment'>;
+
+describe('a consumer can name the retained era through the namespace alone', () => {
+  it('declares the result the retained arm resolves to', () => {
+    expectTypeOf(submitCallTx(providers, options)).toEqualTypeOf<
+      Promise<Ledger8.FinalizedCallTxData<Counter016Contract, 'increment'>>
+    >();
+  });
+
+  it('declares the result the non-finalizing entry point resolves to', () => {
+    expectTypeOf(submitCallTxAsync(providers, options)).toEqualTypeOf<
+      Promise<Ledger8.SubmittedCallTx<Counter016Contract, 'increment'>>
+    >();
+  });
+
+  it('constrains a helper of its own by the retained contract type', () => {
+    // What the family is published FOR: a caller writing `<C extends Ledger8.Contract>` of its own.
+    // Without the constraint being namable, a consumer holding a retained-era contract can call the
+    // entry points and still not declare a function that takes one.
+    expectTypeOf<Counter016Contract>().toExtend<Ledger8.Contract<Counter016PrivateState>>();
+    expectTypeOf<Ledger8.CircuitId<Counter016Contract>>().toEqualTypeOf<'increment'>();
+  });
+
+  it('names the witness and circuit members a retained contract declaration needs', () => {
+    // A contract type cannot be declared from the outside without these two, so they travel with
+    // the family rather than being held back as internals.
+    expectTypeOf<Counter016Contract['witnesses']>().toExtend<
+      Readonly<Record<string, Ledger8.Witness<Counter016PrivateState>>>
+    >();
+    expectTypeOf<Counter016Contract['impureCircuits']>().toExtend<Readonly<Record<string, Ledger8.Circuit>>>();
+  });
+});

--- a/packages/contracts/src/test/typecheck/ledger8-namespace.test-d.ts
+++ b/packages/contracts/src/test/typecheck/ledger8-namespace.test-d.ts
@@ -19,38 +19,113 @@ import { describe, expectTypeOf, it } from 'vitest';
 // same resolutions against the source modules, which a consumer cannot import: it would keep
 // passing with the retained-era types unreachable from the published surface entirely.
 import { type Ledger8, submitCallTx, submitCallTxAsync } from '../../index';
+// The left-hand side of the renaming table, imported from the module that DECLARES it. The
+// namespace is a table of `Ledger8X as X` renames written by hand, and a transposed pair type-checks
+// and passes every name-based gate: `contracts-type-acl.test.ts` compares the member NAME list, and
+// both names are in it either way. These assertions are what compares the two sides.
+import type {
+  Ledger8CallResultPrivate,
+  Ledger8CallResultPublic,
+  Ledger8CallTxOptions,
+  Ledger8CallTxOptionsBase,
+  Ledger8CallTxOptionsWithPrivateStateId,
+  Ledger8CallTxTarget,
+  Ledger8Circuit,
+  Ledger8CircuitCallTxInterface,
+  Ledger8CircuitContext,
+  Ledger8CircuitId,
+  Ledger8CircuitParameters,
+  Ledger8CircuitResult,
+  Ledger8CircuitReturnType,
+  Ledger8ConstructorParameters,
+  Ledger8Contract,
+  Ledger8ContractCall,
+  Ledger8ContractCallPublic,
+  Ledger8ContractProviders,
+  Ledger8DeployContractOptions,
+  Ledger8DeployContractOptionsBase,
+  Ledger8FinalizedCallTxData,
+  Ledger8FinalizedCallTxPublicData,
+  Ledger8FindDeployedContractOptions,
+  Ledger8FoundContract,
+  Ledger8InitialStateResult,
+  Ledger8PrivateState,
+  Ledger8SubmittedCallTx,
+  Ledger8UnsubmittedCallTxData,
+  Ledger8Witness
+} from '../../ledger8-contract';
 import type { Counter016Contract, Counter016PrivateState } from '../ledger8-fixture-types';
 
-declare const providers: Ledger8.ContractProviders<Counter016Contract, 'increment'>;
-declare const options: Ledger8.CallTxOptionsBase<Counter016Contract, 'increment'>;
+type C = Counter016Contract;
+type K = 'increment';
+type PS = Counter016PrivateState;
+
+declare const providers: Ledger8.ContractProviders<C, K>;
+declare const options: Ledger8.CallTxOptionsBase<C, K>;
 
 describe('a consumer can name the retained era through the namespace alone', () => {
   it('declares the result the retained arm resolves to', () => {
-    expectTypeOf(submitCallTx(providers, options)).toEqualTypeOf<
-      Promise<Ledger8.FinalizedCallTxData<Counter016Contract, 'increment'>>
-    >();
+    expectTypeOf(submitCallTx(providers, options)).toEqualTypeOf<Promise<Ledger8.FinalizedCallTxData<C, K>>>();
   });
 
   it('declares the result the non-finalizing entry point resolves to', () => {
-    expectTypeOf(submitCallTxAsync(providers, options)).toEqualTypeOf<
-      Promise<Ledger8.SubmittedCallTx<Counter016Contract, 'increment'>>
-    >();
+    expectTypeOf(submitCallTxAsync(providers, options)).toEqualTypeOf<Promise<Ledger8.SubmittedCallTx<C, K>>>();
   });
 
   it('constrains a helper of its own by the retained contract type', () => {
     // What the family is published FOR: a caller writing `<C extends Ledger8.Contract>` of its own.
-    // Without the constraint being namable, a consumer holding a retained-era contract can call the
-    // entry points and still not declare a function that takes one.
-    expectTypeOf<Counter016Contract>().toExtend<Ledger8.Contract<Counter016PrivateState>>();
-    expectTypeOf<Ledger8.CircuitId<Counter016Contract>>().toEqualTypeOf<'increment'>();
+    // Asserted through the family's own machinery rather than `Counter016Contract extends
+    // Ledger8.Contract`, which is true by the fixture's DECLARATION and so cannot fail -- the rule
+    // `typecheck/overloads.test-d.ts` states for the same fixture.
+    expectTypeOf<Ledger8.CircuitId<C>>().toEqualTypeOf<K>();
+    expectTypeOf<Ledger8.CircuitParameters<C, K>>().toEqualTypeOf<[]>();
+  });
+});
+
+describe('every namespace member is the declaration it renames', () => {
+  // One assertion per member, all 29 types, comparing `Ledger8.X` against the `Ledger8X` the source
+  // module declares. A swapped pair -- `Ledger8CallResultPrivate as CallResultPublic` and its
+  // converse -- compiles, keeps both names on the surface, and is caught only here.
+  it('renames the contract and circuit declarations', () => {
+    expectTypeOf<Ledger8.Contract<PS>>().toEqualTypeOf<Ledger8Contract<PS>>();
+    expectTypeOf<Ledger8.Circuit>().toEqualTypeOf<Ledger8Circuit>();
+    expectTypeOf<Ledger8.CircuitContext<PS>>().toEqualTypeOf<Ledger8CircuitContext<PS>>();
+    expectTypeOf<Ledger8.CircuitResult>().toEqualTypeOf<Ledger8CircuitResult>();
+    expectTypeOf<Ledger8.Witness<PS>>().toEqualTypeOf<Ledger8Witness<PS>>();
+    expectTypeOf<Ledger8.InitialStateResult<PS>>().toEqualTypeOf<Ledger8InitialStateResult<PS>>();
+    expectTypeOf<Ledger8.PrivateState<C>>().toEqualTypeOf<Ledger8PrivateState<C>>();
+    expectTypeOf<Ledger8.CircuitId<C>>().toEqualTypeOf<Ledger8CircuitId<C>>();
+    expectTypeOf<Ledger8.CircuitParameters<C, K>>().toEqualTypeOf<Ledger8CircuitParameters<C, K>>();
+    expectTypeOf<Ledger8.CircuitReturnType<C, K>>().toEqualTypeOf<Ledger8CircuitReturnType<C, K>>();
+    expectTypeOf<Ledger8.ConstructorParameters<C>>().toEqualTypeOf<Ledger8ConstructorParameters<C>>();
   });
 
-  it('names the witness and circuit members a retained contract declaration needs', () => {
-    // A contract type cannot be declared from the outside without these two, so they travel with
-    // the family rather than being held back as internals.
-    expectTypeOf<Counter016Contract['witnesses']>().toExtend<
-      Readonly<Record<string, Ledger8.Witness<Counter016PrivateState>>>
+  it('renames the call declarations', () => {
+    expectTypeOf<Ledger8.ContractProviders<C, K>>().toEqualTypeOf<Ledger8ContractProviders<C, K>>();
+    expectTypeOf<Ledger8.CallTxTarget<C, K>>().toEqualTypeOf<Ledger8CallTxTarget<C, K>>();
+    expectTypeOf<Ledger8.CallTxOptions<C, K>>().toEqualTypeOf<Ledger8CallTxOptions<C, K>>();
+    expectTypeOf<Ledger8.CallTxOptionsBase<C, K>>().toEqualTypeOf<Ledger8CallTxOptionsBase<C, K>>();
+    expectTypeOf<Ledger8.CallTxOptionsWithPrivateStateId<C, K>>().toEqualTypeOf<
+      Ledger8CallTxOptionsWithPrivateStateId<C, K>
     >();
-    expectTypeOf<Counter016Contract['impureCircuits']>().toExtend<Readonly<Record<string, Ledger8.Circuit>>>();
+    expectTypeOf<Ledger8.CircuitCallTxInterface<C>>().toEqualTypeOf<Ledger8CircuitCallTxInterface<C>>();
+  });
+
+  it('renames the result declarations', () => {
+    expectTypeOf<Ledger8.CallResultPublic>().toEqualTypeOf<Ledger8CallResultPublic>();
+    expectTypeOf<Ledger8.CallResultPrivate<C, K>>().toEqualTypeOf<Ledger8CallResultPrivate<C, K>>();
+    expectTypeOf<Ledger8.ContractCall>().toEqualTypeOf<Ledger8ContractCall>();
+    expectTypeOf<Ledger8.ContractCallPublic>().toEqualTypeOf<Ledger8ContractCallPublic>();
+    expectTypeOf<Ledger8.FinalizedCallTxData<C, K>>().toEqualTypeOf<Ledger8FinalizedCallTxData<C, K>>();
+    expectTypeOf<Ledger8.FinalizedCallTxPublicData>().toEqualTypeOf<Ledger8FinalizedCallTxPublicData>();
+    expectTypeOf<Ledger8.UnsubmittedCallTxData<C, K>>().toEqualTypeOf<Ledger8UnsubmittedCallTxData<C, K>>();
+    expectTypeOf<Ledger8.SubmittedCallTx<C, K>>().toEqualTypeOf<Ledger8SubmittedCallTx<C, K>>();
+  });
+
+  it('renames the deploy and lookup declarations', () => {
+    expectTypeOf<Ledger8.DeployContractOptions<C>>().toEqualTypeOf<Ledger8DeployContractOptions<C>>();
+    expectTypeOf<Ledger8.DeployContractOptionsBase<C>>().toEqualTypeOf<Ledger8DeployContractOptionsBase<C>>();
+    expectTypeOf<Ledger8.FindDeployedContractOptions<C>>().toEqualTypeOf<Ledger8FindDeployedContractOptions<C>>();
+    expectTypeOf<Ledger8.FoundContract<C>>().toEqualTypeOf<Ledger8FoundContract<C>>();
   });
 });

--- a/packages/contracts/typedoc.json
+++ b/packages/contracts/typedoc.json
@@ -13,15 +13,6 @@
     "TypeId",
     "SubmitCallTxProviders",
     "CachedStateIdentity",
-    "Ledger8Contract",
-    "Ledger8CircuitId",
-    "Ledger8ContractProviders",
-    "Ledger8CallTxOptions",
-    "Ledger8FinalizedCallTxData",
-    "Ledger8SubmittedCallTx",
-    "Ledger8DeployContractOptions",
-    "Ledger8DeployedContract",
-    "Ledger8FindDeployedContractOptions",
-    "Ledger8FoundContract"
+    "Ledger8DeployedContract"
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up to the architecture review of #1218 (finding 4: the retained era duplicates the public type surface permanently).

`packages/contracts` published 37 retained-era names flat, next to the current-era family they mirror: 29 `Ledger8*` types, 7 error classes and `createLedger8CircuitCallTxInterface`. The fork window is transitional; a duplicated public interface is not, so withdrawing those names once the window closes would be a second breaking change on top of the one this release already makes.

They are now re-exported through one curated module, `packages/contracts/src/ledger8.ts`, published as `export * as Ledger8`, with the era prefix dropped inside:

```typescript
import { Ledger8, submitCallTx } from '@midnight-ntwrk/midnight-js-contracts';

const result: Ledger8.FinalizedCallTxData<C, 'increment'> = await submitCallTx(providers, options);

try {
  await submitCallTx(providers, options);
} catch (error) {
  if (error instanceof Ledger8.CallTxFailedError) { /* ... */ }
}
```

- The era-NEUTRAL half stays flat -- `AnyEraFinalizedCallTxData`, `AnyEraSubmittedCallTx`, `isLedger8Result`, `AnyEraTxFailedError`, the `*_PIPELINE_ERA` vocabulary, `UnrecognisedResultEraError` -- so a consumer that only receives results imports nothing transitional. `Ledger8.CallTxFailedError` still extends `AnyEraTxFailedError`, so a handler written against the base keeps catching it.
- Membership is two-clause: a name goes in when it disappears with the retained era AND belongs to that era's own API family. The FORK-WINDOW group (`StaleHeadError`, `SubmitRejectionUndiagnosedError` and their payload types, `HeadStateEraMismatchError`, `EraArtifactMismatchError`, `ScopedTxEraUnsupportedError`, `MixedEraScopeError`) also disappears when the window closes but is **not** the retained era's family, stays flat, and is a separate later removal. Filing it under a name that says `Ledger8` would misname it; whether it earns a namespace of its own is left open in the ADR.
- Withdrawal of the era's own family is one file plus one re-export line, changing no current-era name. `errors.ts` and `tx-interfaces.ts` are shared by both eras and are not deleted.
- The declarations keep their `Ledger8`-prefixed names in the source; the rename happens in one place. Rule for reading the design docs and the API reference: a declaration named `Ledger8X` is published as `Ledger8.X`. Stated on the namespace's own doc comment, so it lands on the generated page, and in the new `packages/contracts/docs/retained-era-namespace.md`.
- ADR 0013 records the decision, its negatives (declaration/published name divergence, `Ledger8.CallTxFailedError` reading as a subtype of the flat one when it is a sibling, namespace-object tree-shaking granularity, TS1361 for type-only consumers) and the deferred follow-ups.

Considered and not taken: an era-scoped `./ledger8` subpath export. It is the stronger end state (it also moves the retained ENTRY points off `"."`, drops one `submitCallTx` overload arm and lets the retained runtime go lazy), but it moves call sites and needs a matching entry in the `midnight-js` barrel. This change is its first commit: `src/ledger8.ts` is the file that would become that subpath's entry.

## Review fixes (second commit)

A review of the first commit found the guards were name-based only, and mutation testing proved it: publishing the **current-era** `createCircuitCallTxInterface` under the retained namespace, and swapping `CallResultPrivate` with `CallResultPublic`, both passed the entire suite. The factory is the sharpest case -- its namespace-local name is the same spelling as the flat current-era one, so no filter on `Ledger8` can see it.

- All 8 runtime members are now asserted against the declarations they rename; all 29 type members are compared with their source declarations in the compile-level suite. Both mutations above now fail (verified).
- The namespace is read back out of the **built bundle** as well as the source -- the reason `contracts-value-acl.test.ts` gives for reading `dist/`.
- The prototype assertion pinned hierarchy depth; it now asserts catchability (`prototype instanceof`), so inserting an intermediate base does not fail it for the wrong reason.
- The dist export scan matched `export * as` only by accident of rollup's emit; the pattern is now explicit.
- Documentation corrections, each verified against the code: the retained deploy refusal does **not** precede every provider touch (`resolveArtifactEra` reads the ZK config provider first); `Ledger8.DeployOnV9Error` is dormant, not an error a caller receives; the membership rule is two-clause; withdrawal cannot delete the shared modules; and two points lost with the deleted barrel comment are restored (a name in the emitted `.d.ts` is not an export on a single-entry package, and `Awaited<ReturnType<typeof submitCallTx>>` resolves from the last overload).
- `typedoc.json`'s `intentionallyNotExported` list dropped from 11 stale entries to 2.

## Test plan

- [x] Tests written first (TDD), verified they fail before the change (4 of 5 RED, each for its own reason)
- [x] `src/test/ledger8-namespace.test.ts` -- pins the namespace's runtime members by strict equality in source **and** in `dist/`, binds each to the declaration it renames, and asserts no retained-era runtime name returned to the flat surface
- [x] `src/test/typecheck/ledger8-namespace.test-d.ts` -- resolves the entry points THROUGH the barrel (the existing compile suites import source modules a consumer cannot reach), and compares all 29 type members against their declarations
- [x] Mutation-tested: transposed rename pairs and a wrong-era factory binding each produce a failing test
- [x] `contracts-type-acl.test.ts` extended to pin the namespace's type members with the compiler's own resolution; `contracts-value-acl.test.ts` updated and its scan hardened
- [x] All existing tests pass: `yarn test --force` -- 31/31 tasks, 0 cached; contracts 628 tests, no type errors
- [x] Lint clean (`yarn lint`), `yarn typecheck:tests` clean, `yarn build` succeeds
- [x] TypeDoc renders the namespace (`index.Ledger8.CallTxFailedError`), 0 errors
